### PR TITLE
Disable husky commit hooks in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,5 @@ jobs:
           publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Don't run the Husky pre-commit hook (see https://typicode.github.io/husky/how-to.html)
+          HUSKY: 0


### PR DESCRIPTION
The [Changeset action is failing](https://github.com/elevenlabs/packages/actions/runs/21173145507/job/60898290532) because the commit happens before we're building and the release action internally resets the repository, so we can't simply build before we run the action.

Merging this PR will:
- Disable the husky commit hook when committing from the Changeset action.

This is not an issues as we will be linting before publishing the final artefacts: https://github.com/elevenlabs/packages/blob/5fa9fb564fe1a5c3dafdbeeea58ea5d2d9874584/package.json#L17
