### PR TITLE
Fix output bytes and device input/output switching

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -374,11 +374,15 @@ const outputVolume = await conversation.getOutputVolume();
 
 ##### getInputByteFrequencyData / getOutputByteFrequencyData
 
-Methods that return `Uint8Array`s containg the current input/output frequency data. See [AnalyserNode.getByteFrequencyData](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getByteFrequencyData) for more information.
+Methods that return `Uint8Array`s containing the current input/output frequency data. See [AnalyserNode.getByteFrequencyData](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getByteFrequencyData) for more information.
+
+**Note:** These methods are only available for voice conversations. In WebRTC mode the audio is hardcoded to use `pcm_48000`, meaning any visualization using the returned data might show different patterns to WebSocket connections.
 
 ##### changeInputDevice
 
 Allows you to change the audio input device during an active voice conversation. This method is only available for voice conversations.
+
+**Note:** In WebRTC mode the input format and sample rate are hardcoded to `pcm` and `48000` respectively. Changing those values when changing the input device is a no-op.
 
 ```js
 import { VoiceConversation } from "@elevenlabs/client";
@@ -401,6 +405,8 @@ await (conversation as VoiceConversation).changeInputDevice({
 ##### changeOutputDevice
 
 Allows you to change the audio output device during an active voice conversation. This method is only available for voice conversations.
+
+**Note:** In WebRTC mode the output format and sample rate are hardcoded to `pcm` and `48000` respectively. Changing those values when changing the output device is a no-op.
 
 ```js
 import { VoiceConversation } from "@elevenlabs/client";

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -161,6 +161,19 @@ The options passed to `startSession` can also be used to register optional callb
 - **onModeChange** - handler called when a status changes, eg. agent switches from `speaking` to `listening`, or the other way around.
 - **onCanSendFeedbackChange** - handler called when sending feedback becomes available or unavailable.
 
