### PR TITLE
fix: typo

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -215,7 +215,7 @@ conversation.sendFeedback(true);
 A method returning the conversation ID.
 
 ```js
-const id = conversation.geId();
+const id = conversation.getId();
 ```
 
 ##### setVolume


### PR DESCRIPTION
we had a ticket saying that getId() wasnt working but i verified it is and suspect it was caused by this typo