### PR TITLE
Revert change to ICE transport policy

### DIFF
--- a/packages/react-native/src/components/LiveKitRoomWrapper.tsx
+++ b/packages/react-native/src/components/LiveKitRoomWrapper.tsx
@@ -46,11 +46,6 @@ export const LiveKitRoomWrapper = ({
       options={{
         adaptiveStream: { pixelDensity: 'screen' },
       }}
-      connectOptions={{
-        rtcConfig: {
-          iceTransportPolicy: 'relay',
-        },
-      }}
       onConnected={onConnected}
       onDisconnected={onDisconnected}
       onError={onError}


### PR DESCRIPTION
This PR addresses #284. The problem we're having is with `@elevenlabs/react-native`. The problem is that, since version 0.3.2, a conversation can't be started. Instead, there's a timeout and an error, saying

```
❌ Conversation error: could not establish pc connection undefined
```

This error can be seen, having installed and run the example at `./examples/react-native-expo` on any platform, when you press "Start Conversation"

I've documented my process in the comments of #284. The commit where things broke is #240, so this reverts the key change made there.

I do see that #240 was trying to address a concern raised in #140 with scary/redundant permission requests.

This concern makes sense. However, the original requestors on #140 have not verified that the `0.3.2` release has in fact worked for them.
