### PR TITLE
Add `commitMode` option to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           publish: pnpm run publish
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # See https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools


### PR DESCRIPTION
We're experiencing with release PRs not kicking off sub-sequent workflow runs.

As per [the `commitMode` documentation](https://github.com/changesets/action?tab=readme-ov-file#inputs):

> Specifies the commit mode. Use `"git-cli"` to push changes using the Git CLI, or `"github-api"` to push changes via the GitHub API. When using `"github-api"`, all commits and tags are GPG-signed and attributed to the user or app who owns the `GITHUB_TOKEN`. Default to `git-cli`.

I want to try using this to force the use of the `GITHUB_TOKEN` - alternatively, I think passing the app token via `GH_TOKEN` might also solve it.

Note: I did try enabling this before and had to revert: https://github.com/elevenlabs/packages/pull/461 at the same time, I don't understand why it was affected by the existence of an executable file (test-publish-validation.sh):
> Error: Unexpected executable file at test-publish-validation.sh, GitHub API only supports non-executable files and directories. You may need to add this file to .gitignore