### PR TITLE
[Agents] Fix ConvAI widget crash on Wix sites

### DIFF
--- a/.changeset/fix-wix-compat.md
+++ b/.changeset/fix-wix-compat.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix widget crash on Wix sites caused by frozen RTCPeerConnection prototype

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "msw"
-    ]
+    ],
+    "patchedDependencies": {
+      "livekit-client@2.16.0": "patches/livekit-client@2.16.0.patch"
+    }
   },
   "packageManager": "pnpm@10.28.1"
 }

--- a/patches/livekit-client@2.16.0.patch
+++ b/patches/livekit-client@2.16.0.patch
@@ -7,10 +7,7 @@ index 6fe677d11b9a5caed7737da899375dc3745144e8..13b2e97c1dc07bffb602efd24d5421dd
    }
    const proto = window.RTCPeerConnection.prototype;
 +  // Guard: skip patching if addEventListener is frozen (e.g. Wix security hardening)
-+  try {
-+    const orig = proto.addEventListener;
-+    proto.addEventListener = orig;
-+  } catch (e) {
++  if (Object.isFrozen(proto)) {
 +    return;
 +  }
    const nativeAddEventListener = proto.addEventListener;

--- a/patches/livekit-client@2.16.0.patch
+++ b/patches/livekit-client@2.16.0.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/livekit-client.esm.mjs b/dist/livekit-client.esm.mjs
-index 6fe677d11b9a5caed7737da899375dc3745144e8..13b2e97c1dc07bffb602efd24d5421dd68c774d2 100644
+index 6fe677d11b9a5caed7737da899375dc3745144e8..d0f471fc225671f7b2c06309aa39416f1ad594f7 100644
 --- a/dist/livekit-client.esm.mjs
 +++ b/dist/livekit-client.esm.mjs
-@@ -8471,6 +8471,13 @@ function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
+@@ -8471,6 +8471,10 @@ function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
      return;
    }
    const proto = window.RTCPeerConnection.prototype;

