### PR TITLE
Fix startSession using outdated values for micMuted and volume

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -102,9 +102,15 @@ export function useConversation<T extends HookOptions & ControlledState>(
   const { micMuted, volume, serverLocation, ...defaultOptions } = props;
   const conversationRef = useRef<Conversation | null>(null);
   const lockRef = useRef<Promise<Conversation> | null>(null);
+  // Store current micMuted and volume in refs to always have up-to-date values by the time they're read in startSession
+  const micMutedRef = useRef<boolean | undefined>(micMuted);
+  const volumeRef = useRef<number | undefined>(volume);
   const [status, setStatus] = useState<Status>("disconnected");
   const [canSendFeedback, setCanSendFeedback] = useState(false);
   const [mode, setMode] = useState<Mode>("listening");
+
+  micMutedRef.current = micMuted;
+  volumeRef.current = volume;
 
   useEffect(() => {
     if (micMuted !== undefined) {
@@ -192,12 +198,12 @@ export function useConversation<T extends HookOptions & ControlledState>(
         } as Options);
 
         conversationRef.current = await lockRef.current;
-        // Persist controlled state between sessions
-        if (micMuted !== undefined) {
-          conversationRef.current.setMicMuted(micMuted);
+
+        if (micMutedRef.current !== undefined) {
+          conversationRef.current.setMicMuted(micMutedRef.current);
         }
-        if (volume !== undefined) {
-          conversationRef.current.setVolume({ volume });
+        if (volumeRef.current !== undefined) {
+          conversationRef.current.setVolume({ volume: volumeRef.current });
         }
 
         return conversationRef.current.getId();


### PR DESCRIPTION
Fixes #210

This solution uses refs to ensure the micMuted and volume props are always up-to-date. There might be a better way to fix this, I'm not sure.

Another approach might be to add `status` or a new state variable to the dependency array of the two useEffect hooks on line 115 to trigger them once `conversationRef.current` becomes available. 

It would be better if `conversationRef.current` were available immediately instead of needing to wait for the connection to finish.