### PR TITLE
fix(convai-widget-core): respect feedback mode to determine if feedback form should be displayed

### DIFF
--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -194,7 +194,7 @@ export function useWebRTC() {
 
 export function useShouldShowFeedbackAtEnd() {
   const config = useWidgetConfig();
-  return useComputed(() => config.value.end_feedback !== undefined);
+  return useComputed(() => !!config.value.end_feedback || config.value.feedback_mode === "end");
 }
 
 async function fetchConfig(

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -34,7 +34,7 @@ export interface WidgetConfig {
   feedback_mode: FeedbackMode;
   end_feedback?: {
     type: FeedbackType;
-  };
+  } | null;
   language: Language;
   supported_language_overrides?: Language[];
   terms_html?: string;

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -61,7 +61,7 @@ function DisconnectionMessage({ entry }: DisconnectionMessageProps) {
 
   return (
     <div className="mt-3 px-8 flex flex-col">
-      {shouldShowFeedbackAtEnd && <Feedback />}
+      {shouldShowFeedbackAtEnd.value && <Feedback />}
       <div className="text-xs text-base-subtle text-center transition-opacity duration-200 data-hidden:opacity-0">
         {entry.role === "user"
           ? text.user_ended_conversation


### PR DESCRIPTION
The handling of feedback_mode doesn't seem to be inline with the widget config API. On my agent, end_feedback is always `null`, but `feedback_mode` will be set to none/during/end.

I assume the API changed, so I've done my best to kind of guess what the right logic should be if one were using the older API. Let me know if I got it wrong.

Screen recording (sorry embedded vids don't work for me): [Screen Recording 2025-11-13 at 1.52.18 PM.mov.gz](https://github.com/user-attachments/files/23533049/Screen.Recording.2025-11-13.at.1.52.18.PM.mov.gz)