--- a/patches/livekit-client@2.16.0.patch
+++ b/patches/livekit-client@2.16.0.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/livekit-client.esm.mjs b/dist/livekit-client.esm.mjs
+index 6fe677d11b9a5caed7737da899375dc3745144e8..13b2e97c1dc07bffb602efd24d5421dd68c774d2 100644
+--- a/dist/livekit-client.esm.mjs
++++ b/dist/livekit-client.esm.mjs
+@@ -8471,6 +8471,13 @@ function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
+     return;
+   }
+   const proto = window.RTCPeerConnection.prototype;
++  // Guard: skip patching if addEventListener is frozen (e.g. Wix security hardening)
++  try {
++    const orig = proto.addEventListener;
++    proto.addEventListener = orig;
++  } catch (e) {
++    return;
++  }
+   const nativeAddEventListener = proto.addEventListener;
+   proto.addEventListener = function (nativeEventName, cb) {
+     if (nativeEventName !== eventNameToWrap) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  livekit-client@2.16.0:
+    hash: 7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c
+    path: patches/livekit-client@2.16.0.patch
+
 importers:
 
   .:
@@ -170,10 +175,10 @@ importers:
         version: link:../../packages/react-native
       '@livekit/react-native':
         specifier: ^2.9.6
-        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/react-native-expo-plugin':
         specifier: ^1.0.1
-        version: 1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@livekit/react-native-webrtc':
         specifier: ^137.0.2
         version: 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
@@ -307,7 +312,7 @@ importers:
         version: link:../types
       livekit-client:
         specifier: ^2.11.4
-        version: 2.16.0(@types/dom-mediacapture-record@1.0.22)
+        version: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
     devDependencies:
       '@types/node-wav':
         specifier: ^0.0.3
@@ -538,13 +543,13 @@ importers:
         version: link:../types
       '@livekit/react-native':
         specifier: ^2.9.2
-        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/react-native-webrtc':
         specifier: ^137.0.2
         version: 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
       livekit-client:
         specifier: ^2.15.4
-        version: 2.16.0(@types/dom-mediacapture-record@1.0.22)
+        version: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
       react:
         specifier: '>=17.0.0'
         version: 19.1.0
@@ -16757,33 +16762,33 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.5
 
-  '@livekit/components-core@0.12.12(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)':
+  '@livekit/components-core@0.12.12(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.7.4
-      livekit-client: 2.16.0(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
       loglevel: 1.9.1
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@2.9.17(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/components-react@2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
+      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
       clsx: 2.1.1
       events: 3.3.0
       jose: 6.1.3
-      livekit-client: 2.16.0(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       tslib: 2.8.1
       usehooks-ts: 3.1.1(react@19.1.0)
 
-  '@livekit/components-react@2.9.17(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/components-react@2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
+      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
       clsx: 2.1.1
       events: 3.3.0
       jose: 6.1.3
-      livekit-client: 2.16.0(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
       react: 19.1.0
       react-dom: 19.2.4(react@19.1.0)
       tslib: 2.8.1
@@ -16795,9 +16800,9 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
-  '@livekit/react-native-expo-plugin@1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@livekit/react-native-expo-plugin@1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@livekit/react-native': 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+      '@livekit/react-native': 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       expo: 54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
@@ -16811,16 +16816,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/mutex': 1.1.1
       '@livekit/react-native-webrtc': 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
       array.prototype.at: 1.1.3
       base64-js: 1.5.1
       event-target-shim: 6.0.2
       events: 3.3.0
-      livekit-client: 2.16.0(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
       loglevel: 1.9.2
       promise.allsettled: 1.0.7
       react: 19.1.0
@@ -16834,16 +16839,16 @@ snapshots:
       - react-dom
       - tslib
 
-  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/mutex': 1.1.1
       '@livekit/react-native-webrtc': 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
       array.prototype.at: 1.1.3
       base64-js: 1.5.1
       event-target-shim: 6.0.2
       events: 3.3.0
-      livekit-client: 2.16.0(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
       loglevel: 1.9.2
       promise.allsettled: 1.0.7
       react: 19.1.0
@@ -24359,7 +24364,7 @@ snapshots:
 
   listenercount@1.0.1: {}
 
-  livekit-client@2.16.0(@types/dom-mediacapture-record@1.0.22):
+  livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22):
     dependencies:
       '@livekit/mutex': 1.1.1
       '@livekit/protocol': 1.42.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   livekit-client@2.16.0:
-    hash: 7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c
+    hash: d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d
     path: patches/livekit-client@2.16.0.patch
 
 importers:
@@ -175,10 +175,10 @@ importers:
         version: link:../../packages/react-native
       '@livekit/react-native':
         specifier: ^2.9.6
-        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/react-native-expo-plugin':
         specifier: ^1.0.1
-        version: 1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@livekit/react-native-webrtc':
         specifier: ^137.0.2
         version: 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
@@ -312,7 +312,7 @@ importers:
         version: link:../types
       livekit-client:
         specifier: ^2.11.4
-        version: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
+        version: 2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22)
     devDependencies:
       '@types/node-wav':
         specifier: ^0.0.3
@@ -543,13 +543,13 @@ importers:
         version: link:../types
       '@livekit/react-native':
         specifier: ^2.9.2
-        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+        version: 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/react-native-webrtc':
         specifier: ^137.0.2
         version: 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
       livekit-client:
         specifier: ^2.15.4
-        version: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
+        version: 2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22)
       react:
         specifier: '>=17.0.0'
         version: 19.1.0
@@ -16762,33 +16762,33 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.5
 
-  '@livekit/components-core@0.12.12(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)':
+  '@livekit/components-core@0.12.12(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)':
     dependencies:
       '@floating-ui/dom': 1.7.4
-      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22)
       loglevel: 1.9.1
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@livekit/components-react@2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/components-react@2.9.17(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
+      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
       clsx: 2.1.1
       events: 3.3.0
       jose: 6.1.3
-      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       tslib: 2.8.1
       usehooks-ts: 3.1.1(react@19.1.0)
 
-  '@livekit/components-react@2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/components-react@2.9.17(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
+      '@livekit/components-core': 0.12.12(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
       clsx: 2.1.1
       events: 3.3.0
       jose: 6.1.3
-      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22)
       react: 19.1.0
       react-dom: 19.2.4(react@19.1.0)
       tslib: 2.8.1
@@ -16800,9 +16800,9 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
-  '@livekit/react-native-expo-plugin@1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@livekit/react-native-expo-plugin@1.0.1(@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1))(expo@54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@livekit/react-native': 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+      '@livekit/react-native': 2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       expo: 54.0.31(@babel/core@7.28.5)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
@@ -16816,16 +16816,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/mutex': 1.1.1
       '@livekit/react-native-webrtc': 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
       array.prototype.at: 1.1.3
       base64-js: 1.5.1
       event-target-shim: 6.0.2
       events: 3.3.0
-      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22)
       loglevel: 1.9.2
       promise.allsettled: 1.0.7
       react: 19.1.0
@@ -16839,16 +16839,16 @@ snapshots:
       - react-dom
       - tslib
 
-  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
+  '@livekit/react-native@2.9.6(@livekit/react-native-webrtc@137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tslib@2.8.1)':
     dependencies:
-      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
+      '@livekit/components-react': 2.9.17(livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       '@livekit/mutex': 1.1.1
       '@livekit/react-native-webrtc': 137.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
       array.prototype.at: 1.1.3
       base64-js: 1.5.1
       event-target-shim: 6.0.2
       events: 3.3.0
-      livekit-client: 2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22)
       loglevel: 1.9.2
       promise.allsettled: 1.0.7
       react: 19.1.0
@@ -24364,7 +24364,7 @@ snapshots:
 
   listenercount@1.0.1: {}
 
-  livekit-client@2.16.0(patch_hash=7ec699c332ba2caa65444c1ea0784bf6a07d538f398db7bc611009f12545537c)(@types/dom-mediacapture-record@1.0.22):
+  livekit-client@2.16.0(patch_hash=d5cf0f23af3cd3b5e9268f7c2551bd1e3ebdbc2ac17ae2a81015aaf1634e8c8d)(@types/dom-mediacapture-record@1.0.22):
     dependencies:
       '@livekit/mutex': 1.1.1
       '@livekit/protocol': 1.42.2


### PR DESCRIPTION
## What

- Patches `livekit-client@2.16.0` (via `pnpm patch`) to add a writability guard to the inlined `wrapPeerConnectionEvent()` function from `webrtc-adapter`
- Fixes `TypeError: Cannot assign to read only property 'addEventListener'` that crashes the widget on all Wix-hosted sites
- Wix's security hardening freezes `RTCPeerConnection.prototype.addEventListener` as read-only; the guard detects this via a try/catch no-op assignment and skips the monkey-patch silently
- https://eleven-labs-workspace.slack.com/archives/C08A0QJ8YQH/p1765139172501399

Not sure if this really 100% fix as didnt test at a real wix, so putting into beta for support to try

## Test plan

- [x] Reproduced the crash: created a test page that freezes `RTCPeerConnection.prototype.addEventListener` before loading the **unpatched** widget → confirmed `TypeError` crash
- [x] Verified the fix: same test page with the **patched** widget → widget loads successfully without errors
- [ ] Publish beta (`pnpm --filter @elevenlabs/convai-widget-embed publish --tag beta --no-git-checks`) and share with Wix customer for real-site testing