### PR TITLE
feat: add speed parameter to tts overrides

### DIFF
--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -37,6 +37,7 @@ export type BaseSessionConfig = {
     };
     tts?: {
       voiceId?: string;
+      speed?: number;
     };
     conversation?: {
       textOnly?: boolean;

--- a/packages/client/src/utils/overrides.ts
+++ b/packages/client/src/utils/overrides.ts
@@ -20,6 +20,7 @@ export function constructOverrides(
       },
       tts: {
         voice_id: config.overrides.tts?.voiceId,
+        speed: config.overrides.tts?.speed,
       },
       conversation: {
         text_only: config.overrides.conversation?.textOnly,

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -70,6 +70,7 @@ export type ConversationConfig = {
     };
     tts?: {
       voiceId?: string;
+      speed?: number;
     };
     conversation?: {
       textOnly?: boolean;

--- a/packages/react-native/src/utils/overrides.ts
+++ b/packages/react-native/src/utils/overrides.ts
@@ -17,6 +17,7 @@ export function constructOverrides(
       },
       tts: {
         voice_id: config.overrides.tts?.voiceId,
+        speed: config.overrides.tts?.speed,
       },
       conversation: {
         text_only: config.overrides.conversation?.textOnly,


### PR DESCRIPTION
exposes the speed parameter (0.7 to 1.2) in tts overrides for both the client and react native packages, allowing developers to control agent speaking pace programmatically as documented in the elevenlabs agents platform.

closes #393