### PR TITLE
chore(deps): update vite to 6.4.1

### DIFF
--- a/packages/convai-widget-core/package.json
+++ b/packages/convai-widget-core/package.json
@@ -38,7 +38,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.5.4",
     "unified": "^11.0.5",
-    "vite": "^6.3.2",
+    "vite": "^6.4.1",
     "vite-bundle-analyzer": "^1.2.3",
     "vitest": "^3.1.2"
   },

--- a/packages/convai-widget-embed/package.json
+++ b/packages/convai-widget-embed/package.json
@@ -23,7 +23,7 @@
     "eslint": "^9.8.0",
     "microbundle": "^0.15.1",
     "typescript": "^5.5.4",
-    "vite": "^6.3.2",
+    "vite": "^6.4.1",
     "vite-bundle-analyzer": "^1.2.3"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,7 +181,7 @@ importers:
         version: 0.0.3
       '@vitest/browser':
         specifier: ^3.0.5
-        version: 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)
+        version: 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)
       eslint:
         specifier: ^9.8.0
         version: 9.33.0(jiti@1.21.7)
@@ -278,7 +278,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.10.1
-        version: 2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+        version: 2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@radix-ui/react-select':
         specifier: ^2.2.2
         version: 2.2.6(@types/react-dom@18.2.7)(@types/react@19.1.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -290,7 +290,7 @@ importers:
         version: 4.0.4
       '@vitest/browser':
         specifier: ^3.1.2
-        version: 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)
+        version: 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)
       eslint:
         specifier: ^9.8.0
         version: 9.33.0(jiti@1.21.7)
@@ -310,8 +310,8 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
       vite:
-        specifier: ^6.3.2
-        version: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
       vite-bundle-analyzer:
         specifier: ^1.2.3
         version: 1.2.3
@@ -334,8 +334,8 @@ importers:
         specifier: ^5.5.4
         version: 5.9.2
       vite:
-        specifier: ^6.3.2
-        version: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
       vite-bundle-analyzer:
         specifier: ^1.2.3
         version: 1.2.3
@@ -520,8 +520,8 @@ packages:
   '@asyncapi/diff@0.5.0':
     resolution: {integrity: sha512-lvKuEBDUOqOQfFwaTJfNTLwztby2r/6mfwoH/l7f1Kyf+7tH2+73ChV0VfIF498FJNKrdivo8isbLzfgi/KNjQ==}
 
-  '@asyncapi/generator-components@0.2.0':
-    resolution: {integrity: sha512-2jm9Mxee2FCRHz2rnLHTLEQF5jcVVuPmRRnqmtr43w/XdPiRvZ3c2K2GH/+Tg8+65nUObQbDRdICJ/1jpUFd6w==}
+  '@asyncapi/generator-components@0.3.1':
+    resolution: {integrity: sha512-CRob0RYsSVGRdx5iSr3TbKdBCAWzYfKIr6S0nEqRWeefhv4OWY8G872TlOLC53fqdVqDP2Zjra2qTrkw0GuT6g==}
 
   '@asyncapi/generator-helpers@0.2.0':
     resolution: {integrity: sha512-pVwuOV0tWiRY8Px7WWOlxux4kJbeBgLZr46CjG8/KHos1dUeWEFELLFzEjiE0TJy+wE+ZYn+TuZc/bPSiKu9PQ==}
@@ -538,8 +538,8 @@ packages:
     engines: {node: '>12.16', npm: '>6.13.7'}
     hasBin: true
 
