### PR TITLE
chore: fix react-native example app's start script

### DIFF
--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -4,9 +4,9 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "start": "expo start --tunnel",
-    "android": "echo '🚨🚨 Once Expo has started, press `a` 🚨🚨' && npm start",
-    "ios": "echo '🚨🚨 Once Expo has started, press `i` 🚨🚨' && npm start",
+    "dev": "expo start",
+    "android": "echo '🚨🚨 Once Expo has started, press `a` 🚨🚨' && node --run dev",
+    "ios": "echo '🚨🚨 Once Expo has started, press `i` 🚨🚨' && node --run dev",
     "build:android": "eas build -p android",
     "build:ios": "eas build -p ios",
     "check-types": "tsc --noEmit"


### PR DESCRIPTION
Using `--tunnel` is not needed for most situations when running the React Native example app locally and provides the following DX when ran, since it depends on a package that aren't declared as a dev-dependency of the app:

```
Starting Metro Bundler
? The package @expo/ngrok@^4.1.0 is required to use tunnels, would you like to install it globally?
```