### PR TITLE
Change environment to use github.ref_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       # Needed for provenance generation
       id-token: write
-    environment: main
+    environment: ${{ github.ref_name }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
To help pick up the `next` environment on the `next` branch.