### PR TITLE
feat: Add VAD score support to client and react packages

### DIFF
--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -12,6 +12,7 @@ import type {
   InternalTentativeAgentResponseEvent,
   InterruptionEvent,
   UserTranscriptionEvent,
+  VadScoreEvent,
 } from "./utils/events";
 import type { InputConfig } from "./utils/input";
 
@@ -58,6 +59,7 @@ export type Callbacks = {
   onUnhandledClientToolCall?: (
     params: ClientToolCallEvent["client_tool_call"]
   ) => void;
+  onVadScore?: (props: { vadScore: number }) => void;
 };
 
 const EMPTY_FREQUENCY_DATA = new Uint8Array(0);
@@ -166,6 +168,14 @@ export class BaseConversation {
     });
   }
 
+  protected handleVadScore(event: VadScoreEvent) {
+    if (this.options.onVadScore) {
+      this.options.onVadScore({
+        vadScore: event.vad_score_event.vad_score,
+      });
+    }
+  }
+
   protected async handleClientToolCall(event: ClientToolCallEvent) {
     if (
       Object.prototype.hasOwnProperty.call(
@@ -251,6 +261,11 @@ export class BaseConversation {
       }
       case "audio": {
         this.handleAudio(parsedEvent);
+        return;
+      }
+
+      case "vad_score": {
+        this.handleVadScore(parsedEvent);
         return;
       }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,7 +12,7 @@ export type {
   Status,
 } from "./BaseConversation";
 export type { InputConfig } from "./utils/input";
-export type { IncomingSocketEvent } from "./utils/events";
+export type { IncomingSocketEvent, VadScoreEvent } from "./utils/events";
 export type {
   SessionConfig,
   BaseSessionConfig,

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -52,6 +52,12 @@ export type ClientToolCallEvent = {
     expects_response: boolean;
   };
 };
+export type VadScoreEvent = {
+  type: "vad_score";
+  vad_score_event: {
+    vad_score: number;
+  };
+};
 
 // TODO correction missing
 export type IncomingSocketEvent =
@@ -62,7 +68,8 @@ export type IncomingSocketEvent =
   | InternalTentativeAgentResponseEvent
   | ConfigEvent
   | PingEvent
-  | ClientToolCallEvent;
+  | ClientToolCallEvent
+  | VadScoreEvent;
 
 export type PongEvent = {
   type: "pong";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ import {
   Status,
   ClientToolsConfig,
   InputConfig,
+  VadScoreEvent,
 } from "@elevenlabs/client";
 
 import { PACKAGE_VERSION } from "./version";
@@ -47,6 +48,7 @@ export type {
   SessionConfig,
   DisconnectionDetails,
   Language,
+  VadScoreEvent,
 } from "@elevenlabs/client";
 export { postOverallFeedback } from "@elevenlabs/client";
 
@@ -71,6 +73,7 @@ export type HookCallbacks = Pick<
   | "onAudio"
   | "onDebug"
   | "onUnhandledClientToolCall"
+  | "onVadScore"
 >;
 
 export function useConversation<T extends HookOptions & ControlledState>(
@@ -148,6 +151,7 @@ export function useConversation<T extends HookOptions & ControlledState>(
           onUnhandledClientToolCall:
             options?.onUnhandledClientToolCall ||
             defaultOptions?.onUnhandledClientToolCall,
+          onVadScore: options?.onVadScore || defaultOptions?.onVadScore,
           onModeChange: ({ mode }) => {
             setMode(mode);
           },


### PR DESCRIPTION
# Add VAD Score Support to Client and React Packages-Closes #158


## Overview

This pull request implements Voice Activity Detection (VAD) score support across the ElevenLabs conversational AI packages, enabling real-time feedback on voice detection confidence levels. This feature allows developers to monitor audio input quality and voice activity in their applications.

## Features Added

### 🎤 VAD Score Events
- Real-time voice activity detection scores (0.0 - 1.0)
- WebSocket-based event streaming
- TypeScript support with proper type definitions
- Optional callback integration

### 📦 Package Support
- **Client Package**: Core VAD score handling
- **React Package**: React hook integration

## Installation

No additional installation required - VAD score support is included in the existing packages:

```bash
npm install @elevenlabs/client @elevenlabs/react
```

## Usage
- **Client Package**:
```bash
import { Conversation } from '@elevenlabs/client';

const conversation = await Conversation.startSession({
  agentId: 'your-agent-id',
  onVadScore: ({ vadScore }) => {
    console.log(`Voice activity: ${(vadScore * 100).toFixed(1)}%`);
    
    // Handle different voice activity levels
    if (vadScore > 0.8) {
      showSpeakingIndicator(true);
    } else if (vadScore < 0.2) {
      showSpeakingIndicator(false);
    }
  }
});

```

- **React Package**: 
```bash
import { useConversation } from '@elevenlabs/react';
import { useState } from 'react';

function VoiceChat() {
  const [voiceLevel, setVoiceLevel] = useState(0);
  
  const conversation = useConversation({
    agentId: 'your-agent-id',
    onVadScore: ({ vadScore }) => {
      setVoiceLevel(vadScore);
    }
  });

  return (
    <div>
      <div className="voice-indicator">
        Voice Activity: {(voiceLevel * 100).toFixed(1)}%
      </div>
      <div 
        className="voice-bar" 
        style={{ width: `${voiceLevel * 100}%` }}
      />
    </div>
  );
}