### PR TITLE
Remove `commitMode: github-api` from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
-          commitMode: github-api
           publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I choose to use the "GitHub API" to push commits, as per documentation:

> commitMode - Specifies the commit mode. Use `"git-cli"` to push changes using the Git CLI, or `"github-api"` to push changes via the GitHub API. When using `"github-api"`, all commits and tags are GPG-signed and attributed to the user or app who owns the `GITHUB_TOKEN`. Default to `git-cli`.

It does however seem this has an issue pushing certain types of files: https://github.com/changesets/action/issues/510

Which is also observable in https://github.com/elevenlabs/packages/actions/runs/21167490522/job/60875728043

Merging this PR will:
- Revert the use of a non-default `commitMode` and use the `"git-cli"` default, meaning the commits on GitHub pushed by the workflow won't have provenance beyond what the Git CLI might provide.
