### PR TITLE
Report correct error at startSession

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -34,11 +34,16 @@ First, initialize the Conversation instance:
 const conversation = await Conversation.startSession(options);
 ```
 
-This will kick off the websocket connection and start using microphone to communicate with the ElevenLabs Conversational AI agent. Consider explaining and allowing microphone access in your apps UI before the Conversation kicks off:
+This will kick off the websocket connection and start using microphone to communicate with the ElevenLabs Conversational AI agent. Consider explaining and allowing microphone access in your apps UI before the Conversation kicks off. The microphone may also be blocked for the current page by default, resulting in the allow prompt not showing up at all. You should handle such use case in your application and display appropriate message to the user:
 
 ```js
 // call after explaning to the user why the microphone access is needed
-await navigator.mediaDevices.getUserMedia();
+// handle errors and show appropriate message to the user
+try {
+  await navigator.mediaDevices.getUserMedia();
+} catch {
+  // handle error
+}
 ```
 
 #### Session configuration

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -13,6 +13,13 @@ export class Input {
     let inputStream: MediaStream | null = null;
 
     try {
+      // some browsers won't allow calling getSupportedConstraints
+      // before getting approval for microphone access
+      const preliminaryInputStream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+      });
+      preliminaryInputStream?.getTracks().forEach(track => track.stop());
+
       const supportsSampleRateConstraint =
         navigator.mediaDevices.getSupportedConstraints().sampleRate;
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -35,11 +35,16 @@ const conversation = useConversation();
 ```
 
 Note that Conversational AI requires microphone access.
-Consider explaining and allowing access in your apps UI before the Conversation kicks off.
+Consider explaining and allowing microphone access in your apps UI before the Conversation kicks off. The microphone may also be blocked for the current page by default, resulting in the allow prompt not showing up at all. You should handle such use case in your application and display appropriate message to the user:
 
 ```js
 // call after explaning to the user why the microphone access is needed
-await navigator.mediaDevices.getUserMedia();
+// handle errors and show appropriate message to the user
+try {
+  await navigator.mediaDevices.getUserMedia();
+} catch {
+  // handle error
+}
 ```
 
 #### Options


### PR DESCRIPTION
Some browsers won't allow calling getSupportedConstraints before getting approval for microphone access. In such case we fail with random error of getSupportedConstraints being undefined, while we should fail on access. 