+#### Setting input/output devices
+
+You can provide a device ID to start the conversation using the input/output device of your choice. If the device ID is invalid, the default input and output devices will be used.
+
+```js
+const conversation = await Conversation.startSession({
+  agentId: '<your-agent-id>',
+  inputDeviceId: '<new-input-id>',
+  outputDeviceId: '<new-output-id>',
+});
+
+**Note:** Device switching only works for voice conversations. You can enumerate available devices using the [MediaDevices.enumerateDevices()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices) API.
+
 #### Client Tools
 
 Client tools are a way to enabled agent to invoke client-side functionality. This can be used to trigger actions in the client, such as opening a modal or doing an API call on behalf of the user.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "ElevenLabs JavaScript Client Library",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.module.js",

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -546,6 +546,11 @@ describe("Volume Control", () => {
       })),
       createMediaStreamSource: vi.fn(() => ({
         connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
+      createMediaStreamDestination: vi.fn(() => ({
+        stream: new MediaStream(),
+        connect: vi.fn(),
       })),
       destination: {},
       audioWorklet: {
@@ -619,6 +624,11 @@ describe("Volume Control", () => {
       })),
       createGain: createGainSpy,
       createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
+      createMediaStreamDestination: vi.fn(() => ({
+        stream: new MediaStream(),
         connect: vi.fn(),
       })),
       destination: {},
@@ -729,6 +739,11 @@ describe("Volume Control", () => {
       })),
       createGain: createGainSpy,
       createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
+      createMediaStreamDestination: vi.fn(() => ({
+        stream: new MediaStream(),
         connect: vi.fn(),
       })),
       destination: {},

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -28,6 +28,7 @@ export { WebSocketConnection } from "./utils/WebSocketConnection";
 export { WebRTCConnection } from "./utils/WebRTCConnection";
 export { postOverallFeedback } from "./utils/postOverallFeedback";
 export { VoiceConversation } from "./VoiceConversation";
+export { TextConversation } from "./TextConversation";
 
 export class Conversation extends BaseConversation {
   public static startSession(options: PartialOptions): Promise<Conversation> {

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -6,7 +6,13 @@ import {
 } from "./BaseConnection";
 import { PACKAGE_VERSION } from "../version";
 import { isValidSocketEvent, type OutgoingSocketEvent } from "./events";
-import { Room, RoomEvent, Track, ConnectionState } from "livekit-client";
+import {
+  Room,
+  RoomEvent,
+  Track,
+  ConnectionState,
+  createLocalAudioTrack,
+} from "livekit-client";
 import type {
   RemoteAudioTrack,
   Participant,
@@ -41,6 +47,10 @@ export class WebRTCConnection extends BaseConnection {
   private audioEventId = 1;
   private audioCaptureContext: AudioContext | null = null;
   private audioElements: HTMLAudioElement[] = [];
+  private outputDeviceId: string | null = null;
+
+  private outputAnalyser: AnalyserNode | null = null;
+  private outputFrequencyData: Uint8Array<ArrayBuffer> | null = null;
 
   private constructor(
     room: Room,
@@ -230,6 +240,18 @@ export class WebRTCConnection extends BaseConnection {
           audioElement.autoplay = true;
           audioElement.controls = false;
 
+          // Set output device if one was previously selected
+          if (this.outputDeviceId && audioElement.setSinkId) {
+            try {
+              await audioElement.setSinkId(this.outputDeviceId);
+            } catch (error) {
+              console.warn(
+                "Failed to set output device for new audio element:",
+                error
+              );
+            }
+          }
+
           // Add to DOM (hidden) to ensure it plays
           audioElement.style.display = "none";
           document.body.appendChild(audioElement);
@@ -371,17 +393,26 @@ export class WebRTCConnection extends BaseConnection {
       const audioContext = new AudioContext();
       this.audioCaptureContext = audioContext;
 
+      // Create analyser for frequency data
+      this.outputAnalyser = audioContext.createAnalyser();
+      this.outputAnalyser.fftSize = 2048;
+      this.outputAnalyser.smoothingTimeConstant = 0.8;
+
       // Create MediaStream from the track
       const mediaStream = new MediaStream([track.mediaStreamTrack]);
 
       // Create audio source from the stream
       const source = audioContext.createMediaStreamSource(mediaStream);
 
-      // Load the raw audio processor worklet (reuse existing processor)
-      await loadRawAudioProcessor(audioContext.audioWorklet);
+      // Connect source to analyser
+      source.connect(this.outputAnalyser);
 
-      // Create worklet node for audio processing
+      // Continue with existing worklet setup...
+      await loadRawAudioProcessor(audioContext.audioWorklet);
       const worklet = new AudioWorkletNode(audioContext, "raw-audio-processor");
+
+      // Connect analyser to worklet for processing
+      this.outputAnalyser.connect(worklet);
 
       // Configure the processor for the output format
       worklet.port.postMessage({
@@ -426,5 +457,92 @@ export class WebRTCConnection extends BaseConnection {
     this.audioElements.forEach(element => {
       element.volume = volume;
     });
+  }
+
+  public async setAudioOutputDevice(deviceId: string): Promise<void> {
+    if (!("setSinkId" in HTMLAudioElement.prototype)) {
+      throw new Error("setSinkId is not supported in this browser");
+    }
+
+    // Set output device for all existing audio elements
+    const promises = this.audioElements.map(async element => {
+      try {
+        await element.setSinkId(deviceId);
+      } catch (error) {
+        console.error("Failed to set sink ID for audio element:", error);
+        throw error;
+      }
+    });
+
+    await Promise.all(promises);
+
+    // Store the device ID for future audio elements
+    this.outputDeviceId = deviceId;
+  }
+
+  public async setAudioInputDevice(deviceId: string): Promise<void> {
+    if (!this.isConnected || !this.room.localParticipant) {
+      throw new Error(
+        "Cannot change input device: room not connected or no local participant"
+      );
+    }
+
+    try {
+      // Get the current microphone track publication
+      const currentMicTrackPublication =
+        this.room.localParticipant.getTrackPublication(Track.Source.Microphone);
+
+      // Stop the current microphone track if it exists
+      if (currentMicTrackPublication?.track) {
+        await currentMicTrackPublication.track.stop();
+        await this.room.localParticipant.unpublishTrack(
+          currentMicTrackPublication.track
+        );
+      }
+
+      // Create constraints for the new input device
+      const audioConstraints: MediaTrackConstraints = {
+        deviceId: { exact: deviceId },
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: { ideal: 1 },
+      };
+
+      // Create new audio track with the specified device
+      const audioTrack = await createLocalAudioTrack(audioConstraints);
+
+      // Publish the new microphone track
+      await this.room.localParticipant.publishTrack(audioTrack, {
+        name: "microphone",
+        source: Track.Source.Microphone,
+      });
+
+      console.log("Successfully switched to input device:", deviceId);
+    } catch (error) {
+      console.error("Failed to change input device:", error);
+
+      // Try to re-enable default microphone on failure
+      try {
+        await this.room.localParticipant.setMicrophoneEnabled(true);
+      } catch (recoveryError) {
+        console.error(
+          "Failed to recover microphone after device switch error:",
+          recoveryError
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  public getOutputByteFrequencyData(): Uint8Array<ArrayBuffer> | null {
+    if (!this.outputAnalyser) return null;
+
+    this.outputFrequencyData ??= new Uint8Array(
+      this.outputAnalyser.frequencyBinCount
+    ) as Uint8Array<ArrayBuffer>;
+    this.outputAnalyser.getByteFrequencyData(this.outputFrequencyData);
+    return this.outputFrequencyData;
   }
 }

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -407,7 +407,6 @@ export class WebRTCConnection extends BaseConnection {
       // Connect source to analyser
       source.connect(this.outputAnalyser);
 
-      // Continue with existing worklet setup...
       await loadRawAudioProcessor(audioContext.audioWorklet);
       const worklet = new AudioWorkletNode(audioContext, "raw-audio-processor");
 
@@ -517,8 +516,6 @@ export class WebRTCConnection extends BaseConnection {
         name: "microphone",
         source: Track.Source.Microphone,
       });
-
-      console.log("Successfully switched to input device:", deviceId);
     } catch (error) {
       console.error("Failed to change input device:", error);
 

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -10,6 +10,15 @@ export type InputConfig = {
 const LIBSAMPLERATE_JS =
   "https://cdn.jsdelivr.net/npm/@alexanderolsen/libsamplerate-js@2.1.2/dist/libsamplerate.worklet.js";
 
+const defaultConstraints = {
+  echoCancellation: true,
+  noiseSuppression: true,
+  // Automatic gain control helps maintain a steady volume level with microphones: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/autoGainControl
+  autoGainControl: true,
+  // Mono audio for better echo cancellation
+  channelCount: { ideal: 1 },
+};
+
 export class Input {
   public static async create({
     sampleRate,
@@ -23,10 +32,7 @@ export class Input {
     try {
       const options: MediaTrackConstraints = {
         sampleRate: { ideal: sampleRate },
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true,
-        channelCount: { ideal: 1 }, // Mono audio for better echo cancellation
+        ...defaultConstraints,
       };
 
       if (isIosDevice() && preferHeadphonesForIosDevices) {
@@ -115,10 +121,7 @@ export class Input {
       // Create new constraints with the specified device
       const options: MediaTrackConstraints = {
         deviceId: { exact: inputDeviceId },
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true,
-        channelCount: { ideal: 1 },
+        ...defaultConstraints,
       };
 
       const constraints = { voiceIsolation: true, ...options };

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -26,8 +26,7 @@ export class Input {
         echoCancellation: true,
         noiseSuppression: true,
         autoGainControl: true,
-        // Enhanced constraints for better echo cancellation
-        channelCount: { ideal: 1 }, // Mono audio for voice
+        channelCount: { ideal: 1 }, // Mono audio for better echo cancellation
       };
 
       if (isIosDevice() && preferHeadphonesForIosDevices) {
@@ -91,7 +90,7 @@ export class Input {
     public readonly context: AudioContext,
     public readonly analyser: AnalyserNode,
     public readonly worklet: AudioWorkletNode,
-    public inputStream: MediaStream, // Remove readonly to allow device switching
+    public inputStream: MediaStream,
     private mediaStreamSource: MediaStreamAudioSourceNode
   ) {}
 
@@ -142,8 +141,6 @@ export class Input {
 
       // Reconnect the audio graph
       this.mediaStreamSource.connect(this.analyser);
-
-      console.log("Input device switched successfully to:", inputDeviceId);
     } catch (error) {
       console.error("Failed to switch input device:", error);
       throw error;

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -21,14 +21,12 @@ export class Output {
       audioElement.autoplay = true;
       audioElement.style.display = "none";
 
-      // Add to DOM so it can play
       document.body.appendChild(audioElement);
 
       // Create media stream destination to route audio to the element
       const destination = context.createMediaStreamDestination();
       audioElement.srcObject = destination.stream;
 
-      // Create audio routing: worklet -> gain -> analyser -> destination (which feeds the audio element)
       gain.connect(analyser);
       analyser.connect(destination);
 

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -9,22 +9,28 @@ export class Output {
   }: FormatConfig): Promise<Output> {
     let context: AudioContext | null = null;
     let audioElement: HTMLAudioElement | null = null;
-    let audioSource: MediaElementAudioSourceNode | null = null;
     try {
       context = new AudioContext({ sampleRate });
       const analyser = context.createAnalyser();
       const gain = context.createGain();
+
+      // Always create an audio element for device switching capability
+      audioElement = new Audio();
+      audioElement.src = "";
+      audioElement.load();
+      audioElement.autoplay = true;
+      audioElement.style.display = "none";
+
+      // Add to DOM so it can play
+      document.body.appendChild(audioElement);
+
+      // Create media stream destination to route audio to the element
+      const destination = context.createMediaStreamDestination();
+      audioElement.srcObject = destination.stream;
+
+      // Create audio routing: worklet -> gain -> analyser -> destination (which feeds the audio element)
       gain.connect(analyser);
-      analyser.connect(context.destination);
-
-      if (outputDeviceId) {
-        audioElement = new Audio();
-        audioElement.src = "";
-        audioElement.load();
-
-        audioSource = context.createMediaElementSource(audioElement);
-        audioSource.connect(gain);
-      }
+      analyser.connect(destination);
 
       await loadAudioConcatProcessor(context.audioWorklet);
       const worklet = new AudioWorkletNode(context, "audio-concat-processor");
@@ -33,7 +39,8 @@ export class Output {
 
       await context.resume();
 
-      if (outputDeviceId && audioElement?.setSinkId) {
+      // Set initial output device if provided
+      if (outputDeviceId && audioElement.setSinkId) {
         await audioElement.setSinkId(outputDeviceId);
       }
 
@@ -42,13 +49,15 @@ export class Output {
         analyser,
         gain,
         worklet,
-        audioElement,
-        audioSource
+        audioElement
       );
 
       return newOutput;
     } catch (error) {
-      audioSource?.disconnect();
+      // Clean up audio element from DOM
+      if (audioElement?.parentNode) {
+        audioElement.parentNode.removeChild(audioElement);
+      }
       audioElement?.pause();
       if (context && context.state !== "closed") {
         await context.close();
@@ -63,13 +72,23 @@ export class Output {
     public readonly analyser: AnalyserNode,
     public readonly gain: GainNode,
     public readonly worklet: AudioWorkletNode,
-    public readonly audioElement: HTMLAudioElement | null,
-    public readonly audioSource: MediaElementAudioSourceNode | null
+    public readonly audioElement: HTMLAudioElement
   ) {}
 
+  public async setOutputDevice(deviceId: string): Promise<void> {
+    if (!("setSinkId" in HTMLAudioElement.prototype)) {
+      throw new Error("setSinkId is not supported in this browser");
+    }
+
+    await this.audioElement.setSinkId(deviceId);
+  }
+
   public async close() {
-    this.audioSource?.disconnect();
-    this.audioElement?.pause();
+    // Remove audio element from DOM
+    if (this.audioElement.parentNode) {
+      this.audioElement.parentNode.removeChild(this.audioElement);
+    }
+    this.audioElement.pause();
     await this.context.close();
   }
 }

--- a/packages/client/src/version.ts
+++ b/packages/client/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during build
-export const PACKAGE_VERSION = "0.6.0";
+export const PACKAGE_VERSION = "0.6.1";

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -410,12 +410,8 @@ Switch the audio input device during an active voice conversation. This method i
 **Note:** In WebRTC mode the input format and sample rate are hardcoded to `pcm` and `48000` respectively. Changing those values when changing the input device is a no-op.
 
 ```js
