### PR TITLE
Add fallback for iframes in Safari

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@11labs/client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ElevenLabs JavaScript Client Library",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.module.js",

--- a/packages/client/src/utils/audioConcatProcessor.ts
+++ b/packages/client/src/utils/audioConcatProcessor.ts
@@ -3,99 +3,97 @@
  * https://github.com/rochars/wavefile/blob/master/lib/codecs/mulaw.js
  */
 
-const blob = new Blob(
-  [
-    // language=JavaScript
-    `
-      const decodeTable = [0,132,396,924,1980,4092,8316,16764];
-      
-      export function decodeSample(muLawSample) {
-        let sign;
-        let exponent;
-        let mantissa;
-        let sample;
-        muLawSample = ~muLawSample;
-        sign = (muLawSample & 0x80);
-        exponent = (muLawSample >> 4) & 0x07;
-        mantissa = muLawSample & 0x0F;
-        sample = decodeTable[exponent] + (mantissa << (exponent+3));
-        if (sign !== 0) sample = -sample;
+import { createWorkletModuleLoader } from "./createWorkletModuleLoader";
 
-        return sample;
-      }
-      
-      class AudioConcatProcessor extends AudioWorkletProcessor {
-        constructor() {
-          super();
-          this.buffers = []; // Initialize an empty buffer
-          this.cursor = 0;
-          this.currentBuffer = null;
+export const loadAudioConcatProcessor = createWorkletModuleLoader(
+  "audio-concat-processor",
+  // language=JavaScript
+  `
+const decodeTable = [0,132,396,924,1980,4092,8316,16764];
+
+export function decodeSample(muLawSample) {
+  let sign;
+  let exponent;
+  let mantissa;
+  let sample;
+  muLawSample = ~muLawSample;
+  sign = (muLawSample & 0x80);
+  exponent = (muLawSample >> 4) & 0x07;
+  mantissa = muLawSample & 0x0F;
+  sample = decodeTable[exponent] + (mantissa << (exponent+3));
+  if (sign !== 0) sample = -sample;
+
+  return sample;
+}
+
+class AudioConcatProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.buffers = []; // Initialize an empty buffer
+    this.cursor = 0;
+    this.currentBuffer = null;
+    this.wasInterrupted = false;
+    this.finished = false;
+    
+    this.port.onmessage = ({ data }) => {
+      switch (data.type) {
+        case "setFormat":
+          this.format = data.format;
+          break;
+        case "buffer":
           this.wasInterrupted = false;
-          this.finished = false;
-          
-          this.port.onmessage = ({ data }) => {
-            switch (data.type) {
-              case "setFormat":
-                this.format = data.format;
-                break;
-              case "buffer":
-                this.wasInterrupted = false;
-                this.buffers.push(
-                  this.format === "ulaw"
-                    ? new Uint8Array(data.buffer)
-                    : new Int16Array(data.buffer)
-                );
-                break;
-              case "interrupt":
-                this.wasInterrupted = true;
-                break;
-              case "clearInterrupted":
-                if (this.wasInterrupted) {
-                  this.wasInterrupted = false;
-                  this.buffers = [];
-                  this.currentBuffer = null;
-                }
-            }
-          };
-        }
-        process(_, outputs) {
-          let finished = false;
-          const output = outputs[0][0];
-          for (let i = 0; i < output.length; i++) {
-            if (!this.currentBuffer) {
-              if (this.buffers.length === 0) {
-                finished = true;
-                break;
-              }
-              this.currentBuffer = this.buffers.shift();
-              this.cursor = 0;
-            }
-
-            let value = this.currentBuffer[this.cursor];
-            if (this.format === "ulaw") {
-              value = decodeSample(value);
-            }
-            output[i] = value / 32768;
-            this.cursor++;
-
-            if (this.cursor >= this.currentBuffer.length) {
-              this.currentBuffer = null;
-            }
+          this.buffers.push(
+            this.format === "ulaw"
+              ? new Uint8Array(data.buffer)
+              : new Int16Array(data.buffer)
+          );
+          break;
+        case "interrupt":
+          this.wasInterrupted = true;
+          break;
+        case "clearInterrupted":
+          if (this.wasInterrupted) {
+            this.wasInterrupted = false;
+            this.buffers = [];
+            this.currentBuffer = null;
           }
-
-          if (this.finished !== finished) {
-            this.finished = finished;
-            this.port.postMessage({ type: "process", finished });
-          }
-
-          return true; // Continue processing
+      }
+    };
+  }
+  process(_, outputs) {
+    let finished = false;
+    const output = outputs[0][0];
+    for (let i = 0; i < output.length; i++) {
+      if (!this.currentBuffer) {
+        if (this.buffers.length === 0) {
+          finished = true;
+          break;
         }
+        this.currentBuffer = this.buffers.shift();
+        this.cursor = 0;
       }
 
-      registerProcessor("audio-concat-processor", AudioConcatProcessor);
-    `,
-  ],
-  { type: "application/javascript" }
-);
+      let value = this.currentBuffer[this.cursor];
+      if (this.format === "ulaw") {
+        value = decodeSample(value);
+      }
+      output[i] = value / 32768;
+      this.cursor++;
 
-export const audioConcatProcessor = URL.createObjectURL(blob);
+      if (this.cursor >= this.currentBuffer.length) {
+        this.currentBuffer = null;
+      }
+    }
+
+    if (this.finished !== finished) {
+      this.finished = finished;
+      this.port.postMessage({ type: "process", finished });
+    }
+
+    return true; // Continue processing
+  }
+}
+
+registerProcessor("audio-concat-processor", AudioConcatProcessor);
+`
+);

--- a/packages/client/src/utils/createWorkletModuleLoader.ts
+++ b/packages/client/src/utils/createWorkletModuleLoader.ts
@@ -1,0 +1,34 @@
+const URLCache = new Map<string, string>();
+
+export function createWorkletModuleLoader(name: string, sourceCode: string) {
+  return async (worklet: AudioWorklet) => {
+    const url = URLCache.get(name);
+    if (url) {
+      return worklet.addModule(url);
+    }
+
+    const blob = new Blob([sourceCode], { type: "application/javascript" });
+    const blobURL = URL.createObjectURL(blob);
+    try {
+      await worklet.addModule(blobURL);
+      URLCache.set(name, blobURL);
+      return;
+    } catch {
+      URL.revokeObjectURL(blobURL);
+    }
+
+    try {
+      // Attempting to start a conversation in Safari inside an iframe will
+      // throw a CORS error because the blob:// protocol is considered
+      // cross-origin. In such cases, fall back to using a base64 data URL:
+      const base64 = btoa(sourceCode);
+      const moduleURL = `data:application/javascript;base64,${base64}`;
+      await worklet.addModule(moduleURL);
+      URLCache.set(name, moduleURL);
+    } catch (error) {
+      throw new Error(
+        `Failed to load the ${name} worklet module. Make sure the browser supports AudioWorklets.`
+      );
+    }
+  };
+}

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -1,4 +1,4 @@
-import { rawAudioProcessor } from "./rawAudioProcessor";
+import { loadRawAudioProcessor } from "./rawAudioProcessor";
 import { FormatConfig } from "./connection";
 import { isIosDevice } from "./compatibility";
 
@@ -52,7 +52,7 @@ export class Input {
       if (!supportsSampleRateConstraint) {
         await context.audioWorklet.addModule(LIBSAMPLERATE_JS);
       }
-      await context.audioWorklet.addModule(rawAudioProcessor);
+      await loadRawAudioProcessor(context.audioWorklet);
 
       inputStream = await navigator.mediaDevices.getUserMedia({
         audio: options,

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -1,4 +1,4 @@
-import { audioConcatProcessor } from "./audioConcatProcessor";
+import { loadAudioConcatProcessor } from "./audioConcatProcessor";
 import { FormatConfig } from "./connection";
 
 export class Output {
@@ -13,7 +13,7 @@ export class Output {
       const gain = context.createGain();
       gain.connect(analyser);
       analyser.connect(context.destination);
-      await context.audioWorklet.addModule(audioConcatProcessor);
+      await loadAudioConcatProcessor(context.audioWorklet);
       const worklet = new AudioWorkletNode(context, "audio-concat-processor");
       worklet.port.postMessage({ type: "setFormat", format });
       worklet.connect(gain);

--- a/packages/client/src/utils/rawAudioProcessor.ts
+++ b/packages/client/src/utils/rawAudioProcessor.ts
@@ -3,131 +3,129 @@
  * https://github.com/rochars/wavefile/blob/master/lib/codecs/mulaw.js
  */
 
-const blob = new Blob(
-  [
-    // language=JavaScript
-    `
-      const BIAS = 0x84;
-      const CLIP = 32635;
-      const encodeTable = [
-        0,0,1,1,2,2,2,2,3,3,3,3,3,3,3,3,
-        4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
-        5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
-        5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
-        6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
-        6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
-        6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
-        6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
-      ];
-      
-      function encodeSample(sample) {
-        let sign;
-        let exponent;
-        let mantissa;
-        let muLawSample;
-        sign = (sample >> 8) & 0x80;
-        if (sign !== 0) sample = -sample;
-        sample = sample + BIAS;
-        if (sample > CLIP) sample = CLIP;
-        exponent = encodeTable[(sample>>7) & 0xFF];
-        mantissa = (sample >> (exponent+3)) & 0x0F;
-        muLawSample = ~(sign | (exponent << 4) | mantissa);
-        
-        return muLawSample;
+import { createWorkletModuleLoader } from "./createWorkletModuleLoader";
+
+export const loadRawAudioProcessor = createWorkletModuleLoader(
+  "raw-audio-processor",
+  // language=JavaScript
+  `
+const BIAS = 0x84;
+const CLIP = 32635;
+const encodeTable = [
+  0,0,1,1,2,2,2,2,3,3,3,3,3,3,3,3,
+  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
+];
+
+function encodeSample(sample) {
+  let sign;
+  let exponent;
+  let mantissa;
+  let muLawSample;
+  sign = (sample >> 8) & 0x80;
+  if (sign !== 0) sample = -sample;
+  sample = sample + BIAS;
+  if (sample > CLIP) sample = CLIP;
+  exponent = encodeTable[(sample>>7) & 0xFF];
+  mantissa = (sample >> (exponent+3)) & 0x0F;
+  muLawSample = ~(sign | (exponent << 4) | mantissa);
+  
+  return muLawSample;
+}
+
+class RawAudioProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+              
+    this.port.onmessage = ({ data }) => {
+      switch (data.type) {
+        case "setFormat":
+          this.isMuted = false;
+          this.buffer = []; // Initialize an empty buffer
+          this.bufferSize = data.sampleRate / 4;
+          this.format = data.format;
+
+          if (globalThis.LibSampleRate && sampleRate !== data.sampleRate) {
+            globalThis.LibSampleRate.create(1, sampleRate, data.sampleRate).then(resampler => {
+              this.resampler = resampler;
+            });
+          }
+          break;
+        case "setMuted":
+          this.isMuted = data.isMuted;
+          break;
       }
+    };
+  }
+  process(inputs) {
+    if (!this.buffer) {
+      return true;
+    }
     
-      class RawAudioProcessor extends AudioWorkletProcessor {
-        constructor() {
-          super();
-                    
-          this.port.onmessage = ({ data }) => {
-            switch (data.type) {
-              case "setFormat":
-                this.isMuted = false;
-                this.buffer = []; // Initialize an empty buffer
-                this.bufferSize = data.sampleRate / 4;
-                this.format = data.format;
+    const input = inputs[0]; // Get the first input node
+    if (input.length > 0) {
+      let channelData = input[0]; // Get the first channel's data
 
-                if (globalThis.LibSampleRate && sampleRate !== data.sampleRate) {
-                  globalThis.LibSampleRate.create(1, sampleRate, data.sampleRate).then(resampler => {
-                    this.resampler = resampler;
-                  });
-                }
-                break;
-              case "setMuted":
-                this.isMuted = data.isMuted;
-                break;
-            }
-          };
-        }
-        process(inputs) {
-          if (!this.buffer) {
-            return true;
-          }
-          
-          const input = inputs[0]; // Get the first input node
-          if (input.length > 0) {
-            let channelData = input[0]; // Get the first channel's data
-
-            // Resample the audio if necessary
-            if (this.resampler) {
-              channelData = this.resampler.full(channelData);
-            }
-
-            // Add channel data to the buffer
-            this.buffer.push(...channelData);
-            // Get max volume 
-            let sum = 0.0;
-            for (let i = 0; i < channelData.length; i++) {
-              sum += channelData[i] * channelData[i];
-            }
-            const maxVolume = Math.sqrt(sum / channelData.length);
-            // Check if buffer size has reached or exceeded the threshold
-            if (this.buffer.length >= this.bufferSize) {
-              const float32Array = this.isMuted 
-                ? new Float32Array(this.buffer.length)
-                : new Float32Array(this.buffer);
-
-              let encodedArray = this.format === "ulaw"
-                ? new Uint8Array(float32Array.length)
-                : new Int16Array(float32Array.length);
-
-              // Iterate through the Float32Array and convert each sample to PCM16
-              for (let i = 0; i < float32Array.length; i++) {
-                // Clamp the value to the range [-1, 1]
-                let sample = Math.max(-1, Math.min(1, float32Array[i]));
-
-                // Scale the sample to the range [-32768, 32767]
-                let value = sample < 0 ? sample * 32768 : sample * 32767;
-                if (this.format === "ulaw") {
-                  value = encodeSample(Math.round(value));
-                }
-
-                encodedArray[i] = value;
-              }
-
-              // Send the buffered data to the main script
-              this.port.postMessage([encodedArray, maxVolume]);
-
-              // Clear the buffer after sending
-              this.buffer = [];
-            }
-          }
-          return true; // Continue processing
-        }
+      // Resample the audio if necessary
+      if (this.resampler) {
+        channelData = this.resampler.full(channelData);
       }
-      registerProcessor("raw-audio-processor", RawAudioProcessor);
-  `,
-  ],
-  { type: "application/javascript" }
-);
 
-export const rawAudioProcessor = URL.createObjectURL(blob);
+      // Add channel data to the buffer
+      this.buffer.push(...channelData);
+      // Get max volume 
+      let sum = 0.0;
+      for (let i = 0; i < channelData.length; i++) {
+        sum += channelData[i] * channelData[i];
+      }
+      const maxVolume = Math.sqrt(sum / channelData.length);
+      // Check if buffer size has reached or exceeded the threshold
+      if (this.buffer.length >= this.bufferSize) {
+        const float32Array = this.isMuted 
+          ? new Float32Array(this.buffer.length)
+          : new Float32Array(this.buffer);
+
+        let encodedArray = this.format === "ulaw"
+          ? new Uint8Array(float32Array.length)
+          : new Int16Array(float32Array.length);
+
+        // Iterate through the Float32Array and convert each sample to PCM16
+        for (let i = 0; i < float32Array.length; i++) {
+          // Clamp the value to the range [-1, 1]
+          let sample = Math.max(-1, Math.min(1, float32Array[i]));
+
+          // Scale the sample to the range [-32768, 32767]
+          let value = sample < 0 ? sample * 32768 : sample * 32767;
+          if (this.format === "ulaw") {
+            value = encodeSample(Math.round(value));
+          }
+
+          encodedArray[i] = value;
+        }
+
+        // Send the buffered data to the main script
+        this.port.postMessage([encodedArray, maxVolume]);
+
+        // Clear the buffer after sending
+        this.buffer = [];
+      }
+    }
+    return true; // Continue processing
+  }
+}
+registerProcessor("raw-audio-processor", RawAudioProcessor);
+`
+);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@11labs/react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ElevenLabs React Library",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.module.js",


### PR DESCRIPTION
Attempting to start a conversation in Safari inside an iframe will throw a CORS error because the `blob://` protocol is considered cross-origin.

In such cases, we fall back to using a base64 data URL which is not as widely supported as the blob but works in Safari.