### PR TITLE
Declare `@elevenlabs/agents-cli` as a `private` package

### DIFF
--- a/packages/agents-cli/package.json
+++ b/packages/agents-cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@elevenlabs/agents-cli",
   "version": "0.6.2",
+  "private": true,
   "description": "CLI tool to manage ElevenLabs agents",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
As a followup to #449 to prevent failures like this: https://github.com/elevenlabs/packages/actions/runs/21165081786/job/60867730646