### PR TITLE
Add `GH_TOKEN` to release workflow environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
           publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Use app token when using the GitHub CLI to enable sub-sequent workflow runs from created PRs
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # See https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
           NPM_CONFIG_PROVENANCE: true
           # Don't run the Husky pre-commit hook (see https://typicode.github.io/husky/how-to.html)


### PR DESCRIPTION
We're experiencing with release PRs not kicking off sub-sequent workflow runs.

Passing the app token through `GH_TOKEN` should make the GitHub CLI use the app-token when creating a PR, allowing sub-sequent workflow runs 🤞