### PR TITLE
fix(react-native): prevent microphone permission and audio session when using text only mode

### DIFF
--- a/packages/react-native/src/ElevenLabsProvider.tsx
+++ b/packages/react-native/src/ElevenLabsProvider.tsx
@@ -129,6 +129,8 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
     userId,
   } = useConversationSession(callbacksRef, setStatus, setConnect, setToken, setConversationId, tokenFetchUrl);
 
+  const textOnly = overrides?.conversation?.textOnly ?? false;
+
   const {
     roomConnected,
     localParticipant,
@@ -136,7 +138,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
     handleConnected,
     handleDisconnected,
     handleError,
-  } = useLiveKitRoom(callbacksRef, setStatus, conversationId, status);
+  } = useLiveKitRoom(callbacksRef, setStatus, conversationId, status, textOnly);
 
   // Enhanced connection handler to initialize feedback state
   const handleConnectedWithFeedback = React.useCallback(() => {
@@ -339,6 +341,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
         updateCurrentEventId={updateCurrentEventId}
         onEndSession={endSession}
         audioSessionConfig={audioSessionConfig}
+        textOnly={textOnly}
       >
         {children}
       </LiveKitRoomWrapper>

--- a/packages/react-native/src/components/LiveKitRoomWrapper.tsx
+++ b/packages/react-native/src/components/LiveKitRoomWrapper.tsx
@@ -21,6 +21,7 @@ interface LiveKitRoomWrapperProps {
   onEndSession: (reason?: "user" | "agent") => void;
   updateCurrentEventId?: (eventId: number) => void;
   audioSessionConfig?: AudioSessionConfig;
+  textOnly?: boolean;
 }
 
 export const LiveKitRoomWrapper = ({
@@ -39,9 +40,14 @@ export const LiveKitRoomWrapper = ({
   updateCurrentEventId,
   onEndSession,
   audioSessionConfig,
+  textOnly = false,
 }: LiveKitRoomWrapperProps) => {
   // Configure audio options based on audioSessionConfig
   const audioOptions = React.useMemo(() => {
+    if (textOnly) {
+      return false;
+    }
+
     if (!audioSessionConfig?.allowMixingWithOthers) {
       return true;
     }
@@ -56,7 +62,7 @@ export const LiveKitRoomWrapper = ({
         allowMixingWithOthers: true,
       },
     };
-  }, [audioSessionConfig]);
+  }, [audioSessionConfig, textOnly]);
 
   return (
     <LiveKitRoom

--- a/packages/react-native/src/hooks/useLiveKitRoom.ts
+++ b/packages/react-native/src/hooks/useLiveKitRoom.ts
@@ -30,7 +30,7 @@ export const useLiveKitRoom = (
 
     if (shouldHaveAudio && !audioSessionActiveRef.current) {
       audioSessionActiveRef.current = true;
-      await AudioSession.startAudioSession();
+      AudioSession.startAudioSession();
     } else if (!shouldHaveAudio && audioSessionActiveRef.current) {
       audioSessionActiveRef.current = false;
       AudioSession.stopAudioSession();

--- a/packages/react-native/src/hooks/useLiveKitRoom.ts
+++ b/packages/react-native/src/hooks/useLiveKitRoom.ts
@@ -30,7 +30,7 @@ export const useLiveKitRoom = (
 
     if (shouldHaveAudio && !audioSessionActiveRef.current) {
       audioSessionActiveRef.current = true;
-      AudioSession.startAudioSession();
+      await AudioSession.startAudioSession();
     } else if (!shouldHaveAudio && audioSessionActiveRef.current) {
       audioSessionActiveRef.current = false;
       AudioSession.stopAudioSession();


### PR DESCRIPTION
when textOnly is set to true in conversation overrides, the sdk now correctly skips requesting microphone permissions and does not start the audio session. this is achieved by passing the textOnly flag through to the livekit room wrapper which sets audio to false, and by conditionally managing the audio session lifecycle in the useLiveKitRoom hook based on both the textOnly flag and active conversation state. voice chat functionality remains unchanged when textOnly is false or omitted.

closes #395