-import { useConversation } from "@elevenlabs/react";
-
-const { changeInputDevice } = useConversation();
-
 // Change to a specific input device
-await changeInputDevice({
+await conversation.changeInputDevice({
   sampleRate: 16000,
   format: "pcm",
   preferHeadphonesForIosDevices: true,
@@ -430,12 +426,8 @@ Switch the audio output device during an active voice conversation. This method 
 **Note:** In WebRTC mode the output format and sample rate are hardcoded to `pcm` and `48000` respectively. Changing those values when changing the output device is a no-op.
 
 ```js
-import { useConversation } from "@elevenlabs/react";
-
-const { changeOutputDevice } = useConversation();
-
 // Change to a specific output device
-await changeOutputDevice({
+await conversation.changeOutputDevice({
   sampleRate: 16000,
   format: "pcm",
   outputDeviceId: "your-device-id", // Optional: specific device ID
@@ -443,6 +435,12 @@ await changeOutputDevice({
 ```
 
 **Note:** Device switching only works for voice conversations. If no specific `deviceId` is provided, the browser will use its default device selection. You can enumerate available devices using the [MediaDevices.enumerateDevices()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices) API.
+
+##### getInputByteFrequencyData / getOutputByteFrequencyData
+
+Methods that return `Uint8Array`s containing the current input/output frequency data. See [AnalyserNode.getByteFrequencyData](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getByteFrequencyData) for more information.
+
+**Note:** These methods are only available for voice conversations. In WebRTC mode the audio is hardcoded to use `pcm_48000`, meaning any visualization using the returned data might show different patterns to WebSocket connections.
 
 ##### status
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -407,6 +407,8 @@ setMicMuted(false);
 
 Switch the audio input device during an active voice conversation. This method is only available for voice conversations.
 
+**Note:** In WebRTC mode the input format and sample rate are hardcoded to `pcm` and `48000` respectively. Changing those values when changing the input device is a no-op.
+
 ```js
 import { useConversation } from "@elevenlabs/react";
 
@@ -424,6 +426,8 @@ await changeInputDevice({
 ##### changeOutputDevice
 
 Switch the audio output device during an active voice conversation. This method is only available for voice conversations.
+
+**Note:** In WebRTC mode the output format and sample rate are hardcoded to `pcm` and `48000` respectively. Changing those values when changing the output device is a no-op.
 
 ```js
 import { useConversation } from "@elevenlabs/react";

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -233,7 +233,9 @@ app.get("/signed-url", yourAuthMiddleware, async (req, res) => {
 const response = await fetch("/signed-url", yourAuthHeaders);
 const signedUrl = await response.text();
 
-const conversation = await Conversation.startSession({
+const { conversation } = useConversation();
+
+const conversationId = await conversation.startSession({
   signedUrl,
   connectionType: "websocket",
 });
@@ -271,11 +273,28 @@ app.get("/conversation-token", yourAuthMiddleware, async (req, res) => {
 const response = await fetch("/conversation-token", yourAuthHeaders);
 const conversationToken = await response.text();
 
-const conversation = await Conversation.startSession({
+const { conversation } = useConversation();
+
+const conversationId = await conversation.startSession({
   conversationToken,
   connectionType: "webrtc",
 });
 ```
+
+You can provide a device ID to start the conversation using the input/output device of your choice. If the device ID is invalid, the default input and output devices will be used.
+
+```js
+const { conversation } = useConversation();
+
+const conversationId = await conversation.startSession({
+  conversationToken,
+  connectionType: "webrtc",
+  inputDeviceId: '<new-input-device-id>',
+  outputDeviceId: '<new-input-device-id>',
+});
+```
+
+**Note:** Device switching only works for voice conversations. You can enumerate available devices using the [MediaDevices.enumerateDevices()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices) API.
 
 ##### endSession
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "ElevenLabs React Library",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.module.js",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,7 @@ import {
   type Options,
   type ClientToolsConfig,
   type InputConfig,
+  type FormatConfig,
   type Mode,
   type Status,
   type Callbacks,
@@ -61,6 +62,7 @@ export type {
   Language,
   VadScoreEvent,
   InputConfig,
+  FormatConfig,
   VoiceConversation,
   TextConversation,
 } from "@elevenlabs/client";
@@ -70,7 +72,8 @@ export type HookOptions = Partial<
   SessionConfig &
     HookCallbacks &
     ClientToolsConfig &
-    InputConfig & {
+    InputConfig &
+    FormatConfig & {
       serverLocation?: Location | string;
     }
 >;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,14 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import {
   Conversation,
-  SessionConfig,
-  Options,
-  ClientToolsConfig,
-  InputConfig,
+  type SessionConfig,
+  type Options,
+  type ClientToolsConfig,
+  type InputConfig,
   type Mode,
   type Status,
   type Callbacks,
-  type VadScoreEvent,
 } from "@elevenlabs/client";
 
 // Device configuration types for audio device switching
@@ -62,6 +61,8 @@ export type {
   Language,
   VadScoreEvent,
   InputConfig,
+  VoiceConversation,
+  TextConversation,
 } from "@elevenlabs/client";
 export { postOverallFeedback } from "@elevenlabs/client";
 

--- a/packages/react/src/version.ts
+++ b/packages/react/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during build
-export const PACKAGE_VERSION = "0.6.0";
+export const PACKAGE_VERSION = "0.6.1";


### PR DESCRIPTION
Fixes https://github.com/elevenlabs/packages/issues/110
Fixes https://github.com/elevenlabs/packages/issues/186

Makes the `getOutputByteFrequencyData` methods work in WebRTC mode. Also fixes setting input/output devices.