### PR TITLE
feat(convai-widget-core): show 'end call' button in text mode

### DIFF
--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -108,7 +108,7 @@ export function SheetActions({
       <div className="flex h-11 items-center">
         <TriggerMuteButton visible={!textOnly.value && !isDisconnected.value} />
         <SizeTransition
-          visible={!textOnly.value && (!isDisconnected.value || showTranscript)}
+          visible={!isDisconnected.value || showTranscript}
           className="p-1"
         >
           <CallButton


### PR DESCRIPTION
We think there is usability benefit to still show the "End call" button while chatting in text mode.

Some rationale:

1. As a user, you otherwise have to write a message to close it out and wait for an LLM loop, I think that's not so straight forward to always have to wait for the "other end" to close it. And I think that's only if you support the agent end_call tool?
2. Our support agent uses MCP to run other resources in parallel with the chat itself. The closing of the chat also cleans up those resources and it's more natural for a user to want to clean those up via "ending" the call.
3. The user has to end to get the conversation id if they need it, so forces them to guess that they have to say goodbye to the agent
4. Users may not understand the special hang up instructions and just leave it running in the background, and ElevenLabs continues to charge per minute in the background.

**Before:**

<img width="439" height="529" alt="image" src="https://github.com/user-attachments/assets/1d49bd72-f5a4-4540-bc12-15a1b347d3b1" />

**After:**

<img width="427" height="511" alt="image" src="https://github.com/user-attachments/assets/05fee22a-2e32-479a-a3c6-4b63a84e32f6" />

Thoughts?