### PR TITLE
fix(convai-widget-core): ignore empty stream messages

### DIFF
--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -241,24 +241,18 @@ function useConversationSetup() {
               if (type === "start") {
                 isReceivingStreamRef.current = true;
                 streamingMessageIndexRef.current = currentTranscript.length;
-                transcript.value = [
-                  ...currentTranscript,
-                  {
+              } else if (type === "delta") {
+                const streamingIndex = streamingMessageIndexRef.current;
+                if (streamingIndex !== null && text) {
+                  const updatedTranscript = [...currentTranscript];
+                  const streamingMessage = updatedTranscript[streamingIndex] ??= {
                     type: "message",
                     role: "ai",
                     message: "",
                     isText: true,
                     conversationIndex: conversationIndex.peek(),
-                  },
-                ];
-              } else if (type === "delta") {
-                const streamingIndex = streamingMessageIndexRef.current;
-                if (
-                  streamingIndex !== null &&
-                  currentTranscript[streamingIndex]
-                ) {
-                  const updatedTranscript = [...currentTranscript];
-                  const streamingMessage = updatedTranscript[streamingIndex];
+                  };
+
                   if (streamingMessage.type === "message") {
                     updatedTranscript[streamingIndex] = {
                       ...streamingMessage,

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -27,6 +27,8 @@ function Playground() {
   const [alwaysExpanded, setAlwaysExpanded] = useState(false);
   const [dynamicVariablesStr, setDynamicVariablesStr] = useState("")
   const [expanded, setExpanded] = useState(false);
+  const [overrideFirstMessage, setOverrideFirstMessage] = useState(false);
+  const [firstMessage, setFirstMessage] = useState("Hi, how can I help you today?")
 
   const dynamicVariables = useMemo(() =>
     dynamicVariablesStr
@@ -113,6 +115,27 @@ function Playground() {
             rows={5}
           />
         </label>
+        <label className="flex flex-row gap-1">
+          <div>
+            <input
+              type="checkbox"
+              checked={overrideFirstMessage}
+              onChange={e => setOverrideFirstMessage(e.currentTarget.checked)}
+            />
+          </div>
+            <div>
+              First message:
+              {overrideFirstMessage && (
+                <input
+                  type="text"
+                  className="p-1 bg-base border border-base-border"
+                  value={firstMessage}
+                  disabled={!overrideFirstMessage}
+                  onChange={e => setFirstMessage(e.currentTarget.value)}
+                />
+              )}
+            </div>
+        </label>
         <label className="flex flex-col">
           Server Location
           <select
@@ -155,6 +178,7 @@ function Playground() {
           always-expanded={JSON.stringify(alwaysExpanded)}
           dynamic-variables={JSON.stringify(dynamicVariables)}
           server-location={location}
+          override-first-message={overrideFirstMessage ? firstMessage : undefined}
         />
       </div>
     </div>


### PR DESCRIPTION
For reasons I have yet to nail down, the elevenlabs websocket can deliver empty streamed messages (i.e., a "start" followed by a "stop" immediately after). It may just be the LLM deciding to send a "text" step with an empty string, and just some funny wording embedded somewhere in our prompting... 

One additional thing about it is while there is both a start/stop onAgentResponsePart message, there is no followup onMessage that triggers -- so this may have been a thing that existed before, but the back-end filters out empty onMessage events?

I can continue trial and error there to see why the LLM wants to give us an empty message, but in the meantime it probably makes sense to not allow empty text messages to stream into the transcript? That's what this fix does.