### PR TITLE
add input props for worker path override

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -429,6 +429,23 @@ await conversation.changeOutputDevice({
 
 **Note:** Device switching only works for voice conversations. If no specific `deviceId` is provided, the browser will use its default device selection. You can enumerate available devices using the [MediaDevices.enumerateDevices()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices) API.
 
+## CSP issues
+
+If your application has a tight Content Security Policy and does not allow data: or blob: in the `script-src`, you self-host the needed files in the public folder.
+
+Whitelisting these values is not recommended w3.org/TR/CSP2#source-list-guid-matching.
+
+Add the worklet file code from
+
+```
+packages/client/src/utils/rawAudioProcessor.ts
+packages/client/src/utils/audioConcatProcessor.ts
+```
+
+to your public/ folder, eg `public/elevenlabs`.
+
+Then call with input "workletPaths" set to your worklets.
+
 ## Development
 
 Please, refer to the README.md file in the root of this repository.

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -16,6 +16,7 @@ import type {
   VadScoreEvent,
 } from "./utils/events";
 import type { InputConfig } from "./utils/input";
+import type { OutputConfig } from "./utils/output";
 
 export type Role = "user" | "ai";
 
@@ -30,12 +31,14 @@ export type Status =
 export type Options = SessionConfig &
   Callbacks &
   ClientToolsConfig &
-  InputConfig;
+  InputConfig &
+  OutputConfig;
 
 export type PartialOptions = SessionConfig &
   Partial<Callbacks> &
   Partial<ClientToolsConfig> &
   Partial<InputConfig> &
+  Partial<OutputConfig> &
   Partial<FormatConfig>;
 
 export type ClientToolsConfig = {

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -28,18 +28,29 @@ export type Status =
   | "disconnecting"
   | "disconnected";
 
+/** Allows self-hosting the worklets to avoid whitelisting blob: and data: in the CSP script-src  */
+export type AudioWorkletConfig = {
+  workletPaths?: {
+    "raw-audio-processor"?: string;
+    "audio-concat-processor"?: string;
+  };
+  libsampleratePath?: string;
+};
+
 export type Options = SessionConfig &
   Callbacks &
   ClientToolsConfig &
   InputConfig &
-  OutputConfig;
+  OutputConfig &
+  AudioWorkletConfig;
 
 export type PartialOptions = SessionConfig &
   Partial<Callbacks> &
   Partial<ClientToolsConfig> &
   Partial<InputConfig> &
   Partial<OutputConfig> &
-  Partial<FormatConfig>;
+  Partial<FormatConfig> &
+  Partial<AudioWorkletConfig>;
 
 export type ClientToolsConfig = {
   clientTools: Record<

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -54,10 +54,12 @@ export class VoiceConversation extends BaseConversation {
           ...connection.inputFormat,
           preferHeadphonesForIosDevices: options.preferHeadphonesForIosDevices,
           inputDeviceId: options.inputDeviceId,
+          rawAudioProcessorPath: options.rawAudioProcessorPath,
         }),
         Output.create({
           ...connection.outputFormat,
           outputDeviceId: options.outputDeviceId,
+          audioConcatProcessorPath: options.audioConcatProcessorPath,
         }),
       ]);
 

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -54,12 +54,13 @@ export class VoiceConversation extends BaseConversation {
           ...connection.inputFormat,
           preferHeadphonesForIosDevices: options.preferHeadphonesForIosDevices,
           inputDeviceId: options.inputDeviceId,
-          rawAudioProcessorPath: options.rawAudioProcessorPath,
+          workletPaths: options.workletPaths,
+          libsampleratePath: options.libsampleratePath,
         }),
         Output.create({
           ...connection.outputFormat,
           outputDeviceId: options.outputDeviceId,
-          audioConcatProcessorPath: options.audioConcatProcessorPath,
+          workletPaths: options.workletPaths,
         }),
       ]);
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,6 +12,7 @@ export type {
   Status,
 } from "./BaseConversation";
 export type { InputConfig } from "./utils/input";