-  '@asyncapi/generator@2.8.3':
-    resolution: {integrity: sha512-toFdCdYZZXAxP9cTpKz3cbK4wkjKw4FmIeT4vAv/85uL6QL3/CZCY0VJcDzroXpLTTlQ37/4MjSecAEg9DLqEQ==}
+  '@asyncapi/generator@2.8.4':
+    resolution: {integrity: sha512-2YTs3VYL1vfqDqm5zZGqR3nOOA0XigjcM7eD1SjD9WUCk7sz9Cu/IKNbW/SELPgVgh6DqUy8qH7vJQMC9Qs1Sg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.0'}
     hasBin: true
 
@@ -551,8 +551,8 @@ packages:
     resolution: {integrity: sha512-p0dLWCkPM7drK3ueTKEBeRfdkA4jD8+ZPRWP4LRSkPGsmHJ3MzNyWpzn6t9GmUlwmVJVbYxKjsNdEarHK3vy9w==}
     engines: {node: '>=18'}
 
-  '@asyncapi/modelina@5.7.2':
-    resolution: {integrity: sha512-TWVYLYtFi/atM5KUN+EKLvnRWB3WFeD/kwwkHAVPTj08xM4VHCxJ2kRUOTvu1j3YNpx7KinG2GPTMraxJi1vVA==}
+  '@asyncapi/modelina@5.10.1':
+    resolution: {integrity: sha512-mvk77+ls2ia+w3uQftJ7s6/Yid4lO+1IgbTkJ94mGSV9Qqk1n+ln5dz2snccARI5ubdy3ofKb3QP2Dq/OGeH8A==}
     engines: {node: '>=18'}
 
   '@asyncapi/multi-parser@2.2.0':
@@ -582,6 +582,9 @@ packages:
 
   '@asyncapi/raml-dt-schema-parser@4.0.24':
     resolution: {integrity: sha512-Fy9IwCXPpXoG4Mkm7sXgWucSwYg8POwdx16xuHAmV6AerpcM8nk5mT/tARLtR3wrMst3OBwReEVYzwT3esSb8g==}
+    deprecated: |-
+      Project is archived. See https://github.com/asyncapi-archived-repos/raml-dt-schema-parser
+      .
 
   '@asyncapi/react-component@1.4.10':
     resolution: {integrity: sha512-ejANS06yj1ZM4YDtsRi0g7h3EEJLGusewjzeugK+tGntNAKVZRvTPUXhbSDMhTARHuZXhUGLlITIno7N1aXapw==}
@@ -780,6 +783,10 @@ packages:
     resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.28.5':
+    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
@@ -855,6 +862,10 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -873,6 +884,11 @@ packages:
 
   '@babel/parser@7.28.3':
     resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1457,8 +1473,16 @@ packages:
     resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.28.5':
+    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -2339,6 +2363,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -4034,6 +4061,9 @@ packages:
   '@types/urijs@1.19.25':
     resolution: {integrity: sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==}
 
+  '@types/urijs@1.19.26':
+    resolution: {integrity: sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==}
+
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
@@ -4814,6 +4844,10 @@ packages:
     resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
     engines: {node: '>=8'}
 
+  ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+    engines: {node: '>=8'}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -5204,6 +5238,15 @@ packages:
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -5799,6 +5842,10 @@ packages:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
     hasBin: true
 
+  fast-xml-parser@5.3.2:
+    resolution: {integrity: sha512-n8v8b6p4Z1sMgqRmqLJm3awW4NX7NkaKPfb3uJIBTSH7Pdvufi3PQ3/lJLQrvxcMYl7JI2jnDO90siPEpD8JBA==}
+    hasBin: true
+
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -6062,6 +6109,10 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
   glob@11.0.3:
@@ -6951,6 +7002,10 @@ packages:
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   js-yaml@4.1.0:
@@ -9277,6 +9332,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -9374,6 +9434,9 @@ packages:
 
   simple-git@3.28.0:
     resolution: {integrity: sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==}
+
+  simple-git@3.30.0:
+    resolution: {integrity: sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==}
 
   simple-plist@1.3.1:
     resolution: {integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==}
@@ -9775,6 +9838,10 @@ packages:
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
   tinygradient@1.1.5:
@@ -10224,8 +10291,8 @@ packages:
     peerDependencies:
       vite: 5.x || 6.x || 7.x
 
-  vite@6.3.5:
-    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -10237,6 +10304,46 @@ packages:
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@7.2.4:
+    resolution: {integrity: sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -10677,7 +10784,7 @@ snapshots:
       chokidar: 3.6.0
       fast-levenshtein: 3.0.0
       fs-extra: 11.3.1
-      generator-v2: '@asyncapi/generator@2.8.3(@types/babel__core@7.20.5)(@types/node@22.18.1)(encoding@0.1.13)'
+      generator-v2: '@asyncapi/generator@2.8.4(@types/babel__core@7.20.5)(@types/node@22.18.1)(encoding@0.1.13)'
       https-proxy-agent: 7.0.6
       inquirer: 8.2.7(@types/node@22.18.1)
       js-yaml: 4.1.0
@@ -10740,10 +10847,11 @@ snapshots:
       js-yaml: 4.1.0
       json2md: 1.13.0
 
-  '@asyncapi/generator-components@0.2.0(@types/babel__core@7.20.5)(encoding@0.1.13)':
+  '@asyncapi/generator-components@0.3.1(@types/babel__core@7.20.5)(encoding@0.1.13)':
     dependencies:
+      '@asyncapi/generator-helpers': 0.2.0
       '@asyncapi/generator-react-sdk': 1.1.3(@types/babel__core@7.20.5)(encoding@0.1.13)
-      '@asyncapi/modelina': 5.7.2(encoding@0.1.13)
+      '@asyncapi/modelina': 5.10.1(encoding@0.1.13)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -10809,9 +10917,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@asyncapi/generator@2.8.3(@types/babel__core@7.20.5)(@types/node@22.18.1)(encoding@0.1.13)':
+  '@asyncapi/generator@2.8.4(@types/babel__core@7.20.5)(@types/node@22.18.1)(encoding@0.1.13)':
     dependencies:
-      '@asyncapi/generator-components': 0.2.0(@types/babel__core@7.20.5)(encoding@0.1.13)
+      '@asyncapi/generator-components': 0.3.1(@types/babel__core@7.20.5)(encoding@0.1.13)
       '@asyncapi/generator-helpers': 0.2.0
       '@asyncapi/generator-hooks': 0.1.0
       '@asyncapi/generator-react-sdk': 1.1.3(@types/babel__core@7.20.5)(encoding@0.1.13)
@@ -10827,7 +10935,7 @@ snapshots:
       fs.extra: 1.3.2
       global-dirs: 3.0.1
       jmespath: 0.15.0
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       levenshtein-edit-distance: 2.0.5
       loglevel: 1.9.2
       minimatch: 3.1.2
@@ -10836,8 +10944,8 @@ snapshots:
       requireg: 0.2.2
       resolve-from: 5.0.0
       resolve-pkg: 2.0.0
-      semver: 7.7.2
-      simple-git: 3.28.0
+      semver: 7.7.3
+      simple-git: 3.30.0
       ts-node: 10.9.2(@types/node@22.18.1)(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -10884,7 +10992,7 @@ snapshots:
       - '@swc/wasm'
       - encoding
 
-  '@asyncapi/modelina@5.7.2(encoding@0.1.13)':
+  '@asyncapi/modelina@5.10.1(encoding@0.1.13)':
     dependencies:
       '@apidevtools/json-schema-ref-parser': 11.9.3
       '@apidevtools/swagger-parser': 10.1.1(openapi-types@12.1.3)
@@ -10892,6 +11000,7 @@ snapshots:
       '@asyncapi/parser': 3.4.0(encoding@0.1.13)
       alterschema: 1.1.3(encoding@0.1.13)
       change-case: 4.1.2
+      fast-xml-parser: 5.3.2
       js-yaml: 4.1.0
       openapi-types: 12.1.3
       typescript-json-schema: 0.58.1
@@ -10955,7 +11064,7 @@ snapshots:
       '@stoplight/spectral-ref-resolver': 1.0.5(encoding@0.1.13)
       '@stoplight/types': 13.20.0
       '@types/json-schema': 7.0.15
-      '@types/urijs': 1.19.25
+      '@types/urijs': 1.19.26
       ajv: 8.17.1
       ajv-errors: 3.0.0(ajv@8.17.1)
       ajv-formats: 2.1.1(ajv@8.17.1)
@@ -10975,7 +11084,7 @@ snapshots:
       '@stoplight/spectral-functions': 1.10.1(encoding@0.1.13)
       '@stoplight/spectral-parsers': 1.0.5
       '@types/json-schema': 7.0.15
-      '@types/urijs': 1.19.25
+      '@types/urijs': 1.19.26
       ajv: 8.17.1
       ajv-errors: 3.0.0(ajv@8.17.1)
       ajv-formats: 2.1.1(ajv@8.17.1)
@@ -11689,6 +11798,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.1.0
 
+  '@babel/generator@7.28.5':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.28.2
@@ -11850,6 +11967,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helper-wrap-function@7.28.3':
@@ -11875,6 +11994,10 @@ snapshots:
   '@babel/parser@7.28.3':
     dependencies:
       '@babel/types': 7.28.2
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.12.9)':
     dependencies:
@@ -13104,10 +13227,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -13945,7 +14085,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -14252,6 +14392,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.30':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -14581,11 +14726,11 @@ snapshots:
     dependencies:
       '@npmcli/map-workspaces': 3.0.6
       '@npmcli/package-json': 5.2.1
-      ci-info: 4.3.0
+      ci-info: 4.3.1
       ini: 4.1.3
       nopt: 7.2.1
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.7.3
       walk-up-path: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -14618,7 +14763,7 @@ snapshots:
       proc-log: 4.2.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.7.2
+      semver: 7.7.3
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -14638,7 +14783,7 @@ snapshots:
   '@npmcli/map-workspaces@3.0.6':
     dependencies:
       '@npmcli/name-from-folder': 2.0.0
-      glob: 10.4.5
+      glob: 10.5.0
       minimatch: 9.0.5
       read-package-json-fast: 3.0.2
 
@@ -14670,12 +14815,12 @@ snapshots:
   '@npmcli/package-json@5.2.1':
     dependencies:
       '@npmcli/git': 5.0.8
-      glob: 10.4.5
+      glob: 10.5.0
       hosted-git-info: 7.0.2
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 6.0.2
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - bluebird
 
@@ -14852,18 +14997,18 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@preact/preset-vite@2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@preact/preset-vite@2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.3)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.3)
-      '@prefresh/vite': 2.4.10(preact@10.27.1)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@prefresh/vite': 2.4.10(preact@10.27.1)(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.28.3)
       debug: 4.4.1(supports-color@8.1.1)
       picocolors: 1.1.1
