### PR TITLE
Add integration test for MediaDeviceInput listener API

### DIFF
--- a/packages/client/src/utils/input.test.ts
+++ b/packages/client/src/utils/input.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { MediaDeviceInput, type InputMessageEvent } from "./input";
+
+describe("MediaDeviceInput", () => {
+  let input: MediaDeviceInput | null = null;
+
+  afterEach(async () => {
+    await input?.close();
+    input = null;
+  });
+
+  it("delivers audio data to listeners", async () => {
+    input = await MediaDeviceInput.create({
+      sampleRate: 16000,
+      format: "pcm",
+    });
+
+    const event = await new Promise<InputMessageEvent>(resolve => {
+      input!.addListener(resolve);
+    });
+
+    const [encodedAudio, volume] = event.data;
+    expect(encodedAudio).toBeInstanceOf(Int16Array);
+    expect(encodedAudio.length).toBeGreaterThan(0);
+    expect(volume).toBeTypeOf("number");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an integration test for `MediaDeviceInput.addListener()` that uses the real browser audio pipeline
- Verifies that audio data flows from the fake media stream through the `rawAudioProcessor` worklet and is delivered to listeners
- This catches regressions where `port.start()` is accidentally removed from the constructor (required for `addEventListener` to work on `MessagePort`)

## Approach

Uses real Web Audio APIs in Playwright browser instances (Chromium + Firefox) with fake media streams rather than mocks. The test:
1. Creates a `MediaDeviceInput` with the real audio worklet pipeline
2. Adds a listener via `addListener()`
3. Waits for the first audio message from the worklet
4. Asserts the message contains encoded audio data (`Int16Array`) and a volume number

Verified that removing `port.start()` from the `MediaDeviceInput` constructor causes this test to fail (times out in both browsers).

## Stacked on

- `kh/composition-over-inheritance`

## Test plan

- [x] Test passes in both Chromium and Firefox
- [x] All 126 client tests pass
- [x] Confirmed regression detection: removing `port.start()` causes test failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)