### PR TITLE
add voiceIsolation to WebRTC

### DIFF
--- a/.changeset/add-voice-isolation-webrtc.md
+++ b/.changeset/add-voice-isolation-webrtc.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Add voiceIsolation to WebRTC audio constraints for improved voice quality

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -158,7 +158,18 @@ export class WebRTCConnection extends BaseConnection {
 
       // Enable microphone only if not text-only mode
       if (!config.textOnly) {
-        await room.localParticipant.setMicrophoneEnabled(true);
+        const audioConstraints = {
+          voiceIsolation: true,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          channelCount: { ideal: 1 },
+        };
+        const audioTrack = await createLocalAudioTrack(audioConstraints);
+        await room.localParticipant.publishTrack(audioTrack, {
+          name: "microphone",
+          source: Track.Source.Microphone,
+        });
       }
 
       const overridesEvent = constructOverrides(config);
@@ -515,7 +526,8 @@ export class WebRTCConnection extends BaseConnection {
       }
 
       // Create constraints for the new input device
-      const audioConstraints: MediaTrackConstraints = {
+      const audioConstraints = {
+        voiceIsolation: true,
         deviceId: { exact: deviceId },
         echoCancellation: true,
         noiseSuppression: true,


### PR DESCRIPTION
-`voiceIsolation: true` was already enabled for WebSocket connections (in`input.ts`)                                                                 
-WebRTC was missing this because it uses LiveKit's APIs instead of the shared `Input` class                                                         
-This PR adds `voiceIsolation` to WebRTC for both initial mic setup and device switching