### PR TITLE
[agents cli] update API base URLs for residency endpoints

### DIFF
--- a/packages/agents-cli/src/__tests__/residency.test.ts
+++ b/packages/agents-cli/src/__tests__/residency.test.ts
@@ -50,7 +50,7 @@ describe('Residency-specific API Client', () => {
     const client = await getElevenLabsClient();
     
     expect(client).toEqual({
-      baseUrl: 'https://api.eu.elevenlabs.io',
+      baseUrl: 'https://api.eu.residency.elevenlabs.io',
       apiKey: 'test-api-key'
     });
   });
@@ -61,7 +61,7 @@ describe('Residency-specific API Client', () => {
     const client = await getElevenLabsClient();
     
     expect(client).toEqual({
-      baseUrl: 'https://api.in.elevenlabs.io',
+      baseUrl: 'https://api.in.residency.elevenlabs.io',
       apiKey: 'test-api-key'
     });
   });

--- a/packages/agents-cli/src/elevenlabs-api.ts
+++ b/packages/agents-cli/src/elevenlabs-api.ts
@@ -18,9 +18,9 @@ function isPlatformSettings(settings: unknown): settings is AgentPlatformSetting
 function getApiBaseUrl(residency?: Location): string {
   switch (residency) {
     case 'eu-residency':
-      return 'https://api.eu.elevenlabs.io';
+      return 'https://api.eu.residency.elevenlabs.io';
     case 'in-residency':
-      return 'https://api.in.elevenlabs.io';
+      return 'https://api.in.residency.elevenlabs.io';
     case 'us':
       return 'https://api.us.elevenlabs.io';
     case 'global':


### PR DESCRIPTION
The residency endpoints for EU and IN do not match what seems to be available.
This is causing fetch/sync errors when using the CLI.