### PR TITLE
Update "dev" turbo task to depend on building dependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -46,7 +46,7 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["generate"]
+      "dependsOn": ["generate", "^build"]
     },
     "generate": {
       "dependsOn": ["generate-types", "generate-version", "generate-worklets"]


### PR DESCRIPTION
It would be great if dependencies aren't stale when starting a dev script.