### PR TITLE
Add 'next' branch to release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
As a pre-requisite of publishing pre-releases from `next` we need the workflow to trigger on pushes to the branch.