### PR TITLE
Rename Input to MediaDeviceInput and use interface types

### DIFF
--- a/.changeset/funny-baths-watch.md
+++ b/.changeset/funny-baths-watch.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+**Breaking:** `VoiceConversation.changeInputDevice()` now returns `void` instead of the input instance. The `input` property is now typed as `InputController & InputEventTarget` interface rather than the concrete implementation, preparing for unified handling of WebSocket and WebRTC input sources. The `Input` class is no longer exported from the package; use the `InputController` interface type instead.

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1179,16 +1179,12 @@ describe("Device Change Default Device", () => {
     const conversation = await conversationPromise;
 
     // Test that changeInputDevice works without deviceId (uses default)
-    const inputResult = await (
-      conversation as VoiceConversation
-    ).changeInputDevice({
+    await (conversation as VoiceConversation).changeInputDevice({
       sampleRate: 16000,
       format: "pcm",
       // No inputDeviceId provided - should use browser default
     });
-
-    expect(inputResult).toBeDefined();
-    expect(inputResult.inputStream).toBeDefined();
+    // Success - the device change completed without throwing
 
     // Test that changeOutputDevice works without deviceId (uses default)
     const outputResult = await (

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -15,7 +15,6 @@ export type {
 export type { InputController } from "./InputController";
 export type { InputConfig } from "./utils/input";
 export type { OutputConfig } from "./utils/output";
-export { Input } from "./utils/input";
 export { Output } from "./utils/output";
 export type {
   IncomingSocketEvent,

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -30,7 +30,7 @@ export type InputEventTarget = {
   removeListener(listener: InputListener): void;
 };
 
-export class Input implements InputController, InputEventTarget {
+export class MediaDeviceInput implements InputController, InputEventTarget {
   public static async create({
     sampleRate,
     format,
@@ -39,7 +39,9 @@ export class Input implements InputController, InputEventTarget {
     workletPaths,
     libsampleratePath,
     onError,
-  }: FormatConfig & InputConfig & AudioWorkletConfig): Promise<Input> {
+  }: FormatConfig &
+    InputConfig &
+    AudioWorkletConfig): Promise<MediaDeviceInput> {
     let context: AudioContext | null = null;
     let inputStream: MediaStream | null = null;
 
@@ -67,7 +69,8 @@ export class Input implements InputController, InputEventTarget {
       }
 
       if (inputDeviceId) {
-        options.deviceId = Input.getDeviceIdConstraint(inputDeviceId);
+        options.deviceId =
+          MediaDeviceInput.getDeviceIdConstraint(inputDeviceId);
       }
 
       const supportsSampleRateConstraint =
@@ -104,7 +107,7 @@ export class Input implements InputController, InputEventTarget {
       const permissions = await navigator.permissions.query({
         name: "microphone",
       });
-      return new Input(
+      return new MediaDeviceInput(
         context,
         analyser,
         worklet,
@@ -198,7 +201,8 @@ export class Input implements InputController, InputEventTarget {
       };
 
       if (inputDeviceId) {
-        options.deviceId = Input.getDeviceIdConstraint(inputDeviceId);
+        options.deviceId =
+          MediaDeviceInput.getDeviceIdConstraint(inputDeviceId);
       }
       // If inputDeviceId is undefined, don't set deviceId constraint - browser uses default
 


### PR DESCRIPTION
## Summary

This PR completes **Milestone 5** of the Input/Output refactoring roadmap: renaming `Input` to `MediaDeviceInput` and transitioning to interface-based typing.

### Changes

- Renamed `Input` class to `MediaDeviceInput` (internal implementation detail)
- Changed `VoiceConversation.input` property type from concrete `MediaDeviceInput` to `InputController & InputEventTarget` interface
- Changed `changeInputDevice()` return type from `MediaDeviceInput` to `void` for better encapsulation
- Added error handling for optional `analyser` field in `getInputByteFrequencyData()`
- Removed `Input` class export from package - consumers should use `InputController` interface type instead
- Updated tests to not rely on `changeInputDevice()` return value

### Breaking Changes

**Breaking:** `VoiceConversation.changeInputDevice()` now returns `void` instead of the input instance. The `input` property is now typed as `InputController & InputEventTarget` interface rather than the concrete implementation, preparing for unified handling of WebSocket and WebRTC input sources. The `Input` class is no longer exported from the package; use the `InputController` interface type instead.

### Test Results

- ✅ Client: 124 tests passed
- ✅ Widget core: 87 tests passed

### Preparation for Next Milestones

This change prepares for **Milestone 6** (WebRTCConnection implements InputController) and **Milestone 7** (platform-specific session setup), enabling composition over inheritance by programming against interfaces instead of concrete implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)