### PR TITLE
[convai widget] optionally use rtc if public

### DIFF
--- a/packages/convai-widget-core/package.json
+++ b/packages/convai-widget-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/convai-widget-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The common library for the Conversational AI Widget.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/convai-widget-core/src/contexts/session-config.tsx
+++ b/packages/convai-widget-core/src/contexts/session-config.tsx
@@ -8,7 +8,7 @@ import { useServerLocation } from "./server-location";
 
 import { useContextSafely } from "../utils/useContextSafely";
 import { parseBoolAttribute } from "../types/attributes";
-import { useTextOnly } from "./widget-config";
+import { useTextOnly, useWebRTC } from "./widget-config";
 
 type DynamicVariables = Record<string, string | number | boolean>;
 
@@ -63,28 +63,40 @@ export function SessionConfigProvider({
   const agentId = useAttribute("agent-id");
   const signedUrl = useAttribute("signed-url");
   const textOnly = useTextOnly();
+  const useWebRTCEnabled = useWebRTC();
   const value = useComputed<SessionConfig | null>(() => {
-    const commonConfig = {
+    const isWebRTC = useWebRTCEnabled.value;
+    const baseConfig = {
       dynamicVariables: dynamicVariables.value,
       overrides: overrides.value,
       connectionDelay: { default: 300 },
       textOnly: textOnly.value,
-      connectionType: "websocket" as const,
       userId: userId.value || undefined,
     };
 
     if (agentId.value) {
-      return {
-        agentId: agentId.value,
-        origin: webSocketUrl.value,
-        ...commonConfig,
-      };
+      if (isWebRTC) {
+        return {
+          agentId: agentId.value,
+          origin: webSocketUrl.value,
+          connectionType: "webrtc" as const,
+          ...baseConfig,
+        };
+      } else {
+        return {
+          agentId: agentId.value,
+          origin: webSocketUrl.value,
+          connectionType: "websocket" as const,
+          ...baseConfig,
+        };
+      }
     }
 
     if (signedUrl.value) {
+      // signedUrl only supports websocket connections
       return {
         signedUrl: signedUrl.value,
-        ...commonConfig,
+        ...baseConfig,
       };
     }
 

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -170,6 +170,11 @@ export function useFirstMessage() {
   );
 }
 
+export function useWebRTC() {
+  const config = useWidgetConfig();
+  return useComputed(() => config.value.use_rtc ?? false);
+}
+
 async function fetchConfig(
   agentId: string,
   serverUrl: string,

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -56,6 +56,7 @@ export interface WidgetConfig {
   text_only: boolean;
   supports_text_only: boolean;
   first_message?: string;
+  use_rtc?: boolean;
 }
 
 export type AvatarConfig =

--- a/packages/convai-widget-core/src/version.ts
+++ b/packages/convai-widget-core/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during build
-export const PACKAGE_VERSION = "0.1.3";
+export const PACKAGE_VERSION = "0.1.4";

--- a/packages/convai-widget-embed/package.json
+++ b/packages/convai-widget-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/convai-widget-embed",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The Conversational AI Widget bundled with all dependencies for easy embedding.",
   "main": "./dist/index.js",
   "unpkg": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Adds optional WebRTC support controlled by `use_rtc` config field
- WebSocket remains default, WebRTC enabled when `use_rtc: true`
- Maintains backward compatibility

## Changes
- Added `use_rtc` to WidgetConfig interface
- Created useWebRTC hook
- Updated SessionConfigProvider for conditional connection type
- SignedUrl connections remain WebSocket-only