### PR TITLE
[ci] check version match and deps exist in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,19 +51,19 @@ jobs:
           echo "package.json version: $PACKAGE_JSON_VERSION"
 
           if [ "$TAG_VERSION" != "$PACKAGE_JSON_VERSION" ]; then
-            echo "❌ ERROR: Version mismatch!"
+            echo "ERROR: Version mismatch!"
             echo "Git tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_JSON_VERSION)"
             echo "Please ensure the git tag matches the version in $PACKAGE_PATH/package.json"
             exit 1
           fi
 
-          echo "✅ Version check passed: $TAG_VERSION"
+          echo "Version check passed: $TAG_VERSION"
 
       - name: Validate workspace dependencies are published
         run: |
           PACKAGE_PATH="packages/$(echo "$PACKAGE_NAME" | sed 's/@elevenlabs\///')"
 
-          # Get all workspace dependencies from package.json
+          # Get all workspace dependencies from package.json (excluding private packages)
           WORKSPACE_DEPS=$(node -p "
             const pkg = require('./$PACKAGE_PATH/package.json');
             const deps = { ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies };
@@ -73,6 +73,8 @@ jobs:
                 const pkgPath = 'packages/' + name.replace('@elevenlabs/', '') + '/package.json';
                 try {
                   const depPkg = require('./' + pkgPath);
+                  // Skip private packages (they are not published to npm)
+                  if (depPkg.private) return null;
                   return name + '@' + depPkg.version;
                 } catch (e) {
                   return null;
@@ -83,7 +85,7 @@ jobs:
           " 2>/dev/null || echo "")
 
           if [ -z "$WORKSPACE_DEPS" ]; then
-            echo "✅ No workspace dependencies to check"
+            echo "No workspace dependencies to check"
             exit 0
           fi
 
@@ -97,16 +99,16 @@ jobs:
 
             # Check if the specific version exists on npm
             if npm view "$DEP_NAME@$DEP_VERSION" version &>/dev/null; then
-              echo "  ✅ $DEP_NAME@$DEP_VERSION is published"
+              echo "  $DEP_NAME@$DEP_VERSION is published"
             else
-              echo "  ❌ $DEP_NAME@$DEP_VERSION is NOT published"
+              echo "  $DEP_NAME@$DEP_VERSION is NOT published"
               MISSING_DEPS+=("$DEP_NAME@$DEP_VERSION")
             fi
           done
 
           if [ ${#MISSING_DEPS[@]} -gt 0 ]; then
             echo ""
-            echo "❌ ERROR: Some workspace dependencies are not published to npm:"
+            echo "ERROR: Some workspace dependencies are not published to npm:"
             for DEP in "${MISSING_DEPS[@]}"; do
               echo "  - $DEP"
             done
@@ -116,7 +118,7 @@ jobs:
           fi
 
           echo ""
-          echo "✅ All workspace dependencies are published"
+          echo "All workspace dependencies are published"
 
       - name: Print package name and publish tag
         run: |


### PR DESCRIPTION
Add validation checks to publish workflow
- Version validation: Ensures git tag version matches package.json version
- Dependency validation: Checks all workspace:* dependencies are published to npm before publishing

Testing

version extraction works correctly
@elevenlabs/react-native@0.4.0 → extracts 0.4.0, matches package.json

detects version mismatch
Tag: @elevenlabs/react-native@0.5.0 vs package.json: 0.4.0 → fails with error

Validates published dependencies  
@elevenlabs/types@0.0.2 → confirmed published on npm

Detects unpublished dependencies
@elevenlabs/types@999.999.999 → fails with clear error message

Would have caught the issue #280 where react-native 0.4.0 was published before types 0.0.2 existed


test commands 
# Test version extraction and validation
  bash -c '
  TAG_NAME="@elevenlabs/react-native@0.4.0"
  TAG_VERSION=$(echo "$TAG_NAME" | rev | cut -d"@" -f1 | rev)
  PACKAGE_NAME=$(echo "$TAG_NAME" | rev | cut -d"@" -f2- | rev)
  PACKAGE_PATH="packages/$(echo "$PACKAGE_NAME" | sed "s/@elevenlabs\///")"
  echo "Tag: $TAG_NAME"
  echo "Package name: $PACKAGE_NAME"
  echo "Tag version: $TAG_VERSION"
  echo "Package path: $PACKAGE_PATH"
  PACKAGE_JSON_VERSION=$(node -p "require(\"./$PACKAGE_PATH/package.json\").version")
  echo "package.json version: $PACKAGE_JSON_VERSION"
  '

  # Test version mismatch detection
  bash -c '
  TAG_NAME="@elevenlabs/react-native@0.5.0"
  TAG_VERSION=$(echo "$TAG_NAME" | rev | cut -d"@" -f1 | rev)
  PACKAGE_NAME=$(echo "$TAG_NAME" | rev | cut -d"@" -f2- | rev)
  PACKAGE_PATH="packages/$(echo "$PACKAGE_NAME" | sed "s/@elevenlabs\///")"
  PACKAGE_JSON_VERSION=$(node -p "require(\"./$PACKAGE_PATH/package.json\").version")
  if [ "$TAG_VERSION" != "$PACKAGE_JSON_VERSION" ]; then
    echo "❌ ERROR: Version mismatch!"
    echo "Git tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_JSON_VERSION)"
    exit 1
  fi
  ' || echo "Command exited with error code $?"

  # Test workspace dependency validation
  bash -c '
  PACKAGE_NAME="@elevenlabs/react-native"
  PACKAGE_PATH="packages/$(echo "$PACKAGE_NAME" | sed "s/@elevenlabs\///")"
  WORKSPACE_DEPS=$(node -p "
    const pkg = require(\"./$PACKAGE_PATH/package.json\");
    const deps = { ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies };
    Object.entries(deps)
      .filter(([_, version]) => version.startsWith(\"workspace:\"))
      .map(([name, version]) => {
        const pkgPath = \"packages/\" + name.replace(\"@elevenlabs/\", \"\") + \"/package.json\";
        try {
          const depPkg = require(\"./\" + pkgPath);
          return name + \"@\" + depPkg.version;
        } catch (e) {
          return null;
        }
      })
      .filter(Boolean)
      .join(\" \");
  ")
  echo "Workspace deps: $WORKSPACE_DEPS"
  for DEP in $WORKSPACE_DEPS; do
    DEP_NAME=$(echo "$DEP" | cut -d"@" -f1-2)
    DEP_VERSION=$(echo "$DEP" | cut -d"@" -f3)
    if npm view "$DEP_NAME@$DEP_VERSION" version &>/dev/null; then
      echo "  ✅ $DEP_NAME@$DEP_VERSION is published"
    else
      echo "  ❌ $DEP_NAME@$DEP_VERSION is NOT published"
    fi
  done
  '

  # Test unpublished dependency detection
  bash -c '
  DEP_NAME="@elevenlabs/types"
  DEP_VERSION="999.999.999"
  if npm view "$DEP_NAME@$DEP_VERSION" version &>/dev/null; then
    echo "  ✅ $DEP_NAME@$DEP_VERSION is published"
  else
    echo "  ❌ $DEP_NAME@$DEP_VERSION is NOT published"
  fi
  '