### PR TITLE
fix: expose websocket close code and reason on connection errors

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -273,8 +273,9 @@ describe("Conversation", () => {
         await clientPromise;
       }).rejects.toThrowError(
         expect.objectContaining({
-          code: 3000,
-          reason: "Test cancellation reason",
+          name: "SessionConnectionError",
+          closeCode: 3000,
+          closeReason: "Test cancellation reason",
         })
       );
     }
@@ -324,6 +325,8 @@ describe("Conversation", () => {
         expect.objectContaining({
           reason: "error",
           message: "Test cancellation reason",
+          closeCode: 3000,
+          closeReason: "Test cancellation reason",
         })
       );
     }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,6 +29,7 @@ export { createConnection } from "./utils/ConnectionFactory";
 export { WebSocketConnection } from "./utils/WebSocketConnection";
 export { WebRTCConnection } from "./utils/WebRTCConnection";
 export { postOverallFeedback } from "./utils/postOverallFeedback";
+export { SessionConnectionError } from "./utils/errors";
 export { VoiceConversation } from "./VoiceConversation";
 export { TextConversation } from "./TextConversation";
 

--- a/packages/client/src/utils/errors.ts
+++ b/packages/client/src/utils/errors.ts
@@ -1,0 +1,14 @@
+export class SessionConnectionError extends Error {
+  public readonly closeCode?: number;
+  public readonly closeReason?: string;
+
+  constructor(
+    message: string,
+    options?: { closeCode?: number; closeReason?: string }
+  ) {
+    super(message);
+    this.name = "SessionConnectionError";
+    this.closeCode = options?.closeCode;
+    this.closeReason = options?.closeReason;
+  }
+}

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -27,10 +27,14 @@ export type DisconnectionDetails =
       reason: "error";
       message: string;
       context: Event;
+      closeCode?: number;
+      closeReason?: string;
     }
   | {
       reason: "agent";
       context?: CloseEvent;
+      closeCode?: number;
+      closeReason?: string;
     }
   | {
       reason: "user";


### PR DESCRIPTION
  ## Summary
  Fixes #241 and relates to #23

  When setting unsupported language overrides or invalid configs, the WebSocket connection closes silently without any error information. This PR exposes
  the WebSocket close code and reason to developers so they can handle these cases appropriately.

  ## Changes
  - Added `closeCode` and `closeReason` fields to `DisconnectionDetails` type
  - Created `SessionConnectionError` class for connection failures during session initialization
  - Updated `WebSocketConnection` to include close code/reason in disconnect details
  - Exported `SessionConnectionError` from the client package

  ## Usage
  ```typescript
  import { Conversation, SessionConnectionError } from '@elevenlabs/client';

  try {
    await Conversation.startSession({
      agentId: 'xxx',
      overrides: { agent: { language: 'et' } }
    });
  } catch (error) {
    if (error instanceof SessionConnectionError) {
      console.log('Close code:', error.closeCode);
      console.log('Close reason:', error.closeReason);
    }
  }

  // Or via onDisconnect callback
  Conversation.startSession({
    agentId: 'xxx',
    onDisconnect: (details) => {
      if (details.reason === 'error') {
        console.log('Close code:', details.closeCode);
        console.log('Close reason:', details.closeReason);
      }
    }
  });
