### PR TITLE
Rename InputController methods to remove 'Input' prefix

### DIFF
--- a/packages/client/src/InputController.ts
+++ b/packages/client/src/InputController.ts
@@ -7,10 +7,8 @@ export type InputDeviceConfig = {
 
 export interface InputController {
   close(): Promise<void>;
-  setInputDevice(
-    config?: Partial<FormatConfig> & InputDeviceConfig
-  ): Promise<void>;
-  setInputMuted(isMuted: boolean): Promise<void>;
+  setDevice(config?: Partial<FormatConfig> & InputDeviceConfig): Promise<void>;
+  setMuted(isMuted: boolean): Promise<void>;
   isMuted(): boolean;
   readonly analyser?: AnalyserNode;
 }

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -234,7 +234,7 @@ export class VoiceConversation extends BaseConversation {
   };
 
   public setMicMuted(isMuted: boolean) {
-    this.input.setInputMuted(isMuted).catch(error => {
+    this.input.setMuted(isMuted).catch(error => {
       this.options.onError?.("Failed to set input muted state", error);
     });
   }
@@ -283,7 +283,7 @@ export class VoiceConversation extends BaseConversation {
     inputDeviceId,
   }: FormatConfig & InputConfig): Promise<void> {
     try {
-      await this.input.setInputDevice({
+      await this.input.setDevice({
         inputDeviceId,
         sampleRate,
         format,

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -75,9 +75,7 @@ export class WebRTCConnection extends BaseConnection {
         }
       }
     },
-    setInputDevice: async (
-      config?: Partial<FormatConfig> & InputDeviceConfig
-    ) => {
+    setDevice: async (config?: Partial<FormatConfig> & InputDeviceConfig) => {
       // WebRTC only supports changing inputDeviceId
       // sampleRate, format, and preferHeadphonesForIosDevices are not supported
       if (
@@ -98,7 +96,7 @@ export class WebRTCConnection extends BaseConnection {
       }
       await this.setAudioInputDevice(inputDeviceId);
     },
-    setInputMuted: async (isMuted: boolean) => {
+    setMuted: async (isMuted: boolean) => {
       if (!this.isConnected || !this.room.localParticipant) {
         console.warn(
           "Cannot set microphone muted: room not connected or no local participant"

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -181,13 +181,13 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
     await this.context.close();
   }
 
-  public async setInputMuted(isMuted: boolean): Promise<void> {
+  public async setMuted(isMuted: boolean): Promise<void> {
     this.muted = isMuted;
     this.worklet.port.postMessage({ type: "setMuted", isMuted });
   }
 
   private settingInput: boolean = false;
-  public async setInputDevice(
+  public async setDevice(
     config?: Partial<FormatConfig> & InputDeviceConfig
   ): Promise<void> {
     try {
@@ -247,7 +247,7 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
       // Let's try to reset the input device, but only if we're not already in the process of setting it
       const [track] = this.inputStream.getAudioTracks();
       const { deviceId } = track?.getSettings() ?? {};
-      this.setInputDevice({ inputDeviceId: deviceId }).catch(error => {
+      this.setDevice({ inputDeviceId: deviceId }).catch(error => {
         this.onError(
           "Failed to reset input device after permission change:",
           error


### PR DESCRIPTION
## Summary
- Renames `setInputDevice()` to `setDevice()`
- Renames `setInputMuted()` to `setMuted()`

Since the methods are already namespaced under the `input` property (e.g., `conversation.input.setDevice()`), the "Input" prefix is redundant and makes the API unnecessarily verbose.

## Changes
- Updated `InputController` interface
- Updated `MediaDeviceInput` implementation
- Updated `WebRTCConnection.input` property implementation
- Updated all call sites in `VoiceConversation`

## Test plan
- [x] All tests passing (124 tests)
- [x] TypeScript compilation successful
- [x] Linting and formatting checks passed

## Depends on
- #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)