### PR TITLE
Wrap error from fetching conversation token

### DIFF
--- a/packages/react-native/src/utils/tokenUtils.ts
+++ b/packages/react-native/src/utils/tokenUtils.ts
@@ -26,9 +26,14 @@ export const getConversationToken = async (
     const data = await response.json();
 
     if (!response.ok) {
-      throw new Error(
-        `Failed to get conversation token: ${data.detail.message}`
-      );
+      if (
+        typeof data.detail === "object" &&
+        data.detail !== null &&
+        typeof data.detail.message === "string"
+      ) {
+        throw new Error(data.detail.message);
+      }
+      throw new Error("Missing error details or message");
     }
 
     if (!data.token) {


### PR DESCRIPTION
Debugging issues with my Android emulator (having issues connecting to the service), I had a hard time determining the origin of the error (since only a message is passed through the callback).

Merging this PR will:
- Wrap the fetch of the conversation token with a try-catch adding additional context to any message thrown in the block
- Increased robustness of code reading out the server-side `message` from the a `details` object.