### PR TITLE
Control how the widget is expanded

### DIFF
--- a/packages/convai-widget-core/package.json
+++ b/packages/convai-widget-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/convai-widget-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The common library for the Conversational AI Widget.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/convai-widget-core/src/contexts/attributes.tsx
+++ b/packages/convai-widget-core/src/contexts/attributes.tsx
@@ -1,6 +1,10 @@
-import { ReadonlySignal, Signal, signal } from "@preact/signals";
+import { ReadonlySignal, Signal, signal, useComputed } from "@preact/signals";
 import { createContext, useMemo } from "preact/compat";
-import { CustomAttributeList, CustomAttributes } from "../types/attributes";
+import {
+  CustomAttributeList,
+  CustomAttributes,
+  parseBoolAttribute,
+} from "../types/attributes";
 import type { JSX } from "preact";
 import { useContextSafely } from "../utils/useContextSafely";
 

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -76,6 +76,8 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
   const micMuting = useAttribute("mic-muting");
   const transcript = useAttribute("transcript");
   const textInput = useAttribute("text-input");
+  const defaultExpanded = useAttribute("default-expanded");
+  const alwaysExpanded = useAttribute("always-expanded");
   const overrideTextOnly = useAttribute("override-text-only");
 
   const value = useComputed<WidgetConfig | null>(() => {
@@ -101,6 +103,14 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
     const patchedTextInput =
       parseBoolAttribute(textInput.value) ??
       fetchedConfig.value.text_input_enabled;
+    const patchedAlwaysExpanded =
+      parseBoolAttribute(alwaysExpanded.value) ??
+      fetchedConfig.value.always_expanded ??
+      false;
+    const patchedDefaultExpanded =
+      parseBoolAttribute(defaultExpanded.value) ??
+      fetchedConfig.value.default_expanded ??
+      false;
 
     return {
       ...fetchedConfig.value,
@@ -110,6 +120,8 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       mic_muting_enabled: !textOnly && patchedMicMuting,
       transcript_enabled: textOnly || patchedTranscript,
       text_input_enabled: textOnly || patchedTextInput,
+      always_expanded: patchedAlwaysExpanded,
+      default_expanded: patchedDefaultExpanded,
     };
   });
 

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -9,7 +9,7 @@ import {
   Variant,
   Variants,
   Location,
-  parseLocation
+  parseLocation,
 } from "./types/config";
 import { useState } from "preact/compat";
 
