### PR TITLE
Disable tests in release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "turbo dev",
     "clean": "turbo clean",
     "changeset": "changeset",
-    "publish": "turbo build lint test && changeset version && changeset publish"
+    "publish": "turbo build lint && changeset version && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",


### PR DESCRIPTION
It turns out we don't have the dependencies in the [release workflow](https://github.com/elevenlabs/packages/blob/main/.github/workflows/release.yml) to run all tests.

In particular, the [client tests are failing](https://github.com/elevenlabs/packages/actions/runs/21149837136/job/60823355198), because its missing a Chrome headless shell.

I suggest we disable testing as part of releasing for now:
- This isn't as strong a guarantee as running tests on the build artefacts which are about to be published.
- I believe this is okay since we already have another workflow running the tests and passing these are a prerequisite for merging the PR kicking off the release.
- We are not running tests in the existing [publish workflow](https://github.com/elevenlabs/packages/blob/main/.github/workflows/publish.yml) - meaning this won't be a regression compared to the existing tooling used before the introduction of Changesets.
