### PR TITLE
[Agents] Replace agent list with dropdown menu

### DIFF
--- a/examples/agent-testbench/src/routes/index.tsx
+++ b/examples/agent-testbench/src/routes/index.tsx
@@ -5,6 +5,12 @@ import { createServerFn } from "@tanstack/react-start";
 import { ElevenLabs, elevenlabs } from "@/lib/elevenlabs.server";
 import { Page } from "@/components/page";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 const getAgents = createServerFn().handler(async () => {
   const { agents } = await elevenlabs.conversationalAi.agents.list();
@@ -45,15 +51,20 @@ function AgentsPage() {
   return (
     <Page title={user ? `${user.firstName ?? user.userId}'s Agents` : "Agents"}>
       {error && <p>{error}</p>}
-      <ul className="flex flex-row gap-2">
-        {agents.map(agent => (
-          <li key={agent.agentId}>
-            <Link to={`/agents/$agentId`} params={{ agentId: agent.agentId }}>
-              <Button variant="outline">{agent.name}</Button>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild className="self-center">
+          <Button variant="outline">Select Agent</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {agents.map(agent => (
+            <DropdownMenuItem key={agent.agentId} asChild>
+              <Link to={`/agents/$agentId`} params={{ agentId: agent.agentId }}>
+                {agent.name}
+              </Link>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced the horizontal button list of agents on the index page with a `DropdownMenu` component centered within the page layout

<img width="473" height="298" alt="Screenshot 2026-02-27 at 14 31 12" src="https://github.com/user-attachments/assets/bd5ff098-f153-485e-a706-571972e4b40c" />


## Test plan
- [x] Verify the "Select Agent" dropdown renders on the index page
- [x] Verify clicking an agent in the dropdown navigates to the correct agent page

🤖 Generated with [Claude Code](https://claude.com/claude-code)