### PR TITLE
add commit_throttled error handling for scribe connections

### DIFF
--- a/packages/client/src/scribe/connection.ts
+++ b/packages/client/src/scribe/connection.ts
@@ -7,6 +7,7 @@ import type {
   ScribeErrorMessage,
   ScribeAuthErrorMessage,
   ScribeQuotaExceededErrorMessage,
+  ScribeCommitThrottledErrorMessage,
 } from "@elevenlabs/types";
 
 // Re-export types for public API
@@ -18,6 +19,7 @@ export type {
   ScribeErrorMessage,
   ScribeAuthErrorMessage,
   ScribeQuotaExceededErrorMessage,
+  ScribeCommitThrottledErrorMessage,
 };
 
 export type WebSocketMessage =
@@ -27,7 +29,8 @@ export type WebSocketMessage =
   | CommittedTranscriptWithTimestampsMessage
   | ScribeErrorMessage
   | ScribeAuthErrorMessage
-  | ScribeQuotaExceededErrorMessage;
+  | ScribeQuotaExceededErrorMessage
+  | ScribeCommitThrottledErrorMessage;
 
 /**
  * Simple EventEmitter implementation for browser compatibility.
@@ -84,6 +87,8 @@ export enum RealtimeEvents {
   CLOSE = "close",
   /** Emitted when a quota exceeded error occurs */
   QUOTA_EXCEEDED = "quota_exceeded",
+  /** Emitted when a commit request is throttled */
+  COMMIT_THROTTLED = "commit_throttled",
 }
 
 /**
@@ -170,6 +175,9 @@ export class RealtimeConnection {
             break;
           case "quota_exceeded":
             this.eventEmitter.emit(RealtimeEvents.QUOTA_EXCEEDED, data);
+            break;
+          case "commit_throttled":
+            this.eventEmitter.emit(RealtimeEvents.COMMIT_THROTTLED, data);
             break;
           case "error":
             this.eventEmitter.emit(RealtimeEvents.ERROR, data);

--- a/packages/react/src/scribe.ts
+++ b/packages/react/src/scribe.ts
@@ -12,6 +12,7 @@ import type {
   ScribeErrorMessage,
   ScribeAuthErrorMessage,
   ScribeQuotaExceededErrorMessage,
+  ScribeCommitThrottledErrorMessage,
 } from "@elevenlabs/client";
 
 // ============= Types =============
@@ -41,6 +42,7 @@ export interface ScribeCallbacks {
   onError?: (error: Error | Event) => void;
   onAuthError?: (data: { error: string }) => void;
   onQuotaExceededError?: (data: { error: string }) => void;
+  onCommitThrottledError?: (data: { error: string }) => void;
   onConnect?: () => void;
   onDisconnect?: () => void;
 }
@@ -118,6 +120,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
     onConnect,
     onDisconnect,
     onQuotaExceededError,
+    onCommitThrottledError,
 
     // Connection options
     token: defaultToken,
@@ -303,6 +306,13 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
           setError(message.error);
           setStatus("error");
           onQuotaExceededError?.(message);
+        });
+
+        connection.on(RealtimeEvents.COMMIT_THROTTLED, (data: unknown) => {
+          const message = data as ScribeCommitThrottledErrorMessage;
+          setError(message.error);
+          setStatus("error");
+          onCommitThrottledError?.(message);
         });
 
         connection.on(RealtimeEvents.OPEN, () => {

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -691,3 +691,8 @@ export interface ScribeQuotaExceededErrorMessage {
   message_type: "quota_exceeded";
   error: string;
 }
+
+export interface ScribeCommitThrottledErrorMessage {
+  message_type: "commit_throttled";
+  error: string;
+}


### PR DESCRIPTION
fixes #378

adds support for handling commit_throttled errors in scribe connections following the same pattern as quota_exceeded errors. users can now catch these errors via RealtimeEvents.COMMIT_THROTTLED event in client or onCommitThrottledError callback in react hook.

changes:
- added COMMIT_THROTTLED event to RealtimeEvents enum
- added commit_throttled case handler in websocket message switch
- added ScribeCommitThrottledErrorMessage type
- added onCommitThrottledError callback to react useScribe hook