### PR TITLE
Expose conversation connections globally

### DIFF
--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -144,9 +144,6 @@ export class BaseConversation {
   private registerDebugAPI() {
     const self = this;
     const api: ElevenLabsConversationAPI = {
-      get status() {
-        return self.status;
-      },
       get conversationId() {
         return self.connection.conversationId;
       },

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -1,10 +1,10 @@
 import {
   Callbacks,
-  ELEVENLABS_CONVERSATION_SYMBOL,
   type ElevenLabsConversationAPI,
   Mode,
   Status,
 } from "@elevenlabs/types";
+import * as debugExtension from "./utils/debug-extension";
 import type {
   BaseConnection,
   DisconnectionDetails,
@@ -137,13 +137,11 @@ export class BaseConversation {
     this.updateStatus("connected");
 
     if (this.options.debug) {
-      this.exposeGlobalAPI();
+      this.registerDebugAPI();
     }
   }
 
-  private exposeGlobalAPI() {
-    if (typeof window === "undefined") return;
-
+  private registerDebugAPI() {
     const self = this;
     const api: ElevenLabsConversationAPI = {
       get status() {
@@ -163,13 +161,7 @@ export class BaseConversation {
       },
     };
 
-    (window as any)[ELEVENLABS_CONVERSATION_SYMBOL] = api;
-  }
-
-  private cleanupGlobalAPI() {
-    if (typeof window !== "undefined") {
-      delete (window as any)[ELEVENLABS_CONVERSATION_SYMBOL];
-    }
+    debugExtension.registerConversation(api);
   }
 
   /** Override in subclasses that support audio injection. */
@@ -198,7 +190,7 @@ export class BaseConversation {
 
   protected async handleEndSession() {
     if (this.options.debug) {
-      this.cleanupGlobalAPI();
+      debugExtension.deregisterConversation(this.connection.conversationId);
     }
     this.connection.close();
   }

--- a/packages/client/src/TextConversation.ts
+++ b/packages/client/src/TextConversation.ts
@@ -1,11 +1,7 @@
 import { createConnection } from "./utils/ConnectionFactory";
 import type { BaseConnection } from "./utils/BaseConnection";
 import { applyDelay } from "./utils/applyDelay";
-import {
-  BaseConversation,
-  type Options,
-  type PartialOptions,
-} from "./BaseConversation";
+import { BaseConversation, type PartialOptions } from "./BaseConversation";
 
 export class TextConversation extends BaseConversation {
   public static async startSession(
@@ -38,9 +34,5 @@ export class TextConversation extends BaseConversation {
       connection?.close();
       throw error;
     }
-  }
-
-  protected constructor(options: Options, connection: BaseConnection) {
-    super(options, connection);
   }
 }

--- a/packages/client/src/TextConversation.ts
+++ b/packages/client/src/TextConversation.ts
@@ -1,7 +1,15 @@
 import { createConnection } from "./utils/ConnectionFactory";
 import type { BaseConnection } from "./utils/BaseConnection";
 import { applyDelay } from "./utils/applyDelay";
-import { BaseConversation, type PartialOptions } from "./BaseConversation";
+import {
+  BaseConversation,
+  type Options,
+  type PartialOptions,
+} from "./BaseConversation";
+import {
+  ELEVENLABS_CONVERSATION_SYMBOL,
+  type ElevenLabsConversationAPI,
+} from "@elevenlabs/types";
 
 export class TextConversation extends BaseConversation {
   public static async startSession(
@@ -34,5 +42,46 @@ export class TextConversation extends BaseConversation {
       connection?.close();
       throw error;
     }
+  }
+
+  protected constructor(options: Options, connection: BaseConnection) {
+    super(options, connection);
+    if (this.options.debug) {
+      this.exposeGlobalAPI();
+    }
+  }
+
+  private exposeGlobalAPI() {
+    if (typeof window === "undefined") return;
+
+    const self = this;
+    const api: ElevenLabsConversationAPI = {
+      get status() {
+        return self.status;
+      },
+      get conversationId() {
+        return self.connection.conversationId;
+      },
+      get inputFormat() {
+        return self.connection.inputFormat;
+      },
+      sendUserMessage(text: string) {
+        self.sendUserMessage(text);
+      },
+      sendAudio() {
+        return Promise.reject(
+          new Error("sendAudio is not available for text-only conversations")
+        );
+      },
+    };
+
+    (window as any)[ELEVENLABS_CONVERSATION_SYMBOL] = api;
+  }
+
+  protected override async handleEndSession() {
+    if (typeof window !== "undefined" && this.options.debug) {
+      delete (window as any)[ELEVENLABS_CONVERSATION_SYMBOL];
+    }
+    await super.handleEndSession();
   }
 }

--- a/packages/client/src/TextConversation.ts
+++ b/packages/client/src/TextConversation.ts
@@ -6,10 +6,6 @@ import {
   type Options,
   type PartialOptions,
 } from "./BaseConversation";
-import {
-  ELEVENLABS_CONVERSATION_SYMBOL,
-  type ElevenLabsConversationAPI,
-} from "@elevenlabs/types";
 
 export class TextConversation extends BaseConversation {
   public static async startSession(
@@ -46,42 +42,5 @@ export class TextConversation extends BaseConversation {
 
   protected constructor(options: Options, connection: BaseConnection) {
     super(options, connection);
-    if (this.options.debug) {
-      this.exposeGlobalAPI();
-    }
-  }
-
-  private exposeGlobalAPI() {
-    if (typeof window === "undefined") return;
-
-    const self = this;
-    const api: ElevenLabsConversationAPI = {
-      get status() {
-        return self.status;
-      },
-      get conversationId() {
-        return self.connection.conversationId;
-      },
-      get inputFormat() {
-        return self.connection.inputFormat;
-      },
-      sendUserMessage(text: string) {
-        self.sendUserMessage(text);
-      },
-      sendAudio() {
-        return Promise.reject(
-          new Error("sendAudio is not available for text-only conversations")
-        );
-      },
-    };
-
-    (window as any)[ELEVENLABS_CONVERSATION_SYMBOL] = api;
-  }
-
-  protected override async handleEndSession() {
-    if (typeof window !== "undefined" && this.options.debug) {
-      delete (window as any)[ELEVENLABS_CONVERSATION_SYMBOL];
-    }
-    await super.handleEndSession();
   }
 }

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -317,7 +317,6 @@ export class VoiceConversation extends BaseConversation {
       } catch (_) {}
     };
 
-    // ── Primary path: seamless track replacement ──
     // Try to swap the mic's MediaStreamTrack directly on the RTCRtpSender.
     // This avoids SDP renegotiation so the server sees an uninterrupted stream.
     const micPub = room.localParticipant?.getTrackPublication(
@@ -326,8 +325,6 @@ export class VoiceConversation extends BaseConversation {
     if (micPub?.track) {
       const originalMicTrack = micPub.track.mediaStreamTrack;
 
-      // Access the publisher's senders through LiveKit's public API:
-      // Room.engine → RTCEngine.pcManager → PCTransportManager.publisher → PCTransport.getSenders()
       const publisher = room.engine.pcManager?.publisher;
       const sender = publisher
         ?.getSenders()
@@ -340,7 +337,6 @@ export class VoiceConversation extends BaseConversation {
         source.start(0);
         await sender.replaceTrack(newAudioTrack);
 
-        // Register cleanup so external cancellation restores the mic
         injection.cleanup = () => {
           this.debugLog(
             "[injectAudioWebRTC] Cancelled — restoring original mic track"
@@ -380,8 +376,6 @@ export class VoiceConversation extends BaseConversation {
       );
     }
 
-    // ── Fallback path: unpublish mic and publish injected track ──
-    // This triggers SDP renegotiation and may cause a brief audio gap.
     this.debugLog(
       "[injectAudioWebRTC] Fallback path: publishing injected audio as new track"
     );

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -12,6 +12,7 @@ import {
   type PartialOptions,
 } from "./BaseConversation";
 import { WebSocketConnection } from "./utils/WebSocketConnection";
+import type { ElevenAgentsGlobalAPI } from "@elevenlabs/types";
 
 export class VoiceConversation extends BaseConversation {
   private static async requestWakeLock(): Promise<WakeLockSentinel | null> {
@@ -134,15 +135,14 @@ export class VoiceConversation extends BaseConversation {
       );
     }
 
-    // Expose connection for browser extensions and debugging
-    this.exposeConnectionGlobally();
+    this.exposeGlobalAPI();
   }
 
-  private exposeConnectionGlobally() {
+  private exposeGlobalAPI() {
     if (typeof window === "undefined") return;
 
     const self = this;
-    const ext: Record<string, any> = {
+    const api: ElevenAgentsGlobalAPI = {
       conversation: {
         get status() {
           return self.status;
@@ -162,9 +162,9 @@ export class VoiceConversation extends BaseConversation {
     };
 
     if (this.connection instanceof WebRTCConnection) {
-      ext.room = this.connection.getRoom();
+      api.room = this.connection.getRoom();
     } else if (this.connection instanceof WebSocketConnection) {
-      ext.sendAudio = (base64Audio: string) => {
+      api.sendAudio = (base64Audio: string) => {
         if (
           this.status === "connected" &&
           this.connection instanceof WebSocketConnection
@@ -178,7 +178,7 @@ export class VoiceConversation extends BaseConversation {
       };
     }
 
-    (window as any).__ELEVENLABS_SDK__ = ext;
+    (window as any).__ELEVENLABS_SDK__ = api;
   }
 
   protected override async handleEndSession() {

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -1,9 +1,15 @@
-import { arrayBufferToBase64, base64ToArrayBuffer } from "./utils/audio";
+import {
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
+  int16ArrayToBase64,
+  resamplePCM,
+} from "./utils/audio";
 import { Input, type InputConfig } from "./utils/input";
 import { Output } from "./utils/output";
 import { createConnection } from "./utils/ConnectionFactory";
 import type { BaseConnection, FormatConfig } from "./utils/BaseConnection";
 import { WebRTCConnection } from "./utils/WebRTCConnection";
+import { Track } from "livekit-client";
 import type { AgentAudioEvent, InterruptionEvent } from "./utils/events";
 import { applyDelay } from "./utils/applyDelay";
 import {
@@ -12,7 +18,34 @@ import {
   type PartialOptions,
 } from "./BaseConversation";
 import { WebSocketConnection } from "./utils/WebSocketConnection";
-import type { ElevenAgentsGlobalAPI } from "@elevenlabs/types";
+import {
+  ELEVENLABS_CONVERSATION_SYMBOL,
+  type ElevenLabsConversationAPI,
+} from "@elevenlabs/types";
+
+// Default sample rate assumed for injected audio when the caller doesn't specify one.
+const DEFAULT_INJECT_SAMPLE_RATE = 48000;
+
+// WebRTC uses 48 kHz natively; LiveKit tracks expect this rate.
+const WEBRTC_SAMPLE_RATE = 48000;
+
+// Int16 PCM range is [-32768, 32767]. Used to convert between Int16 and Float32.
+const INT16_MAX = 32768;
+
+// Gain multiplier applied to injected WebRTC audio to compensate for
+// signal loss through the MediaStreamDestination → RTP pipeline.
+const INJECT_GAIN = 2.0;
+
+// Extra milliseconds to wait after the computed audio duration before
+// restoring the original mic track, ensuring playback fully completes.
+const PLAYBACK_TAIL_MS = 200;
+
+// Interval at which the WebRTC injection loop checks for cancellation.
+const CANCEL_POLL_MS = 100;
+
+// Brief pause after unpublishing the mic track so the server can process
+// the removal before we publish the injected track in its place.
+const UNPUBLISH_SETTLE_MS = 100;
 
 export class VoiceConversation extends BaseConversation {
   private static async requestWakeLock(): Promise<WakeLockSentinel | null> {
@@ -135,54 +168,326 @@ export class VoiceConversation extends BaseConversation {
       );
     }
 
-    this.exposeGlobalAPI();
+    if (this.options.debug) {
+      this.exposeGlobalAPI();
+    }
+  }
+
+  private activeInjection: { cancelled: boolean; cleanup?: () => void } | null =
+    null;
+
+  private debugLog(...args: unknown[]) {
+    if (this.options.onDebug) {
+      this.options.onDebug({ type: "debug_log", args });
+    }
   }
 
   private exposeGlobalAPI() {
     if (typeof window === "undefined") return;
 
     const self = this;
-    const api: ElevenAgentsGlobalAPI = {
-      conversation: {
-        get status() {
-          return self.status;
-        },
-        get conversationId() {
-          return self.connection.conversationId;
-        },
-        get inputFormat() {
-          return self.connection.inputFormat;
-        },
-        sendUserMessage(text: string) {
-          self.sendUserMessage(text);
-        },
+    const api: ElevenLabsConversationAPI = {
+      get status() {
+        return self.status;
       },
-      room: null,
-      sendAudio: null,
+      get conversationId() {
+        return self.connection.conversationId;
+      },
+      get inputFormat() {
+        return self.connection.inputFormat;
+      },
+      sendUserMessage(text: string) {
+        self.sendUserMessage(text);
+      },
+      sendAudio(base64Audio: string, sampleRate?: number) {
+        return self.injectAudio(base64Audio, sampleRate);
+      },
+    };
+
+    (window as any)[ELEVENLABS_CONVERSATION_SYMBOL] = api;
+  }
+
+  private async injectAudio(
+    base64Audio: string,
+    sourceSampleRate?: number
+  ): Promise<{ cancel: () => void }> {
+    if (this.status !== "connected") {
+      throw new Error("Not connected to a conversation");
+    }
+
+    if (this.activeInjection) {
+      this.activeInjection.cancelled = true;
+      this.activeInjection.cleanup?.();
+    }
+
+    const injection = {
+      cancelled: false,
+      cleanup: undefined as (() => void) | undefined,
+    };
+    this.activeInjection = injection;
+
+    const cancel = () => {
+      injection.cancelled = true;
+      injection.cleanup?.();
     };
 
     if (this.connection instanceof WebRTCConnection) {
-      api.room = this.connection.getRoom();
+      await this.injectAudioWebRTC(base64Audio, injection);
     } else if (this.connection instanceof WebSocketConnection) {
-      api.sendAudio = (base64Audio: string) => {
-        if (
-          this.status === "connected" &&
-          this.connection instanceof WebSocketConnection
-        ) {
-          this.connection.sendMessage({
-            user_audio_chunk: base64Audio,
-          });
-          return true;
-        }
-        return false;
-      };
+      await this.injectAudioWebSocket(
+        base64Audio,
+        sourceSampleRate ?? DEFAULT_INJECT_SAMPLE_RATE,
+        injection
+      );
+    } else {
+      throw new Error("Unknown connection type");
     }
 
-    (window as any).__ELEVENLABS_SDK__ = api;
+    if (this.activeInjection === injection) {
+      this.activeInjection = null;
+    }
+
+    return { cancel };
+  }
+
+  private async injectAudioWebSocket(
+    base64Audio: string,
+    sourceSampleRate: number,
+    injection: { cancelled: boolean }
+  ) {
+    if (!(this.connection instanceof WebSocketConnection)) return;
+
+    const bytes = base64ToArrayBuffer(base64Audio);
+    const pcmData = new Int16Array(bytes);
+    const targetSampleRate = this.connection.inputFormat.sampleRate;
+
+    let finalPcm: Int16Array = pcmData;
+    if (sourceSampleRate !== targetSampleRate) {
+      finalPcm = resamplePCM(pcmData, sourceSampleRate, targetSampleRate);
+    }
+
+    // Match the rawAudioProcessor worklet's buffer size (sampleRate / 10 = 100ms)
+    // so injected audio is indistinguishable from mic audio on the server side.
+    const samplesPerChunk = Math.floor(targetSampleRate / 10);
+    const msPerChunk = 100;
+    const startTime = performance.now();
+
+    for (
+      let i = 0, chunkIndex = 0;
+      i < finalPcm.length;
+      i += samplesPerChunk, chunkIndex++
+    ) {
+      if (injection.cancelled || this.status !== "connected") return;
+
+      const chunk = finalPcm.slice(
+        i,
+        Math.min(i + samplesPerChunk, finalPcm.length)
+      );
+      const chunkBase64 = int16ArrayToBase64(chunk);
+
+      this.connection.sendMessage({ user_audio_chunk: chunkBase64 });
+
+      const nextChunkTime = startTime + (chunkIndex + 1) * msPerChunk;
+      const sleepMs = nextChunkTime - performance.now();
+      if (sleepMs > 1) {
+        await new Promise(r => setTimeout(r, sleepMs));
+      }
+    }
+  }
+
+  /**
+   * Injects pre-recorded audio into a WebRTC (LiveKit) connection by swapping
+   * the mic track on the publisher's RTCRtpSender. Falls back to
+   * unpublishing/republishing if the publisher transport or sender isn't available.
+   */
+  private async injectAudioWebRTC(
+    base64Audio: string,
+    injection: { cancelled: boolean; cleanup?: () => void }
+  ) {
+    if (!(this.connection instanceof WebRTCConnection)) return;
+
+    const room = this.connection.getRoom();
+    if (!room || room.state !== "connected") {
+      throw new Error("LiveKit room not connected");
+    }
+
+    // Decode base64 PCM16 → Int16 → Float32 (Web Audio API requires [-1.0, 1.0])
+    const bytes = base64ToArrayBuffer(base64Audio);
+    const int16Data = new Int16Array(bytes);
+    const float32Data = new Float32Array(int16Data.length);
+    for (let i = 0; i < int16Data.length; i++) {
+      float32Data[i] = int16Data[i] / INT16_MAX;
+    }
+
+    const sampleRate = WEBRTC_SAMPLE_RATE;
+    const durationSeconds = float32Data.length / sampleRate;
+    this.debugLog(
+      `[injectAudioWebRTC] Preparing ${durationSeconds.toFixed(2)}s of audio (${int16Data.length} samples @ ${sampleRate}Hz)`
+    );
+
+    // Build audio graph: BufferSource → GainNode → MediaStreamDestination
+    // The destination exposes a MediaStream whose audio track we feed into WebRTC.
+    const audioContext = new AudioContext({ sampleRate });
+    const audioBuffer = audioContext.createBuffer(
+      1,
+      float32Data.length,
+      sampleRate
+    );
+    audioBuffer.copyToChannel(float32Data, 0);
+
+    const source = audioContext.createBufferSource();
+    source.buffer = audioBuffer;
+
+    const gainNode = audioContext.createGain();
+    gainNode.gain.value = INJECT_GAIN;
+
+    const destination = audioContext.createMediaStreamDestination();
+    source.connect(gainNode);
+    gainNode.connect(destination);
+
+    const newAudioTrack = destination.stream.getAudioTracks()[0];
+
+    const cleanupResources = () => {
+      try {
+        source.stop();
+      } catch (_) {}
+      try {
+        audioContext.close();
+      } catch (_) {}
+      try {
+        newAudioTrack.stop();
+      } catch (_) {}
+    };
+
+    // ── Primary path: seamless track replacement ──
+    // Try to swap the mic's MediaStreamTrack directly on the RTCRtpSender.
+    // This avoids SDP renegotiation so the server sees an uninterrupted stream.
+    const micPub = room.localParticipant?.getTrackPublication(
+      Track.Source.Microphone
+    );
+    if (micPub?.track) {
+      const originalMicTrack = micPub.track.mediaStreamTrack;
+
+      // Access the publisher's senders through LiveKit's public API:
+      // Room.engine → RTCEngine.pcManager → PCTransportManager.publisher → PCTransport.getSenders()
+      const publisher = room.engine.pcManager?.publisher;
+      const sender = publisher
+        ?.getSenders()
+        .find((s: RTCRtpSender) => s.track === originalMicTrack);
+
+      if (sender) {
+        this.debugLog(
+          "[injectAudioWebRTC] Primary path: replacing mic track on RTCRtpSender"
+        );
+        source.start(0);
+        await sender.replaceTrack(newAudioTrack);
+
+        // Register cleanup so external cancellation restores the mic
+        injection.cleanup = () => {
+          this.debugLog(
+            "[injectAudioWebRTC] Cancelled — restoring original mic track"
+          );
+          sender.replaceTrack(originalMicTrack).catch(() => {});
+          cleanupResources();
+        };
+
+        // Wait for playback to finish, polling for cancellation
+        const totalMs = durationSeconds * 1000 + PLAYBACK_TAIL_MS;
+        let elapsed = 0;
+        while (elapsed < totalMs) {
+          if (injection.cancelled) return;
+          await new Promise(r => setTimeout(r, CANCEL_POLL_MS));
+          elapsed += CANCEL_POLL_MS;
+        }
+
+        this.debugLog(
+          "[injectAudioWebRTC] Playback complete — restoring original mic track"
+        );
+        await sender.replaceTrack(originalMicTrack);
+        cleanupResources();
+        injection.cleanup = undefined;
+        return;
+      } else if (!publisher) {
+        console.warn(
+          "[injectAudioWebRTC] Publisher transport not available on pcManager — falling back to republish"
+        );
+      } else {
+        console.warn(
+          "[injectAudioWebRTC] RTCRtpSender for mic track not found — falling back to republish"
+        );
+      }
+    } else {
+      console.warn(
+        "[injectAudioWebRTC] No published mic track found — falling back to republish"
+      );
+    }
+
+    // ── Fallback path: unpublish mic and publish injected track ──
+    // This triggers SDP renegotiation and may cause a brief audio gap.
+    this.debugLog(
+      "[injectAudioWebRTC] Fallback path: publishing injected audio as new track"
+    );
+    if (micPub) {
+      await room.localParticipant.unpublishTrack(micPub.track!);
+      await new Promise(r => setTimeout(r, UNPUBLISH_SETTLE_MS));
+    }
+
+    const publication = await room.localParticipant.publishTrack(
+      newAudioTrack,
+      {
+        name: "injected-audio",
+        source: Track.Source.Microphone,
+      }
+    );
+
+    source.start(0);
+
+    injection.cleanup = async () => {
+      this.debugLog(
+        "[injectAudioWebRTC] Cancelled — unpublishing injected track, re-enabling mic"
+      );
+      try {
+        await room.localParticipant.unpublishTrack(publication.track!);
+      } catch (_) {}
+      cleanupResources();
+      try {
+        await room.localParticipant.setMicrophoneEnabled(true);
+      } catch (_) {}
+    };
+
+    const totalMs = durationSeconds * 1000 + PLAYBACK_TAIL_MS;
+    let elapsed = 0;
+    while (elapsed < totalMs) {
+      if (injection.cancelled) return;
+      await new Promise(r => setTimeout(r, CANCEL_POLL_MS));
+      elapsed += CANCEL_POLL_MS;
+    }
+
+    this.debugLog(
+      "[injectAudioWebRTC] Fallback playback complete — re-enabling mic"
+    );
+    try {
+      await room.localParticipant.unpublishTrack(publication.track!);
+    } catch (_) {}
+    cleanupResources();
+    try {
+      await room.localParticipant.setMicrophoneEnabled(true);
+    } catch (_) {}
+    injection.cleanup = undefined;
   }
 
   protected override async handleEndSession() {
     await super.handleEndSession();
+
+    if (this.activeInjection) {
+      this.activeInjection.cancelled = true;
+      this.activeInjection.cleanup?.();
+      this.activeInjection = null;
+    }
+
+    if (typeof window !== "undefined" && this.options.debug) {
+      delete (window as any)[ELEVENLABS_CONVERSATION_SYMBOL];
+    }
 
     if (this.visibilityChangeHandler) {
       document.removeEventListener(
@@ -230,6 +535,10 @@ export class VoiceConversation extends BaseConversation {
   }
 
   private onInputWorkletMessage = (event: MessageEvent): void => {
+    // Suppress mic audio during injection so silent mic chunks don't
+    // interleave with injected chunks, which causes gaps in the recording.
+    if (this.activeInjection) return;
+
     const rawAudioPcmData = event.data[0];
 
     // TODO: When supported, maxVolume can be used to avoid sending silent audio

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -178,7 +178,7 @@ export class VoiceConversation extends BaseConversation {
       };
     }
 
-    (window as any).__ELEVENLABS_EXTENSION__ = ext;
+    (window as any).__ELEVENLABS_SDK__ = ext;
   }
 
   protected override async handleEndSession() {

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -133,6 +133,166 @@ export class VoiceConversation extends BaseConversation {
         this.visibilityChangeHandler
       );
     }
+
+    // Expose LiveKit room for browser extensions (e.g., voice recorder extension)
+    this.exposeForExtension();
+  }
+
+  /**
+   * Exposes the conversation for browser extensions.
+   * This allows extensions to inject pre-recorded audio into conversations.
+   * Supports both WebRTC (LiveKit room) and WebSocket connections.
+   */
+  private extLog(...args: any[]) {
+    if ((window as any).__ELEVENLABS_LOGGING_ENABLED__ !== false) {
+      console.log("[ElevenLabs SDK]", ...args);
+    }
+  }
+
+  private exposeForExtension() {
+    this.extLog("exposeForExtension called");
+    if (typeof window === "undefined") {
+      this.extLog("No window object, skipping");
+      return;
+    }
+
+    const connectionType =
+      this.connection instanceof WebRTCConnection ? "webrtc" : "websocket";
+    this.extLog("Connection type:", connectionType);
+
+    // Always expose the conversation instance
+    (window as any).__ELEVENLABS_CONVERSATION__ = this;
+
+    if (this.connection instanceof WebRTCConnection) {
+      const room = this.connection.getRoom();
+      this.extLog("Got room:", room?.name, "state:", room?.state);
+
+      // Expose LiveKit room for WebRTC
+      (window as any).__ELEVENLABS_ROOM__ = room;
+      (window as any).__ELEVENLABS_CONNECTION_TYPE__ = "webrtc";
+      (window as any).__ELEVENLABS_WS__ = null;
+      this.extLog("Set window.__ELEVENLABS_ROOM__ =", room);
+
+      // Call extension registration function if available
+      if (
+        typeof (window as any).__ELEVENLABS_EXTENSION_REGISTER_ROOM__ ===
+        "function"
+      ) {
+        this.extLog("Calling __ELEVENLABS_EXTENSION_REGISTER_ROOM__");
+        (window as any).__ELEVENLABS_EXTENSION_REGISTER_ROOM__(room);
+      }
+
+      // Dispatch custom event for extensions
+      this.extLog("Dispatching elevenlabs-conversation-started event");
+      window.dispatchEvent(
+        new CustomEvent("elevenlabs-conversation-started", {
+          detail: {
+            conversationId: this.connection.conversationId,
+            room,
+            connectionType: "webrtc",
+            inputFormat: this.connection.inputFormat,
+          },
+        })
+      );
+    } else if (this.connection instanceof WebSocketConnection) {
+      this.extLog("WebSocket connection detected");
+
+      // Expose WebSocket connection info
+      (window as any).__ELEVENLABS_ROOM__ = null;
+      (window as any).__ELEVENLABS_CONNECTION_TYPE__ = "websocket";
+      (window as any).__ELEVENLABS_WS__ = this.connection;
+      (window as any).__ELEVENLABS_INPUT_FORMAT__ = this.connection.inputFormat;
+
+      // Create a helper function to send audio chunks
+      (window as any).__ELEVENLABS_SEND_AUDIO__ = (base64Audio: string) => {
+        if (
+          this.status === "connected" &&
+          this.connection instanceof WebSocketConnection
+        ) {
+          this.connection.sendMessage({
+            user_audio_chunk: base64Audio,
+          });
+          return true;
+        }
+        return false;
+      };
+
+      this.extLog(
+        "Exposed WebSocket connection. Input format:",
+        this.connection.inputFormat
+      );
+
+      // Call extension registration function if available
+      if (
+        typeof (window as any).__ELEVENLABS_EXTENSION_REGISTER_WEBSOCKET__ ===
+        "function"
+      ) {
+        this.extLog("Calling __ELEVENLABS_EXTENSION_REGISTER_WEBSOCKET__");
+        (window as any).__ELEVENLABS_EXTENSION_REGISTER_WEBSOCKET__(
+          this.connection,
+          this.connection.inputFormat
+        );
+      }
+
+      // Dispatch custom event for extensions
+      this.extLog("Dispatching elevenlabs-conversation-started event");
+      window.dispatchEvent(
+        new CustomEvent("elevenlabs-conversation-started", {
+          detail: {
+            conversationId: this.connection.conversationId,
+            connectionType: "websocket",
+            inputFormat: this.connection.inputFormat,
+          },
+        })
+      );
+    }
+  }
+
+  /**
+   * Get the LiveKit room instance for advanced usage.
+   * Only available for WebRTC connections.
+   * @returns The LiveKit Room instance or null if not using WebRTC
+   */
+  public getLiveKitRoom(): any | null {
+    if (this.connection instanceof WebRTCConnection) {
+      return this.connection.getRoom();
+    }
+    return null;
+  }
+
+  /**
+   * Get the connection type being used.
+   * @returns "webrtc" | "websocket"
+   */
+  public getConnectionType(): "webrtc" | "websocket" {
+    return this.connection instanceof WebRTCConnection ? "webrtc" : "websocket";
+  }
+
+  /**
+   * Get the input audio format configuration.
+   * @returns The format configuration (sample rate, format type)
+   */
+  public getInputFormat(): FormatConfig {
+    return this.connection.inputFormat;
+  }
+
+  /**
+   * Send a pre-recorded audio chunk to the conversation (WebSocket only).
+   * For WebRTC, use the LiveKit room directly.
+   * @param base64Audio - Base64 encoded PCM audio data
+   * @returns true if sent successfully, false otherwise
+   */
+  public sendAudioChunk(base64Audio: string): boolean {
+    if (
+      this.status === "connected" &&
+      this.connection instanceof WebSocketConnection
+    ) {
+      this.connection.sendMessage({
+        user_audio_chunk: base64Audio,
+      });
+      return true;
+    }
+    return false;
   }
 
   protected override async handleEndSession() {

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -1,15 +1,10 @@
-import {
-  arrayBufferToBase64,
-  base64ToArrayBuffer,
-  int16ArrayToBase64,
-  resamplePCM,
-} from "./utils/audio";
+import { arrayBufferToBase64, base64ToArrayBuffer } from "./utils/audio";
+import { AudioInjector } from "./utils/audio-injector";
 import { Input, type InputConfig } from "./utils/input";
 import { Output } from "./utils/output";
 import { createConnection } from "./utils/ConnectionFactory";
 import type { BaseConnection, FormatConfig } from "./utils/BaseConnection";
 import { WebRTCConnection } from "./utils/WebRTCConnection";
-import { Track } from "livekit-client";
 import type { AgentAudioEvent, InterruptionEvent } from "./utils/events";
 import { applyDelay } from "./utils/applyDelay";
 import {
@@ -18,18 +13,6 @@ import {
   type PartialOptions,
 } from "./BaseConversation";
 import { WebSocketConnection } from "./utils/WebSocketConnection";
-
-// Default sample rate assumed for injected audio when the caller doesn't specify one.
-const DEFAULT_INJECT_SAMPLE_RATE = 48000;
-
-// WebRTC uses 48 kHz natively; LiveKit tracks expect this rate.
-const WEBRTC_SAMPLE_RATE = 48000;
-
-// Int16 PCM range is [-32768, 32767]. Used to convert between Int16 and Float32.
-const INT16_MAX = 32768;
-
-// Interval at which the WebRTC injection loop checks for cancellation.
-const CANCEL_POLL_MS = 100;
 
 export class VoiceConversation extends BaseConversation {
   private static async requestWakeLock(): Promise<WakeLockSentinel | null> {
@@ -153,288 +136,26 @@ export class VoiceConversation extends BaseConversation {
     }
   }
 
-  private activeInjection: { cancelled: boolean; cleanup?: () => void } | null =
-    null;
-
-  private debugLog(...args: unknown[]) {
-    if (this.options.onDebug) {
-      this.options.onDebug({ type: "debug_log", args });
-    }
-  }
+  private injector = new AudioInjector();
 
   protected override sendAudioToConversation(
     base64Audio: string,
     sampleRate?: number
   ): Promise<{ cancel: () => void }> {
-    return this.injectAudio(base64Audio, sampleRate);
-  }
-
-  private async injectAudio(
-    base64Audio: string,
-    sourceSampleRate?: number
-  ): Promise<{ cancel: () => void }> {
-    if (this.status !== "connected") {
-      throw new Error("Not connected to a conversation");
-    }
-
-    if (this.activeInjection) {
-      this.activeInjection.cancelled = true;
-      this.activeInjection.cleanup?.();
-    }
-
-    const injection = {
-      cancelled: false,
-      cleanup: undefined as (() => void) | undefined,
-    };
-    this.activeInjection = injection;
-
-    const cancel = () => {
-      injection.cancelled = true;
-      injection.cleanup?.();
-    };
-
-    if (this.connection instanceof WebRTCConnection) {
-      await this.injectAudioWebRTC(base64Audio, injection);
-    } else if (this.connection instanceof WebSocketConnection) {
-      await this.injectAudioWebSocket(
-        base64Audio,
-        sourceSampleRate ?? DEFAULT_INJECT_SAMPLE_RATE,
-        injection
-      );
-    } else {
-      throw new Error("Unknown connection type");
-    }
-
-    if (this.activeInjection === injection) {
-      this.activeInjection = null;
-    }
-
-    return { cancel };
-  }
-
-  private async injectAudioWebSocket(
-    base64Audio: string,
-    sourceSampleRate: number,
-    injection: { cancelled: boolean }
-  ) {
-    if (!(this.connection instanceof WebSocketConnection)) return;
-
-    const bytes = base64ToArrayBuffer(base64Audio);
-    const pcmData = new Int16Array(bytes);
-    const targetSampleRate = this.connection.inputFormat.sampleRate;
-
-    let finalPcm: Int16Array = pcmData;
-    if (sourceSampleRate !== targetSampleRate) {
-      finalPcm = resamplePCM(pcmData, sourceSampleRate, targetSampleRate);
-    }
-
-    // Match the rawAudioProcessor worklet's buffer size (sampleRate / 10 = 100ms)
-    // so injected audio is indistinguishable from mic audio on the server side.
-    const samplesPerChunk = Math.floor(targetSampleRate / 10);
-    const msPerChunk = 100;
-    const startTime = performance.now();
-
-    for (
-      let i = 0, chunkIndex = 0;
-      i < finalPcm.length;
-      i += samplesPerChunk, chunkIndex++
-    ) {
-      if (injection.cancelled || this.status !== "connected") return;
-
-      const chunk = finalPcm.slice(
-        i,
-        Math.min(i + samplesPerChunk, finalPcm.length)
-      );
-      const chunkBase64 = int16ArrayToBase64(chunk);
-
-      this.connection.sendMessage({ user_audio_chunk: chunkBase64 });
-
-      const nextChunkTime = startTime + (chunkIndex + 1) * msPerChunk;
-      const sleepMs = nextChunkTime - performance.now();
-      if (sleepMs > 1) {
-        await new Promise(r => setTimeout(r, sleepMs));
-      }
-    }
-  }
-
-  /**
-   * Injects pre-recorded audio into a WebRTC (LiveKit) connection by swapping
-   * the mic track on the publisher's RTCRtpSender. Falls back to
-   * unpublishing/republishing if the publisher transport or sender isn't available.
-   */
-  private async injectAudioWebRTC(
-    base64Audio: string,
-    injection: { cancelled: boolean; cleanup?: () => void }
-  ) {
-    if (!(this.connection instanceof WebRTCConnection)) return;
-
-    const room = this.connection.getRoom();
-    if (!room || room.state !== "connected") {
-      throw new Error("LiveKit room not connected");
-    }
-
-    // Decode base64 PCM16 → Int16 → Float32 (Web Audio API requires [-1.0, 1.0])
-    const bytes = base64ToArrayBuffer(base64Audio);
-    const int16Data = new Int16Array(bytes);
-    const float32Data = new Float32Array(int16Data.length);
-    for (let i = 0; i < int16Data.length; i++) {
-      float32Data[i] = int16Data[i] / INT16_MAX;
-    }
-
-    const sampleRate = WEBRTC_SAMPLE_RATE;
-    const durationSeconds = float32Data.length / sampleRate;
-    this.debugLog(
-      `[injectAudioWebRTC] Preparing ${durationSeconds.toFixed(2)}s of audio (${int16Data.length} samples @ ${sampleRate}Hz)`
-    );
-
-    // Build audio graph: BufferSource → GainNode → MediaStreamDestination
-    // The destination exposes a MediaStream whose audio track we feed into WebRTC.
-    const audioContext = new AudioContext({ sampleRate });
-    const audioBuffer = audioContext.createBuffer(
-      1,
-      float32Data.length,
-      sampleRate
-    );
-    audioBuffer.copyToChannel(float32Data, 0);
-
-    const source = audioContext.createBufferSource();
-    source.buffer = audioBuffer;
-
-    const destination = audioContext.createMediaStreamDestination();
-    source.connect(destination);
-
-    const newAudioTrack = destination.stream.getAudioTracks()[0];
-
-    const cleanupResources = () => {
-      try {
-        source.stop();
-      } catch (_) {}
-      try {
-        audioContext.close();
-      } catch (_) {}
-      try {
-        newAudioTrack.stop();
-      } catch (_) {}
-    };
-
-    // Try to swap the mic's MediaStreamTrack directly on the RTCRtpSender.
-    // This avoids SDP renegotiation so the server sees an uninterrupted stream.
-    const micPub = room.localParticipant?.getTrackPublication(
-      Track.Source.Microphone
-    );
-    if (micPub?.track) {
-      const originalMicTrack = micPub.track.mediaStreamTrack;
-
-      const publisher = room.engine.pcManager?.publisher;
-      const sender = publisher
-        ?.getSenders()
-        .find((s: RTCRtpSender) => s.track === originalMicTrack);
-
-      if (sender) {
-        this.debugLog(
-          "[injectAudioWebRTC] Primary path: replacing mic track on RTCRtpSender"
-        );
-        source.start(0);
-        await sender.replaceTrack(newAudioTrack);
-
-        injection.cleanup = () => {
-          this.debugLog(
-            "[injectAudioWebRTC] Cancelled — restoring original mic track"
-          );
-          sender.replaceTrack(originalMicTrack).catch(() => {});
-          cleanupResources();
-        };
-
-        // Wait for playback to finish, polling for cancellation
-        const totalMs = durationSeconds * 1000;
-        let elapsed = 0;
-        while (elapsed < totalMs) {
-          if (injection.cancelled) return;
-          await new Promise(r => setTimeout(r, CANCEL_POLL_MS));
-          elapsed += CANCEL_POLL_MS;
-        }
-
-        this.debugLog(
-          "[injectAudioWebRTC] Playback complete — restoring original mic track"
-        );
-        await sender.replaceTrack(originalMicTrack);
-        cleanupResources();
-        injection.cleanup = undefined;
-        return;
-      } else if (!publisher) {
-        console.warn(
-          "[injectAudioWebRTC] Publisher transport not available on pcManager — falling back to republish"
-        );
-      } else {
-        console.warn(
-          "[injectAudioWebRTC] RTCRtpSender for mic track not found — falling back to republish"
-        );
-      }
-    } else {
-      console.warn(
-        "[injectAudioWebRTC] No published mic track found — falling back to republish"
-      );
-    }
-
-    this.debugLog(
-      "[injectAudioWebRTC] Fallback path: publishing injected audio as new track"
-    );
-    if (micPub) {
-      await room.localParticipant.unpublishTrack(micPub.track!);
-    }
-
-    const publication = await room.localParticipant.publishTrack(
-      newAudioTrack,
-      {
-        name: "injected-audio",
-        source: Track.Source.Microphone,
-      }
-    );
-
-    source.start(0);
-
-    injection.cleanup = async () => {
-      this.debugLog(
-        "[injectAudioWebRTC] Cancelled — unpublishing injected track, re-enabling mic"
-      );
-      try {
-        await room.localParticipant.unpublishTrack(publication.track!);
-      } catch (_) {}
-      cleanupResources();
-      try {
-        await room.localParticipant.setMicrophoneEnabled(true);
-      } catch (_) {}
-    };
-
-    const totalMs = durationSeconds * 1000;
-    let elapsed = 0;
-    while (elapsed < totalMs) {
-      if (injection.cancelled) return;
-      await new Promise(r => setTimeout(r, CANCEL_POLL_MS));
-      elapsed += CANCEL_POLL_MS;
-    }
-
-    this.debugLog(
-      "[injectAudioWebRTC] Fallback playback complete — re-enabling mic"
-    );
-    try {
-      await room.localParticipant.unpublishTrack(publication.track!);
-    } catch (_) {}
-    cleanupResources();
-    try {
-      await room.localParticipant.setMicrophoneEnabled(true);
-    } catch (_) {}
-    injection.cleanup = undefined;
+    return this.injector.inject(base64Audio, this.connection, {
+      sourceSampleRate: sampleRate,
+      isConnected: () => this.status === "connected",
+      debugLog: this.options.onDebug
+        ? (...args: unknown[]) =>
+            this.options.onDebug!({ type: "debug_log", args })
+        : undefined,
+    });
   }
 
   protected override async handleEndSession() {
     await super.handleEndSession();
 
-    if (this.activeInjection) {
-      this.activeInjection.cancelled = true;
-      this.activeInjection.cleanup?.();
-      this.activeInjection = null;
-    }
+    this.injector.cancel();
 
     if (this.visibilityChangeHandler) {
       document.removeEventListener(
@@ -484,7 +205,7 @@ export class VoiceConversation extends BaseConversation {
   private onInputWorkletMessage = (event: MessageEvent): void => {
     // Suppress mic audio during injection so silent mic chunks don't
     // interleave with injected chunks, which causes gaps in the recording.
-    if (this.activeInjection) return;
+    if (this.injector.isInjecting) return;
 
     const rawAudioPcmData = event.data[0];
 

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -55,6 +55,7 @@ export type BaseSessionConfig = {
   connectionDelay?: DelayConfig;
   textOnly?: boolean;
   userId?: string;
+  debug?: boolean;
 };
 
 export type ConnectionType = "websocket" | "webrtc";

--- a/packages/client/src/utils/audio-injector.ts
+++ b/packages/client/src/utils/audio-injector.ts
@@ -1,0 +1,312 @@
+import { base64ToArrayBuffer, int16ArrayToBase64, resamplePCM } from "./audio";
+import type { BaseConnection } from "./BaseConnection";
+import { WebRTCConnection } from "./WebRTCConnection";
+import { WebSocketConnection } from "./WebSocketConnection";
+import { Track } from "livekit-client";
+
+/** Default sample rate assumed for injected audio when the caller doesn't specify one. */
+const DEFAULT_INJECT_SAMPLE_RATE = 48000;
+
+/** WebRTC uses 48 kHz natively; LiveKit tracks expect this rate. */
+const WEBRTC_SAMPLE_RATE = 48000;
+
+/** Int16 PCM range is [-32768, 32767]. Used to convert between Int16 and Float32. */
+const INT16_MAX = 32768;
+
+/** Interval at which the playback loop checks for cancellation. */
+const CANCEL_POLL_MS = 100;
+
+interface Injection {
+  cancelled: boolean;
+  cleanup?: () => void;
+}
+
+type DebugLog = (...args: unknown[]) => void;
+
+/**
+ * Encapsulates audio injection into an active conversation.
+ *
+ * Supports both WebSocket (chunked PCM) and WebRTC (track replacement on
+ * LiveKit) transports. Only one injection can be active at a time; starting
+ * a new injection automatically cancels any in-flight one.
+ */
+export class AudioInjector {
+  private active: Injection | null = null;
+
+  /** Whether an injection is currently in progress. */
+  get isInjecting(): boolean {
+    return this.active !== null;
+  }
+
+  /** Cancel the current injection (if any) and clean up resources. */
+  cancel(): void {
+    if (this.active) {
+      this.active.cancelled = true;
+      this.active.cleanup?.();
+      this.active = null;
+    }
+  }
+
+  /**
+   * Inject pre-recorded audio into the conversation.
+   *
+   * @returns A handle with a `cancel` function that stops injection early.
+   */
+  async inject(
+    base64Audio: string,
+    connection: BaseConnection,
+    opts: {
+      sourceSampleRate?: number;
+      isConnected: () => boolean;
+      debugLog?: DebugLog;
+    }
+  ): Promise<{ cancel: () => void }> {
+    if (!opts.isConnected()) {
+      throw new Error("Not connected to a conversation");
+    }
+
+    this.cancel();
+
+    const injection: Injection = { cancelled: false };
+    this.active = injection;
+
+    const cancel = () => {
+      injection.cancelled = true;
+      injection.cleanup?.();
+    };
+
+    if (connection instanceof WebRTCConnection) {
+      await this.injectWebRTC(
+        base64Audio,
+        connection,
+        injection,
+        opts.debugLog
+      );
+    } else if (connection instanceof WebSocketConnection) {
+      await this.injectWebSocket(
+        base64Audio,
+        opts.sourceSampleRate ?? DEFAULT_INJECT_SAMPLE_RATE,
+        connection,
+        injection,
+        opts.isConnected
+      );
+    } else {
+      throw new Error("Unknown connection type");
+    }
+
+    if (this.active === injection) {
+      this.active = null;
+    }
+
+    return { cancel };
+  }
+
+  /**
+   * Sends audio over a WebSocket connection in real-time PCM chunks that
+   * match the mic worklet's cadence (sampleRate / 10 = 100 ms per chunk).
+   */
+  private async injectWebSocket(
+    base64Audio: string,
+    sourceSampleRate: number,
+    connection: WebSocketConnection,
+    injection: Injection,
+    isConnected: () => boolean
+  ) {
+    const bytes = base64ToArrayBuffer(base64Audio);
+    const pcmData = new Int16Array(bytes);
+    const targetSampleRate = connection.inputFormat.sampleRate;
+
+    let finalPcm: Int16Array = pcmData;
+    if (sourceSampleRate !== targetSampleRate) {
+      finalPcm = resamplePCM(pcmData, sourceSampleRate, targetSampleRate);
+    }
+
+    const samplesPerChunk = Math.floor(targetSampleRate / 10);
+    const msPerChunk = 100;
+    const startTime = performance.now();
+
+    for (
+      let i = 0, chunkIndex = 0;
+      i < finalPcm.length;
+      i += samplesPerChunk, chunkIndex++
+    ) {
+      if (injection.cancelled || !isConnected()) return;
+
+      const chunk = finalPcm.slice(
+        i,
+        Math.min(i + samplesPerChunk, finalPcm.length)
+      );
+      const chunkBase64 = int16ArrayToBase64(chunk);
+
+      connection.sendMessage({ user_audio_chunk: chunkBase64 });
+
+      const nextChunkTime = startTime + (chunkIndex + 1) * msPerChunk;
+      const sleepMs = nextChunkTime - performance.now();
+      if (sleepMs > 1) {
+        await new Promise(r => setTimeout(r, sleepMs));
+      }
+    }
+  }
+
+  /**
+   * Injects audio into a WebRTC (LiveKit) connection by swapping the mic
+   * track on the publisher's RTCRtpSender. Falls back to
+   * unpublishing/republishing if the sender isn't available.
+   */
+  private async injectWebRTC(
+    base64Audio: string,
+    connection: WebRTCConnection,
+    injection: Injection,
+    debugLog?: DebugLog
+  ) {
+    const log: DebugLog = debugLog ?? (() => {});
+
+    const room = connection.getRoom();
+    if (!room || room.state !== "connected") {
+      throw new Error("LiveKit room not connected");
+    }
+
+    const bytes = base64ToArrayBuffer(base64Audio);
+    const int16Data = new Int16Array(bytes);
+    const float32Data = new Float32Array(int16Data.length);
+    for (let i = 0; i < int16Data.length; i++) {
+      float32Data[i] = int16Data[i] / INT16_MAX;
+    }
+
+    const sampleRate = WEBRTC_SAMPLE_RATE;
+    const durationSeconds = float32Data.length / sampleRate;
+    log(
+      `[injectAudioWebRTC] Preparing ${durationSeconds.toFixed(2)}s of audio (${int16Data.length} samples @ ${sampleRate}Hz)`
+    );
+
+    const audioContext = new AudioContext({ sampleRate });
+    const audioBuffer = audioContext.createBuffer(
+      1,
+      float32Data.length,
+      sampleRate
+    );
+    audioBuffer.copyToChannel(float32Data, 0);
+
+    const source = audioContext.createBufferSource();
+    source.buffer = audioBuffer;
+
+    const destination = audioContext.createMediaStreamDestination();
+    source.connect(destination);
+
+    const newAudioTrack = destination.stream.getAudioTracks()[0];
+
+    const cleanupResources = () => {
+      try {
+        source.stop();
+      } catch (_) {}
+      try {
+        audioContext.close();
+      } catch (_) {}
+      try {
+        newAudioTrack.stop();
+      } catch (_) {}
+    };
+
+    const micPub = room.localParticipant?.getTrackPublication(
+      Track.Source.Microphone
+    );
+    if (micPub?.track) {
+      const originalMicTrack = micPub.track.mediaStreamTrack;
+
+      const publisher = room.engine.pcManager?.publisher;
+      const sender = publisher
+        ?.getSenders()
+        .find((s: RTCRtpSender) => s.track === originalMicTrack);
+
+      if (sender) {
+        log(
+          "[injectAudioWebRTC] Primary path: replacing mic track on RTCRtpSender"
+        );
+        source.start(0);
+        await sender.replaceTrack(newAudioTrack);
+
+        injection.cleanup = () => {
+          log("[injectAudioWebRTC] Cancelled — restoring original mic track");
+          sender.replaceTrack(originalMicTrack).catch(() => {});
+          cleanupResources();
+        };
+
+        const totalMs = durationSeconds * 1000;
+        let elapsed = 0;
+        while (elapsed < totalMs) {
+          if (injection.cancelled) return;
+          await new Promise(r => setTimeout(r, CANCEL_POLL_MS));
+          elapsed += CANCEL_POLL_MS;
+        }
+
+        log(
+          "[injectAudioWebRTC] Playback complete — restoring original mic track"
+        );
+        await sender.replaceTrack(originalMicTrack);
+        cleanupResources();
+        injection.cleanup = undefined;
+        return;
+      } else if (!publisher) {
+        console.warn(
+          "[injectAudioWebRTC] Publisher transport not available on pcManager — falling back to republish"
+        );
+      } else {
+        console.warn(
+          "[injectAudioWebRTC] RTCRtpSender for mic track not found — falling back to republish"
+        );
+      }
+    } else {
+      console.warn(
+        "[injectAudioWebRTC] No published mic track found — falling back to republish"
+      );
+    }
+
+    log(
+      "[injectAudioWebRTC] Fallback path: publishing injected audio as new track"
+    );
+    if (micPub) {
+      await room.localParticipant.unpublishTrack(micPub.track!);
+    }
+
+    const publication = await room.localParticipant.publishTrack(
+      newAudioTrack,
+      {
+        name: "injected-audio",
+        source: Track.Source.Microphone,
+      }
+    );
+
+    source.start(0);
+
+    injection.cleanup = async () => {
+      log(
+        "[injectAudioWebRTC] Cancelled — unpublishing injected track, re-enabling mic"
+      );
+      try {
+        await room.localParticipant.unpublishTrack(publication.track!);
+      } catch (_) {}
+      cleanupResources();
+      try {
+        await room.localParticipant.setMicrophoneEnabled(true);
+      } catch (_) {}
+    };
+
+    const totalMs = durationSeconds * 1000;
+    let elapsed = 0;
+    while (elapsed < totalMs) {
+      if (injection.cancelled) return;
+      await new Promise(r => setTimeout(r, CANCEL_POLL_MS));
+      elapsed += CANCEL_POLL_MS;
+    }
+
+    log("[injectAudioWebRTC] Fallback playback complete — re-enabling mic");
+    try {
+      await room.localParticipant.unpublishTrack(publication.track!);
+    } catch (_) {}
+    cleanupResources();
+    try {
+      await room.localParticipant.setMicrophoneEnabled(true);
+    } catch (_) {}
+    injection.cleanup = undefined;
+  }
+}

--- a/packages/client/src/utils/audio.ts
+++ b/packages/client/src/utils/audio.ts
@@ -14,3 +14,36 @@ export function base64ToArrayBuffer(base64: string): ArrayBuffer {
   }
   return bytes.buffer;
 }
+
+export function int16ArrayToBase64(int16Array: Int16Array): string {
+  const uint8 = new Uint8Array(
+    int16Array.buffer,
+    int16Array.byteOffset,
+    int16Array.byteLength
+  );
+  let binary = "";
+  for (let i = 0; i < uint8.length; i++) {
+    binary += String.fromCharCode(uint8[i]);
+  }
+  return btoa(binary);
+}
+
+/** Resample PCM16 audio using linear interpolation. */
+export function resamplePCM(
+  pcmData: Int16Array,
+  fromRate: number,
+  toRate: number
+): Int16Array {
+  if (fromRate === toRate) return pcmData;
+  const ratio = fromRate / toRate;
+  const newLength = Math.floor(pcmData.length / ratio);
+  const result = new Int16Array(newLength);
+  for (let i = 0; i < newLength; i++) {
+    const srcIndex = i * ratio;
+    const floor = Math.floor(srcIndex);
+    const ceil = Math.min(floor + 1, pcmData.length - 1);
+    const t = srcIndex - floor;
+    result[i] = Math.round(pcmData[floor] * (1 - t) + pcmData[ceil] * t);
+  }
+  return result;
+}

--- a/packages/client/src/utils/debug-extension.ts
+++ b/packages/client/src/utils/debug-extension.ts
@@ -1,0 +1,42 @@
+import type { ElevenLabsConversationAPI } from "@elevenlabs/types";
+
+/**
+ * Well-known symbols used by debug extensions (e.g. browser extensions) to
+ * hook into SDK conversations. Extensions place callback functions at these
+ * symbols on globalThis before the SDK creates a conversation.
+ *
+ * @example Setting up hooks from an extension's content script:
+ * ```js
+ * globalThis[Symbol.for("elevenlabs.debugger.registerConversation")] = (api) => {
+ *   // api implements ElevenLabsConversationAPI
+ * };
+ * globalThis[Symbol.for("elevenlabs.debugger.deregisterConversation")] = (id) => {
+ *   // conversation with this id has ended
+ * };
+ * ```
+ */
+const REGISTER = Symbol.for("elevenlabs.debugger.registerConversation");
+const DEREGISTER = Symbol.for("elevenlabs.debugger.deregisterConversation");
+
+interface DebugHooks {
+  [REGISTER]?: (api: ElevenLabsConversationAPI) => void;
+  [DEREGISTER]?: (conversationId: string) => void;
+}
+
+function getHooks(): DebugHooks {
+  return globalThis as unknown as DebugHooks;
+}
+
+export function registerConversation(api: ElevenLabsConversationAPI): void {
+  const register = getHooks()[REGISTER];
+  if (typeof register === "function") {
+    register(api);
+  }
+}
+
+export function deregisterConversation(conversationId: string): void {
+  const deregister = getHooks()[DEREGISTER];
+  if (typeof deregister === "function") {
+    deregister(conversationId);
+  }
+}

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -97,7 +97,7 @@ export type Callbacks = {
 };
 
 /**
- * The well-known symbol used to store the active conversation on `window`.
+ * The symbol used to store the active conversation on `window`.
  * Exposed by the SDK when `debug: true` is set in the session options.
  *
  * @example

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -97,18 +97,36 @@ export type Callbacks = {
 };
 
 /**
- * Shape of `window.__ELEVENLABS_SDK__`, exposed by the SDK so any JavaScript
- * running on the page can interact with an active conversation.
+ * The well-known symbol used to store the active conversation on `window`.
+ * Exposed by the SDK when `debug: true` is set in the session options.
+ *
+ * @example
+ * ```ts
+ * const api = window[Symbol.for("ElevenLabs.SDK.CurrentAgentConversation")];
+ * api?.sendUserMessage("hello");
+ * ```
  */
-export interface ElevenAgentsGlobalAPI {
-  conversation: {
-    readonly status: Status;
-    readonly conversationId: string;
-    readonly inputFormat: { sampleRate: number; format: string };
-    sendUserMessage(text: string): void;
-  };
-  /** LiveKit Room instance for WebRTC connections, null otherwise. */
-  room: unknown;
-  /** Sends a base64-encoded PCM audio chunk over a WebSocket connection. */
-  sendAudio: ((base64Audio: string) => boolean) | null;
+export const ELEVENLABS_CONVERSATION_SYMBOL = Symbol.for(
+  "ElevenLabs.SDK.CurrentAgentConversation"
+);
+
+/**
+ * Shape of the object stored at {@link ELEVENLABS_CONVERSATION_SYMBOL} on
+ * `window`. Provides a transport-agnostic interface for any JavaScript
+ * running on the page to interact with an active conversation.
+ */
+export interface ElevenLabsConversationAPI {
+  readonly status: Status;
+  readonly conversationId: string;
+  readonly inputFormat: { sampleRate: number; format: string };
+  sendUserMessage(text: string): void;
+  /**
+   * Injects base64-encoded PCM audio into the conversation as user input.
+   * Works identically for both WebSocket and WebRTC connections.
+   * Returns a cancel function that stops the injection and restores state.
+   */
+  sendAudio(
+    base64Audio: string,
+    sampleRate?: number
+  ): Promise<{ cancel: () => void }>;
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -91,9 +91,24 @@ export type Callbacks = {
   onAgentChatResponsePart?: (
     props: Generated.AgentChatResponsePartClientEvent["text_response_part"]
   ) => void;
-  onAudioAlignment?: (
-    props: AudioAlignmentEvent
-  ) => void;
+  onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   // internal debug events, not to be used
   onDebug?: (props: any) => void;
 };
+
+/**
+ * Shape of `window.__ELEVENLABS_SDK__`, exposed by the SDK so any JavaScript
+ * running on the page can interact with an active conversation.
+ */
+export interface ElevenAgentsGlobalAPI {
+  conversation: {
+    readonly status: Status;
+    readonly conversationId: string;
+    readonly inputFormat: { sampleRate: number; format: string };
+    sendUserMessage(text: string): void;
+  };
+  /** LiveKit Room instance for WebRTC connections, null otherwise. */
+  room: unknown;
+  /** Sends a base64-encoded PCM audio chunk over a WebSocket connection. */
+  sendAudio: ((base64Audio: string) => boolean) | null;
+}

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -97,26 +97,12 @@ export type Callbacks = {
 };
 
 /**
- * The symbol used to store the active conversation on `window`.
- * Exposed by the SDK when `debug: true` is set in the session options.
+ * Transport-agnostic interface exposed to debug extensions (e.g. browser
+ * extensions) so they can interact with an active conversation.
  *
- * @example
- * ```ts
- * const api = window[Symbol.for("ElevenLabs.SDK.CurrentAgentConversation")];
- * api?.sendUserMessage("hello");
- * ```
- */
-export const ELEVENLABS_CONVERSATION_SYMBOL = Symbol.for(
-  "ElevenLabs.SDK.CurrentAgentConversation"
-);
-
-/**
- * Shape of the object stored at {@link ELEVENLABS_CONVERSATION_SYMBOL} on
- * `window`. Provides a transport-agnostic interface for any JavaScript
- * running on the page to interact with an active conversation.
+ * Registered/deregistered via the well-known symbols in `debug-extension.ts`.
  */
 export interface ElevenLabsConversationAPI {
-  readonly status: Status;
   readonly conversationId: string;
   readonly inputFormat: { sampleRate: number; format: string };
   sendUserMessage(text: string): void;


### PR DESCRIPTION
This will allow javascript like browser extensions to interact with the conversation, and also allow developers to debug in the console. Currently exposing only what I'm specifically using as although this technically doesn't introduce any malicious capabilities, would prefer to trivialise it less.