### PR TITLE
fix(convai-widget-core): suppress first-message in text-only when using dynamic vars

### DIFF
--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -78,6 +78,7 @@ export function useConversation() {
 function useConversationSetup() {
   const conversationRef = useRef<Conversation | null>(null);
   const lockRef = useRef<Promise<Conversation> | null>(null);
+  const receivedFirstMessageRef = useRef(false);
 
   const widgetConfig = useWidgetConfig();
   const firstMessage = useFirstMessage();
@@ -194,12 +195,15 @@ function useConversationSetup() {
               if (
                 conversationTextOnly.peek() === true &&
                 source === "ai" &&
-                message === firstMessage.peek()
+                !receivedFirstMessageRef.current
               ) {
+                receivedFirstMessageRef.current = true
                 // Text mode is always started by the user sending a text message.
                 // We need to ignore the first agent message as it is immediately
                 // interrupted by the user input.
                 return;
+              } else if (source === "ai") {
+                receivedFirstMessageRef.current = true
               }
 
               transcript.value = [
@@ -214,6 +218,7 @@ function useConversationSetup() {
               ];
             },
             onDisconnect: details => {
+              receivedFirstMessageRef.current = false;
               conversationTextOnly.value = null;
               transcript.value = [
                 ...transcript.value,

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -30,7 +30,7 @@ function Playground() {
 
   const dynamicVariables = useMemo(() =>
     dynamicVariablesStr
-      .split(',')
+      .split('\n')
       .reduce<Record<string, string>>((acc, expr) => {
         const [name, value] = expr.split('=')
         return { ...acc, [name]: value };

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -11,7 +11,7 @@ import {
   Location,
   parseLocation,
 } from "./types/config";
-import { useState } from "preact/compat";
+import { useMemo, useState } from "preact/compat";
 
 /**
  * A dev-only playground for testing the ConvAIWidget component.
@@ -25,7 +25,17 @@ function Playground() {
   const [textInput, setTextInput] = useState(false);
   const [textOnly, setTextOnly] = useState(false);
   const [alwaysExpanded, setAlwaysExpanded] = useState(false);
+  const [dynamicVariablesStr, setDynamicVariablesStr] = useState("")
   const [expanded, setExpanded] = useState(false);
+
+  const dynamicVariables = useMemo(() =>
+    dynamicVariablesStr
+      .split(',')
+      .reduce<Record<string, string>>((acc, expr) => {
+        const [name, value] = expr.split('=')
+        return { ...acc, [name]: value };
+      }, {})
+  , [dynamicVariablesStr])
 
   return (
     <div className="w-screen h-screen flex items-center justify-center bg-base-hover text-base-primary">
@@ -95,6 +105,15 @@ function Playground() {
           Always expanded
         </label>
         <label className="flex flex-col">
+          Dynamic variables (i.e., new-line separated name=value)
+          <textarea
+            className="p-1 bg-base border border-base-border"
+            onChange={e => setDynamicVariablesStr(e.currentTarget.value)}
+            value={dynamicVariablesStr}
+            rows={5}
+          />
+        </label>
+        <label className="flex flex-col">
           Server Location
           <select
             value={location}
@@ -134,6 +153,7 @@ function Playground() {
           mic-muting={JSON.stringify(micMuting)}
           override-text-only={JSON.stringify(textOnly)}
           always-expanded={JSON.stringify(alwaysExpanded)}
+          dynamic-variables={JSON.stringify(dynamicVariables)}
           server-location={location}
         />
       </div>


### PR DESCRIPTION
When starting a conversation as text-only (i.e., when a text message input), the "first-message" from the agent is suppressed by checking the exact text match.

This does not work when there is a dynamic variable used in the first message. For example, the first-message from config is `Hi, I'm {{name}}, how can I help?`, but the message content over the socket is `Hi, I'm John, how can I help?`.

This fix uses a ref to track if the first AI message has arrived since the start of a session, to determine if we should suppress the AI message in text-only mode.

Bonus improvement in here to support dynamic variables in the sandbox, in case you wanted that.
