### PR TITLE
Fix post tool call sound speech fade out

### DIFF
--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -122,7 +122,16 @@ export class VoiceConversation extends BaseConversation {
 
   protected override handleInterruption(event: InterruptionEvent) {
     super.handleInterruption(event);
-    this.fadeOutAudio();
+
+    const interruptionType =
+      event.interruption_event?.interruption_type ?? "user";
+
+    if (interruptionType === "tool_sound") {
+      this.output.worklet.port.postMessage({ type: "interrupt" });
+      this.output.worklet.port.postMessage({ type: "clearInterrupted" });
+    } else {
+      this.fadeOutAudio();
+    }
   }
 
   protected override handleAudio(event: AgentAudioEvent) {

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -214,7 +214,10 @@ export interface Interruption {
 
 export interface InterruptionEvent {
   event_id: number;
+  interruption_type?: InterruptionEventInterruptionType;
 }
+
+export type InterruptionEventInterruptionType = "user" | "tool_sound";
 
 export interface ConversationMetadata {
   type: "conversation_initiation_metadata";

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -325,6 +325,16 @@ components:
         - internal_tentative_agent_response
       description: Types of events that can be sent from server to client
 
+    InterruptionType:
+      type: string
+      enum:
+        - user
+        - tool_sound
+      description: |
+        Type of interruption:
+        - user: User interrupted the agent (default)
+        - tool_sound: Tool call sound stopping
+
     Language:
       type: string
       enum:
@@ -823,6 +833,9 @@ components:
       properties:
         event_id:
           type: integer
+        interruption_type:
+          $ref: "#/components/schemas/InterruptionType"
+          description: Type of interruption. Defaults to 'user' if not specified.
 
     ConversationMetadataData:
       type: object


### PR DESCRIPTION
the js sdk currently has an issue where an interruption event triggers a fade out which ramps the audio down and back up over 2 seconds, which can disrupt agent speech. to mitigate this, i have introduced an interruption type [in xi](https://github.com/elevenlabs/xi/pull/19632) to differentiate between a user interruption and a tool call sound interruption, this pr utilizes said type