+export type { OutputConfig } from "./utils/output";
 export { Input } from "./utils/input";
 export { Output } from "./utils/output";
 export type { IncomingSocketEvent, VadScoreEvent } from "./utils/events";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,6 +10,7 @@ export type {
   ClientToolsConfig,
   Callbacks,
   Status,
+  AudioWorkletConfig,
 } from "./BaseConversation";
 export type { InputConfig } from "./utils/input";
 export type { OutputConfig } from "./utils/output";

--- a/packages/client/src/utils/createWorkletModuleLoader.ts
+++ b/packages/client/src/utils/createWorkletModuleLoader.ts
@@ -1,10 +1,23 @@
 const URLCache = new Map<string, string>();
 
 export function createWorkletModuleLoader(name: string, sourceCode: string) {
-  return async (worklet: AudioWorklet) => {
-    const url = URLCache.get(name);
-    if (url) {
-      return worklet.addModule(url);
+  return async (worklet: AudioWorklet, path?: string) => {
+    const cachedUrl = URLCache.get(name);
+    if (cachedUrl) {
+      return worklet.addModule(cachedUrl);
+    }
+
+    // If a path is provided, use it directly (CSP-friendly approach)
+    if (path) {
+      try {
+        await worklet.addModule(path);
+        URLCache.set(name, path);
+        return;
+      } catch (error) {
+        throw new Error(
+          `Failed to load the ${name} worklet module from path: ${path}. Error: ${error}`
+        );
+      }
     }
 
     const blob = new Blob([sourceCode], { type: "application/javascript" });

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -5,6 +5,7 @@ import { isIosDevice } from "./compatibility";
 export type InputConfig = {
   preferHeadphonesForIosDevices?: boolean;
   inputDeviceId?: string;
+  rawAudioProcessorPath?: string;
 };
 
 const LIBSAMPLERATE_JS =
@@ -25,6 +26,7 @@ export class Input {
     format,
     preferHeadphonesForIosDevices,
     inputDeviceId,
+    rawAudioProcessorPath,
   }: FormatConfig & InputConfig): Promise<Input> {
     let context: AudioContext | null = null;
     let inputStream: MediaStream | null = null;
@@ -66,7 +68,7 @@ export class Input {
       if (!supportsSampleRateConstraint) {
         await context.audioWorklet.addModule(LIBSAMPLERATE_JS);
       }
-      await loadRawAudioProcessor(context.audioWorklet);
+      await loadRawAudioProcessor(context.audioWorklet, rawAudioProcessorPath);
 
       const constraints = { voiceIsolation: true, ...options };
       inputStream = await navigator.mediaDevices.getUserMedia({

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -1,9 +1,9 @@
 import { loadAudioConcatProcessor } from "./audioConcatProcessor";
 import type { FormatConfig } from "./connection";
+import type { AudioWorkletConfig } from "../BaseConversation";
 
 export type OutputConfig = {
   outputDeviceId?: string;
-  audioConcatProcessorPath?: string;
 };
 
 export class Output {
@@ -11,8 +11,8 @@ export class Output {
     sampleRate,
     format,
     outputDeviceId,
-    audioConcatProcessorPath,
-  }: FormatConfig & OutputConfig): Promise<Output> {
+    workletPaths,
+  }: FormatConfig & OutputConfig & AudioWorkletConfig): Promise<Output> {
     let context: AudioContext | null = null;
     let audioElement: HTMLAudioElement | null = null;
     try {
@@ -38,7 +38,7 @@ export class Output {
 
       await loadAudioConcatProcessor(
         context.audioWorklet,
-        audioConcatProcessorPath
+        workletPaths?.["audio-concat-processor"]
       );
       const worklet = new AudioWorkletNode(context, "audio-concat-processor");
       worklet.port.postMessage({ type: "setFormat", format });

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -1,12 +1,18 @@
 import { loadAudioConcatProcessor } from "./audioConcatProcessor";
 import type { FormatConfig } from "./connection";
 
+export type OutputConfig = {
+  outputDeviceId?: string;
+  audioConcatProcessorPath?: string;
+};
+
 export class Output {
   public static async create({
     sampleRate,
     format,
     outputDeviceId,
-  }: FormatConfig): Promise<Output> {
+    audioConcatProcessorPath,
+  }: FormatConfig & OutputConfig): Promise<Output> {
     let context: AudioContext | null = null;
     let audioElement: HTMLAudioElement | null = null;
     try {
@@ -30,7 +36,10 @@ export class Output {
       gain.connect(analyser);
       analyser.connect(destination);
 
-      await loadAudioConcatProcessor(context.audioWorklet);
+      await loadAudioConcatProcessor(
+        context.audioWorklet,
+        audioConcatProcessorPath
+      );
       const worklet = new AudioWorkletNode(context, "audio-concat-processor");
       worklet.port.postMessage({ type: "setFormat", format });
       worklet.connect(gain);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -289,8 +289,8 @@ const { conversation } = useConversation();
 const conversationId = await conversation.startSession({
   conversationToken,
   connectionType: "webrtc",
-  inputDeviceId: '<new-input-device-id>',
-  outputDeviceId: '<new-input-device-id>',
+  inputDeviceId: "<new-input-device-id>",
+  outputDeviceId: "<new-input-device-id>",
 });
 ```
 
@@ -489,6 +489,34 @@ This is helpful to conditionally show the feedback button in your UI.
 ```js
 const { canSendFeedback } = useConversation();
 console.log(canSendFeedback); // boolean
+```
+
+## CSP issues
+
+If your application has a tight Content Security Policy and does not allow data: or blob: in the `script-src`, you self-host the needed files in the public folder.
+
+Whitelisting these values is not recommended w3.org/TR/CSP2#source-list-guid-matching.
+
+Add the worklet file code from
+
+```
+packages/client/src/utils/rawAudioProcessor.ts
+packages/client/src/utils/audioConcatProcessor.ts
+```
+
+to your public/ folder, eg `public/elevenlabs`.
+
+Then call start with
+
+```ts
+      await conversation.startSession({
+...
+        workletPaths: {
+          'raw-audio-processor': '/worklets/raw-audio-processor.worklet.js',
+          'audio-concat-processor':
+            '/worklets/audio-concat-processor.worklet.js',
+        },
+      });
 ```
 
 ## Development

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,7 @@ import {
   type Options,
   type ClientToolsConfig,
   type InputConfig,
+  type AudioWorkletConfig,
   type OutputConfig,
   type FormatConfig,
   type Mode,
@@ -75,6 +76,7 @@ export type HookOptions = Partial<
     ClientToolsConfig &
     InputConfig &
     OutputConfig &
+    AudioWorkletConfig &
     FormatConfig & {
       serverLocation?: Location | string;
     }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,7 @@ import {
   type Options,
   type ClientToolsConfig,
   type InputConfig,
+  type OutputConfig,
   type FormatConfig,
   type Mode,
   type Status,
@@ -73,6 +74,7 @@ export type HookOptions = Partial<
     HookCallbacks &
     ClientToolsConfig &
     InputConfig &
+    OutputConfig &
     FormatConfig & {
       serverLocation?: Location | string;
     }


### PR DESCRIPTION
relates to #193

Allows passing worklets paths via options to client, allowing for secure CSPs. 

Should have worklet files as js in a specific folder to allow automatic updating on CI, so that we can suggest something like 

```
import { viteStaticCopy } from 'vite-plugin-static-copy'
import { createRequire } from 'node:module';

const require = createRequire(import.meta.url);

export default {
  plugins: [
    viteStaticCopy({
      targets: [
        {
          src: require.resolve('@elevenlabs/client')/dist/worklets/audio-concat-processor.js',
          dest: 'dist',
        },
        {
          src: require.resolve('@elevenlabs/client')/dist/worklets/raw-audio-processor.js',
          dest: 'dist',
        },
      ],
    }),
  ],
}
```
which would automatically keep the files up-to-date (thanks @aapzu)