-      vite: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
-      vite-prerender-plugin: 0.5.11(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      vite: 6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite-prerender-plugin: 0.5.11(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -14883,7 +15028,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.10(preact@10.27.1)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@prefresh/vite@2.4.10(preact@10.27.1)(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@prefresh/babel-plugin': 0.5.2
@@ -14891,7 +15036,7 @@ snapshots:
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
       preact: 10.27.1
-      vite: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16514,6 +16659,8 @@ snapshots:
 
   '@types/urijs@1.19.25': {}
 
+  '@types/urijs@1.19.26': {}
+
   '@types/uuid@9.0.8': {}
 
   '@types/wrap-ansi@3.0.0': {}
@@ -16619,11 +16766,30 @@ snapshots:
       '@urql/core': 5.2.0(graphql@16.11.0)
       wonka: 6.3.5
 
-  '@vitest/browser@3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/utils': 3.2.4
+      magic-string: 0.30.17
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/browser@3.2.4)(jiti@1.21.7)(jsdom@16.7.0)(lightningcss@1.27.0)(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      ws: 8.18.3
+    optionalDependencies:
+      playwright: 1.54.2
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/mocker': 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
@@ -16646,14 +16812,23 @@ snapshots:
       chai: 5.3.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.5(@types/node@22.18.1)(typescript@5.9.2)
-      vite: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+
+  '@vitest/mocker@3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.10.5(@types/node@22.18.1)(typescript@5.9.2)
+      vite: 7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -16721,7 +16896,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17462,6 +17637,8 @@ snapshots:
 
   ci-info@4.3.0: {}
 
+  ci-info@4.3.1: {}
+
   cjs-module-lexer@1.4.3: {}
 
   classcat@5.0.5: {}
@@ -17669,7 +17846,7 @@ snapshots:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       parse-json: 4.0.0
 
   cosmiconfig@7.1.0:
@@ -17888,6 +18065,10 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   debuglog@1.0.1: {}
 
@@ -18585,6 +18766,10 @@ snapshots:
     dependencies:
       strnum: 2.1.1
 
+  fast-xml-parser@5.3.2:
+    dependencies:
+      strnum: 2.1.1
+
   fastest-levenshtein@1.0.16: {}
 
   fastest-stable-stringify@2.0.2: {}
@@ -18858,6 +19043,15 @@ snapshots:
       is-glob: 4.0.3
 
   glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
@@ -19143,7 +19337,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19151,7 +19345,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19163,7 +19357,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -20171,6 +20365,11 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -20482,7 +20681,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
 
   make-error@1.3.6: {}
 
@@ -20782,7 +20981,7 @@ snapshots:
   metro-source-map@0.82.5:
     dependencies:
       '@babel/traverse': 7.28.3
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.3'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.5'
       '@babel/types': 7.28.2
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -21490,7 +21689,7 @@ snapshots:
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
 
   npm-normalize-package-bin@1.0.1: {}
 
@@ -21531,7 +21730,7 @@ snapshots:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.3
-      semver: 7.7.2
+      semver: 7.7.3
 
   npm-registry-fetch@13.3.1:
     dependencies:
@@ -22900,6 +23099,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.7.3: {}
+
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -23060,6 +23261,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-git@3.30.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   simple-plist@1.3.1:
     dependencies:
       bplist-creator: 0.1.0
@@ -23108,7 +23317,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -23129,7 +23338,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.2
       sort-object-keys: 1.1.3
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
 
@@ -23528,6 +23737,11 @@ snapshots:
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
@@ -24039,7 +24253,7 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -24054,7 +24268,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-prerender-plugin@0.5.11(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)):
+  vite-prerender-plugin@0.5.11(vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.17
@@ -24062,9 +24276,9 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.6
       stack-trace: 1.0.0-pre2
-      vite: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
 
-  vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1):
+  vite@6.4.1(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -24081,11 +24295,28 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.8.1
 
+  vite@7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.46.4
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.18.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      lightningcss: 1.27.0
+      terser: 5.43.1
+      tsx: 4.20.5
+      yaml: 2.8.1
+
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/browser@3.2.4)(jiti@1.21.7)(jsdom@16.7.0)(lightningcss@1.27.0)(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(vite@7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -24103,13 +24334,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
       vite-node: 3.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.18.1
-      '@vitest/browser': 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@6.3.5(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.10.5(@types/node@22.18.1)(typescript@5.9.2))(playwright@1.54.2)(vite@7.2.4(@types/node@22.18.1)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)
       jsdom: 16.7.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
Resolves the following issues from `pnpm audit`: 
```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ vite allows server.fs.deny bypass via backslash on     │
│                     │ Windows                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ vite                                                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=6.0.0 <=6.4.0                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=6.4.1                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ packages__convai-widget-core>vite                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-93m4-6634-74q7      │
└─────────────────────┴────────────────────────────────────────────────────────┘

│ low                 │ Vite middleware may serve files starting with the same │
│                     │ name with the public directory                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ vite                                                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=6.0.0 <=6.3.5                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=6.3.6                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ packages__convai-widget-core>vite                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-g4jq-h2w9-997c      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ low                 │ Vite's `server.fs` settings were not applied to HTML   │
│                     │ files                                                  │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ vite                                                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=6.0.0 <=6.3.5                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=6.3.6                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ packages__convai-widget-core>vite                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-jqfw-vq24-v9c3      │
```