@@ -24,6 +24,7 @@ function Playground() {
   const [transcript, setTranscript] = useState(false);
   const [textInput, setTextInput] = useState(false);
   const [textOnly, setTextOnly] = useState(false);
+  const [alwaysExpanded, setAlwaysExpanded] = useState(false);
 
   return (
     <div className="w-screen h-screen flex items-center justify-center bg-base-hover text-base-primary">
@@ -84,6 +85,14 @@ function Playground() {
           />{" "}
           Text only
         </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={alwaysExpanded}
+            onChange={e => setAlwaysExpanded(e.currentTarget.checked)}
+          />{" "}
+          Always expanded
+        </label>
         <label className="flex flex-col">
           Server Location
           <select
@@ -91,7 +100,7 @@ function Playground() {
             onChange={e => setLocation(parseLocation(e.currentTarget.value))}
             className="p-1 bg-base border border-base-border"
           >
-            {(["us", "global", "eu-residency", "in-residency"]).map(location => (
+            {["us", "global", "eu-residency", "in-residency"].map(location => (
               <option value={location}>{location}</option>
             ))}
           </select>
@@ -106,6 +115,7 @@ function Playground() {
           text-input={JSON.stringify(textInput)}
           mic-muting={JSON.stringify(micMuting)}
           override-text-only={JSON.stringify(textOnly)}
+          always-expanded={JSON.stringify(alwaysExpanded)}
           server-location={location}
         />
       </div>

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -15,6 +15,8 @@ const BASIC_CONFIG: WidgetConfig = {
   mic_muting_enabled: false,
   transcript_enabled: false,
   text_input_enabled: false,
+  default_expanded: false,
+  always_expanded: false,
   text_contents: {
     start_chat: "Start a call",
   },

--- a/packages/convai-widget-core/src/types/attributes.ts
+++ b/packages/convai-widget-core/src/types/attributes.ts
@@ -35,6 +35,8 @@ export const CustomAttributeList = [
   "transcript",
   "text-input",
   "text-contents",
+  "default-expanded",
+  "always-expanded",
   "user-id",
 ] as const;
 

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -38,6 +38,8 @@ export interface WidgetConfig {
   mic_muting_enabled: boolean;
   transcript_enabled: boolean;
   text_input_enabled: boolean;
+  default_expanded: boolean;
+  always_expanded: boolean;
   text_contents: Partial<TextContents>;
   styles?: Partial<Styles>;
   language_presets: Partial<

--- a/packages/convai-widget-core/src/version.ts
+++ b/packages/convai-widget-core/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during build
-export const PACKAGE_VERSION = "0.1.0";
+export const PACKAGE_VERSION = "0.1.1";

--- a/packages/convai-widget-core/src/widget/Sheet.tsx
+++ b/packages/convai-widget-core/src/widget/Sheet.tsx
@@ -1,4 +1,4 @@
-import { Signal, useComputed, useSignal } from "@preact/signals";
+import { useComputed, useSignal } from "@preact/signals";
 import {
   useFirstMessage,
   useIsConversationTextOnly,
@@ -16,9 +16,10 @@ import { SheetLanguageSelect } from "./SheetLanguageSelect";
 import { SheetActions } from "./SheetActions";
 import { Transcript } from "./Transcript";
 import { useTextContents } from "../contexts/text-contents";
+import { Signalish } from "../utils/signalish";
 
 interface SheetProps {
-  open: Signal<boolean>;
+  open: Signalish<boolean>;
 }
 
 const ORIGIN_CLASSES: Record<Placement, string> = {
@@ -81,7 +82,13 @@ export function Sheet({ open }: SheetProps) {
           "flex flex-col overflow-hidden absolute bg-base shadow-lg pointer-events-auto rounded-sheet w-full max-w-[400px] h-[calc(100%-80px)] max-h-[550px]",
           "transition-[transform,opacity] duration-200 data-hidden:scale-90 data-hidden:opacity-0",
           ORIGIN_CLASSES[placement],
-          placement.startsWith("top") ? "top-20" : "bottom-20"
+          placement.startsWith("top")
+            ? config.value.always_expanded
+              ? "top-0"
+              : "top-20"
+            : config.value.always_expanded
+              ? "bottom-0"
+              : "bottom-20"
         )}
       >
         <div className="bg-base shrink-0 flex gap-2 p-4 items-start">

--- a/packages/convai-widget-core/src/widget/Wrapper.tsx
+++ b/packages/convai-widget-core/src/widget/Wrapper.tsx
@@ -40,8 +40,8 @@ const HIDDEN_STYLE = {
 };
 
 export const Wrapper = memo(function Wrapper() {
-  const expanded = useSignal(false);
   const config = useWidgetConfig();
+  const expanded = useSignal(config.peek().default_expanded);
   const sawError = useSignal(false);
   const { error } = useConversation();
   const terms = useTerms();
@@ -84,8 +84,14 @@ export const Wrapper = memo(function Wrapper() {
     <>
       <InOutTransition initial={false} active={isConversation}>
         <Root className={className} style={HIDDEN_STYLE}>
-          {expandable.value && <Sheet open={expanded} />}
-          <Trigger expandable={expandable.value} expanded={expanded} />
+          {config.value.always_expanded ? (
+            <Sheet open />
+          ) : (
+            <>
+              {expandable.value && <Sheet open={expanded} />}
+              <Trigger expandable={expandable.value} expanded={expanded} />
+            </>
+          )}
         </Root>
       </InOutTransition>
       <InOutTransition initial={false} active={isTerms}>

--- a/packages/convai-widget-embed/package.json
+++ b/packages/convai-widget-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/convai-widget-embed",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The Conversational AI Widget bundled with all dependencies for easy embedding.",
   "main": "./dist/index.js",
   "unpkg": "./dist/index.js",


### PR DESCRIPTION
Adds two new attributes to the widget:
- `default-expanded` - used to control whether the widget should be expanded by default
- `always-expanded` - when `true`, forces the widget to always be expanded and hides the trigger completely
    <img width="777" height="635" alt="Screenshot 2025-07-25 at 14 33 41" src="https://github.com/user-attachments/assets/b769b673-8ff4-482e-88e9-517fb729aa6b" />
