### PR TITLE
[minor] add version.ts generation script to postinstall automation

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
+    "postinstall": "pnpm run generate-version",
     "generate-worklets": "node scripts/generateWorklets.js",
     "prebuild": "pnpm run generate-version && pnpm run generate-worklets",
     "build": "BROWSERSLIST_ENV=modern microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react src/index.ts",

--- a/packages/convai-widget-core/package.json
+++ b/packages/convai-widget-core/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "scripts": {
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
+    "postinstall": "npm run generate-version",
     "prebuild": "npm run generate-version",
     "build": "vite build && tsc --declaration --emitDeclarationOnly",
     "dev": "npm run generate-version && vite",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
+    "postinstall": "pnpm run generate-version",
     "prebuild": "pnpm run generate-version",
     "build": "BROWSERSLIST_ENV=modern microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react src/index.ts",
     "clean": "rm -rf ./dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
+    "postinstall": "pnpm run generate-version",
     "prebuild": "pnpm run generate-version",
     "build": "BROWSERSLIST_ENV=modern microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react src/index.ts",
     "clean": "rm -rf ./dist",


### PR DESCRIPTION
quick followup for https://github.com/elevenlabs/packages/pull/289, which makes versions.ts generate automatically in postinstall hook.