### PR TITLE
iOS headphones hack

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -159,6 +159,16 @@ const conversation = await Conversation.startSession({
 });
 ```
 
+#### Prefer Headphones for iOS Devices
+
+While this SDK leaves the choice of audio input/output device to the browser/system, iOS Safari seem to prefer the built-in speaker over headphones even when bluetooth device is in use. If you want to "force" the use of headphones on iOS devices when available, you can use the following option. Please, keep in mind that this is not guaranteed, since this functionality is not provided by the browser. System audio should be the default choice.
+
+```ts
+const conversation = await Conversation.startSession({
+  preferHeadphonesForIosDevices: true,
+});
+```
+
 #### Return value
 
 `startSession` returns a `Conversation` instance that can be used to control the session. The method will throw an error if the session cannot be established. This can happen if the user denies microphone access, or if the websocket connection

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -1,24 +1,67 @@
 import { rawAudioProcessor } from "./rawAudioProcessor";
 import { FormatConfig } from "./connection";
 
+export type InputConfig = {
+  preferHeadphonesForIosDevices?: boolean;
+};
+
 const LIBSAMPLERATE_JS =
   "https://cdn.jsdelivr.net/npm/@alexanderolsen/libsamplerate-js@2.1.2/dist/libsamplerate.worklet.js";
+
+function isIosDevice() {
+  return (
+    [
+      "iPad Simulator",
+      "iPhone Simulator",
+      "iPod Simulator",
+      "iPad",
+      "iPhone",
+      "iPod",
+    ].includes(navigator.platform) ||
+    // iPad on iOS 13 detection
+    (navigator.userAgent.includes("Mac") && "ontouchend" in document)
+  );
+}
 
 export class Input {
   public static async create({
     sampleRate,
     format,
-  }: FormatConfig): Promise<Input> {
+    preferHeadphonesForIosDevices,
+  }: FormatConfig & InputConfig): Promise<Input> {
     let context: AudioContext | null = null;
     let inputStream: MediaStream | null = null;
 
     try {
-      // some browsers won't allow calling getSupportedConstraints
+      const options: MediaTrackConstraints = {
+        sampleRate: { ideal: sampleRate },
+        echoCancellation: { ideal: true },
+        noiseSuppression: { ideal: true },
+      };
+
+      // some browsers won't allow calling getSupportedConstraints or enumerateDevices
       // before getting approval for microphone access
       const preliminaryInputStream = await navigator.mediaDevices.getUserMedia({
         audio: true,
       });
       preliminaryInputStream?.getTracks().forEach(track => track.stop());
+
+      if (isIosDevice() && preferHeadphonesForIosDevices) {
+        const availableDevices =
+          await window.navigator.mediaDevices.enumerateDevices();
+        const idealDevice = availableDevices.find(
+          d =>
+            // cautious to include "bluetooth" in the search
+            // as might trigger bluetooth speakers
+            d.kind === "audioinput" &&
+            ["airpod", "headphone", "earphone"].find(keyword =>
+              d.label.toLowerCase().includes(keyword)
+            )
+        );
+        if (idealDevice) {
+          options.deviceId = { ideal: idealDevice.deviceId };
+        }
+      }
 
       const supportsSampleRateConstraint =
         navigator.mediaDevices.getSupportedConstraints().sampleRate;
@@ -33,11 +76,7 @@ export class Input {
       await context.audioWorklet.addModule(rawAudioProcessor);
 
       inputStream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          sampleRate: { ideal: sampleRate },
-          echoCancellation: { ideal: true },
-          noiseSuppression: { ideal: true },
-        },
+        audio: options,
       });
 
       const source = context.createMediaStreamSource(inputStream);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -109,6 +109,16 @@ const conversation = useConversation({
 });
 ```
 
+#### Prefer Headphones for iOS Devices
+
+While this SDK leaves the choice of audio input/output device to the browser/system, iOS Safari seem to prefer the built-in speaker over headphones even when bluetooth device is in use. If you want to "force" the use of headphones on iOS devices when available, you can use the following option. Please, keep in mind that this is not guaranteed, since this functionality is not provided by the browser. System audio should be the default choice.
+
+```ts
+const conversation = useConversation({
+  preferHeadphonesForIosDevices: true,
+});
+```
+
 #### Methods
 
 ##### startConversation

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,11 +8,12 @@ import {
   Status,
   ClientToolsConfig,
 } from "@11labs/client";
+import { InputConfig } from "@11labs/client/dist/utils/input";
 export type { Role, Mode, Status, SessionConfig } from "@11labs/client";
 export { postOverallFeedback } from "@11labs/client";
 
 export type HookOptions = Partial<
-  SessionConfig & HookCallbacks & ClientToolsConfig
+  SessionConfig & HookCallbacks & ClientToolsConfig & InputConfig
 >;
 export type HookCallbacks = Pick<
   Callbacks,


### PR DESCRIPTION
In majority of the cases, the system/browser selects correct input/output based on connected devices. However, iOS seems to struggle with it in browser, and instead of using connected bluetooth headphones uses iPhone mic/speaker. Annoyingly, this is not a consistent issue, and even iPhone can be forced to use Airpods at times, seemingly with no specific steps to reproduce consistently. 

This PR ads a hack into the SDK to detect iOS, and find audio devices containing "airpod" or "headphone" or "earphone" in the label, and sets those as ideal if found. Selecting a correct audio input device will switch to correct (same) audio output also. This is only applicable on iOS, but not in other browser, where i/o could be set to different devices using this method. That's why the hack is limited purely to iOS. 

I didn't want to include the hack in the SDK itself, but it's becoming too complex to follow and I suspect this will be a frequent request. 

Alternative is to provide a workaround instructions + way to set preferred device id (eg. user would have to figure that out on their own) when starting a call.