### PR TITLE
Add `InputController` interface and implement it

### DIFF
--- a/.changeset/shy-llamas-lose.md
+++ b/.changeset/shy-llamas-lose.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Export a new InputController interface which the existing Input implements.

--- a/packages/client/src/InputController.ts
+++ b/packages/client/src/InputController.ts
@@ -1,0 +1,7 @@
+export interface InputController {
+  close(): Promise<void>;
+  setInputDevice(deviceId?: string): Promise<void>;
+  setMuted(isMuted: boolean): void;
+  readonly isMuted: boolean;
+  readonly analyser?: AnalyserNode;
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,6 +12,7 @@ export type {
   Status,
   AudioWorkletConfig,
 } from "./BaseConversation";
+export type { InputController } from "./InputController";
 export type { InputConfig } from "./utils/input";
 export type { OutputConfig } from "./utils/output";
 export { Input } from "./utils/input";

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -2,6 +2,7 @@ import { loadRawAudioProcessor } from "./rawAudioProcessor.generated";
 import type { FormatConfig } from "./connection";
 import { isIosDevice } from "./compatibility";
 import type { AudioWorkletConfig } from "../BaseConversation";
+import type { InputController } from "../InputController";
 
 export type InputConfig = {
   preferHeadphonesForIosDevices?: boolean;
@@ -21,7 +22,7 @@ const defaultConstraints = {
   channelCount: { ideal: 1 },
 };
 
-export class Input {
+export class Input implements InputController {
   public static async create({
     sampleRate,
     format,
@@ -123,6 +124,8 @@ export class Input {
     return isIosDevice() ? { ideal: inputDeviceId } : { exact: inputDeviceId };
   }
 
+  private muted = false;
+
   private constructor(
     public readonly context: AudioContext,
     public readonly analyser: AnalyserNode,
@@ -136,6 +139,10 @@ export class Input {
     ) => void = console.error
   ) {
     this.permissions.addEventListener("change", this.handlePermissionsChange);
+  }
+
+  public get isMuted(): boolean {
+    return this.muted;
   }
 
   private forgetInputStreamAndSource() {
@@ -155,6 +162,7 @@ export class Input {
   }
 
   public setMuted(isMuted: boolean) {
+    this.muted = isMuted;
     this.worklet.port.postMessage({ type: "setMuted", isMuted });
   }
 


### PR DESCRIPTION
Merging this PR will:
- Implement the first milestone of #511, adding an interface to control inputs (to be implemented by `WebRTCController` in a follow-up PR).