### PR TITLE
[Widget] Add expand event

### DIFF
--- a/packages/convai-widget-core/package.json
+++ b/packages/convai-widget-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/convai-widget-core",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "The common library for the Conversational AI Widget.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -25,6 +25,7 @@ function Playground() {
   const [textInput, setTextInput] = useState(false);
   const [textOnly, setTextOnly] = useState(false);
   const [alwaysExpanded, setAlwaysExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <div className="w-screen h-screen flex items-center justify-center bg-base-hover text-base-primary">
@@ -105,6 +106,23 @@ function Playground() {
             ))}
           </select>
         </label>
+        {(textOnly || textInput || transcript) && (
+          <button
+            type="button"
+            onClick={() => {
+              const event = new CustomEvent('elevenlabs-agent:expand', {
+                detail: { action: expanded ? 'collapse' : 'expand' },
+                bubbles: true,
+                composed: true
+              });
+              document.dispatchEvent(event);
+              setExpanded(!expanded);
+            }}
+            className="p-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            Toggle expand
+          </button>
+        )}
       </div>
       <div className="dev-host">
         <ConvAIWidget

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -190,4 +190,108 @@ describe("elevenlabs-convai", () => {
       await expect.element(startButton).toBeInTheDocument();
     }
   );
+
+  describe("expansion events", () => {
+    it("should expand and collapse widget when elevenlabs-agent:expand event is dispatched", async () => {
+      setupWebComponent({
+        "agent-id": "basic",
+        "text-input": "true",
+        variant: "compact",
+      });
+
+      // Initially, the widget should not be expanded
+      await expect
+        .element(page.getByRole("button", { name: "Start a call" }))
+        .toBeInTheDocument();
+
+      // Dispatch expand event
+      const expandEvent = new CustomEvent("elevenlabs-agent:expand", {
+        detail: { action: "expand" },
+        bubbles: true,
+        composed: true,
+      });
+      document.dispatchEvent(expandEvent);
+
+      // The widget should now be expanded (Sheet should be visible)
+      // We can check for the presence of the text input which is only visible when expanded
+      await expect
+        .element(page.getByRole("textbox", { name: "Text message input" }))
+        .toBeInTheDocument();
+
+      // Now collapse it
+      const collapseEvent = new CustomEvent("elevenlabs-agent:expand", {
+        detail: { action: "collapse" },
+        bubbles: true,
+        composed: true,
+      });
+      document.dispatchEvent(collapseEvent);
+
+      // The text input should no longer be visible
+      await expect
+        .element(page.getByRole("textbox", { name: "Text message input" }))
+        .not.toBeInTheDocument();
+    });
+
+    it("should toggle widget when elevenlabs-agent:expand event is dispatched with toggle action", async () => {
+      setupWebComponent({
+        "agent-id": "basic",
+        transcript: "true",
+        "text-input": "true",
+        variant: "compact",
+      });
+
+      // Initially collapsed
+      await expect
+        .element(page.getByRole("button", { name: "Start a call" }))
+        .toBeInTheDocument();
+
+      // First toggle - should expand
+      const toggleEvent1 = new CustomEvent("elevenlabs-agent:expand", {
+        detail: { action: "toggle" },
+        bubbles: true,
+        composed: true,
+      });
+      document.dispatchEvent(toggleEvent1);
+
+      // Should be expanded now
+      await expect
+        .element(page.getByRole("textbox", { name: "Text message input" }))
+        .toBeInTheDocument();
+
+      // Second toggle - should collapse
+      const toggleEvent2 = new CustomEvent("elevenlabs-agent:expand", {
+        detail: { action: "toggle" },
+        bubbles: true,
+        composed: true,
+      });
+      document.dispatchEvent(toggleEvent2);
+
+      // Should be collapsed now
+      await expect
+        .element(page.getByRole("textbox", { name: "Text message input" }))
+        .not.toBeInTheDocument();
+    });
+
+    it("should not expand widget when it's not expandable (no transcript or text input)", async () => {
+      setupWebComponent({
+        "agent-id": "basic",
+        variant: "compact",
+        // No transcript or text-input enabled
+      });
+
+      // Dispatch expand event
+      const expandEvent = new CustomEvent("elevenlabs-agent:expand", {
+        detail: { action: "expand" },
+        bubbles: true,
+        composed: true,
+      });
+      document.dispatchEvent(expandEvent);
+
+      // Widget should remain in its original state (not expanded)
+      // The text input should not be present since the widget is not expandable
+      await expect
+        .element(page.getByRole("textbox", { name: "Text message input" }))
+        .not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/convai-widget-core/src/version.ts
+++ b/packages/convai-widget-core/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during build
-export const PACKAGE_VERSION = "0.2.1";
+export const PACKAGE_VERSION = "0.3.0";

--- a/packages/convai-widget-core/src/widget/Wrapper.tsx
+++ b/packages/convai-widget-core/src/widget/Wrapper.tsx
@@ -66,6 +66,26 @@ export const Wrapper = memo(function Wrapper() {
     }
   });
 
+  // Listen for custom expansion events
+  useSignalEffect(() => {
+    const handleExpandEvent = (event: CustomEvent) => {
+      if (event.detail?.action === 'expand') {
+        expanded.value = true;
+      } else if (event.detail?.action === 'collapse') {
+        expanded.value = false;
+      } else if (event.detail?.action === 'toggle') {
+        expanded.value = !expanded.value;
+      }
+    };
+
+    // Listen for custom events on the document
+    document.addEventListener('elevenlabs-agent:expand', handleExpandEvent as EventListener);
+
+    return () => {
+      document.removeEventListener('elevenlabs-agent:expand', handleExpandEvent as EventListener);
+    };
+  });
+
   const state = useComputed(() => {
     if (!expandable.value && !!error.value && !sawError.value) {
       return "error";

--- a/packages/convai-widget-embed/package.json
+++ b/packages/convai-widget-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/convai-widget-embed",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "The Conversational AI Widget bundled with all dependencies for easy embedding.",
   "main": "./dist/index.js",
   "unpkg": "./dist/index.js",

--- a/packages/react-native/src/components/LiveKitRoomWrapper.tsx
+++ b/packages/react-native/src/components/LiveKitRoomWrapper.tsx
@@ -57,7 +57,7 @@ export const LiveKitRoomWrapper = ({
         clientTools={clientTools}
         updateCurrentEventId={updateCurrentEventId}
       />
-      {children}
+      {children as any}
     </LiveKitRoom>
   );
 };


### PR DESCRIPTION
Adds a new `elevenlabs-agent:expand` event to trigger the widget expanding without clicking the "Start call" button. Only works if the widget is able to expand, i.e. if text-input, text-only or transcript modes are enabled.