### PR TITLE
Use OIDC for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
@@ -127,5 +129,3 @@ jobs:
 
       - name: Publish package
         run: pnpm --filter $PACKAGE_NAME publish --access=public --no-git-checks --tag $PUBLISH_TAG
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.ELEVENLABS_NPM_TOKEN }}


### PR DESCRIPTION
Switch publishing to NPM via OIDC rather than auth tokens.

Before merging this each package needs to be updated on npm to use OIDC.