### PR TITLE
refactor: Rename audioSessionConfiguration to audioSessionConfig

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -64,7 +64,7 @@ import { ElevenLabsProvider, useConversation } from '@elevenlabs/react-native';
 function App() {
   return (
     <ElevenLabsProvider
-      audioSessionConfiguration={{
+      audioSessionConfig={{
         allowMixingWithOthers: true,
       }}
     >
@@ -238,7 +238,7 @@ Control how the SDK manages audio sessions with other audio sources:
 
 ```typescript
 <ElevenLabsProvider
-  audioSessionConfiguration={{
+  audioSessionConfig={{
     allowMixingWithOthers: true, // Default: false
   }}
 >

--- a/packages/react-native/src/ElevenLabsProvider.tsx
+++ b/packages/react-native/src/ElevenLabsProvider.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createContext, useContext, useState } from 'react';
 import { registerGlobals } from '@livekit/react-native';
 import type { LocalParticipant } from 'livekit-client';
-import type { Callbacks, ConversationConfig, ConversationStatus, ClientToolsConfig, AudioSessionConfiguration } from './types';
+import type { Callbacks, ConversationConfig, ConversationStatus, ClientToolsConfig, AudioSessionConfig } from './types';
 import { constructOverrides } from './utils/overrides';
 import { DEFAULT_SERVER_URL } from './utils/constants';
 import { useConversationCallbacks } from './hooks/useConversationCallbacks';
@@ -81,10 +81,10 @@ export const useConversation = (options: ConversationOptions = {}): Conversation
 
 interface ElevenLabsProviderProps {
   children: React.ReactNode;
-  audioSessionConfiguration?: AudioSessionConfiguration;
+  audioSessionConfig?: AudioSessionConfig;
 }
 
-export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children, audioSessionConfiguration }) => {
+export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children, audioSessionConfig }) => {
   // Initialize globals on mount
   registerGlobals();
 
@@ -320,7 +320,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
         clientTools={clientToolsRef.current}
         updateCurrentEventId={updateCurrentEventId}
         onEndSession={endSession}
-        audioSessionConfiguration={audioSessionConfiguration}
+        audioSessionConfig={audioSessionConfig}
       >
         {children}
       </LiveKitRoomWrapper>

--- a/packages/react-native/src/components/LiveKitRoomWrapper.tsx
+++ b/packages/react-native/src/components/LiveKitRoomWrapper.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { LiveKitRoom } from '@livekit/react-native';
 import type { LocalParticipant } from 'livekit-client';
-import type { Callbacks, ClientToolsConfig, AudioSessionConfiguration } from '../types';
+import type { Callbacks, ClientToolsConfig, AudioSessionConfig } from '../types';
 import { MessageHandler } from './MessageHandler';
 
 interface LiveKitRoomWrapperProps {
@@ -20,7 +20,7 @@ interface LiveKitRoomWrapperProps {
   clientTools: ClientToolsConfig['clientTools'];
   onEndSession: (reason?: "user" | "agent") => void;
   updateCurrentEventId?: (eventId: number) => void;
-  audioSessionConfiguration?: AudioSessionConfiguration;
+  audioSessionConfig?: AudioSessionConfig;
 }
 
 export const LiveKitRoomWrapper = ({
@@ -38,11 +38,11 @@ export const LiveKitRoomWrapper = ({
   clientTools,
   updateCurrentEventId,
   onEndSession,
-  audioSessionConfiguration,
+  audioSessionConfig,
 }: LiveKitRoomWrapperProps) => {
-  // Configure audio options based on audioSessionConfiguration
+  // Configure audio options based on audioSessionConfig
   const audioOptions = React.useMemo(() => {
-    if (!audioSessionConfiguration?.allowMixingWithOthers) {
+    if (!audioSessionConfig?.allowMixingWithOthers) {
       return true;
     }
 
@@ -56,7 +56,7 @@ export const LiveKitRoomWrapper = ({
         allowMixingWithOthers: true,
       },
     };
-  }, [audioSessionConfiguration]);
+  }, [audioSessionConfig]);
 
   return (
     <LiveKitRoom

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -12,5 +12,5 @@ export type {
   ConversationOptions,
   ConversationConfig,
   ConversationEvent,
-  AudioSessionConfiguration,
+  AudioSessionConfig,
 } from "./types";

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -143,7 +143,7 @@ export type ConversationEvent =
 /**
  * Audio session configuration for controlling how the SDK handles audio
  */
-export interface AudioSessionConfiguration {
+export interface AudioSessionConfig {
   /**
    * Whether audio should mix with other audio sources.
    * When true, the SDK will configure the audio session to allow


### PR DESCRIPTION
Quick follow-up to #397

Rename for consistency with other prop naming conventions:
- AudioSessionConfiguration -> AudioSessionConfig (type)
- audioSessionConfiguration -> audioSessionConfig (prop)

