### PR TITLE
Remove `outputDeviceId` from `FormatConfig`

### DIFF
--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -19,7 +19,6 @@ export type DelayConfig = {
 export type FormatConfig = {
   format: "pcm" | "ulaw";
   sampleRate: number;
-  outputDeviceId?: string;
 };
 
 export type OnDisconnectCallback = (details: DisconnectionDetails) => void;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,7 +17,6 @@ import {
 export type DeviceFormatConfig = {
   format: "pcm" | "ulaw";
   sampleRate: number;
-  outputDeviceId?: string;
 };
 
 export type DeviceInputConfig = {
@@ -369,7 +368,7 @@ export function useConversation<T extends HookOptions & ControlledState>(
         "Device switching is only available for voice conversations"
       );
     },
-    changeOutputDevice: async (config: DeviceFormatConfig) => {
+    changeOutputDevice: async (config: DeviceFormatConfig & OutputConfig) => {
       if (
         conversationRef.current &&
         "changeOutputDevice" in conversationRef.current


### PR DESCRIPTION
## Summary

- Removes \`outputDeviceId\` from \`FormatConfig\` (client) and \`DeviceFormatConfig\` (react)
- Updates \`changeOutputDevice\` in the React hook to accept \`DeviceFormatConfig & OutputConfig\`

## Context

\`FormatConfig\` should only describe the audio format (codec + sample rate). The \`outputDeviceId\` field was already provided by \`OutputDeviceConfig\` / \`OutputConfig\` in every intersection type that needed it, making its presence on \`FormatConfig\` redundant and confusing.

The most visible symptom: \`changeInputDevice\` accepted \`FormatConfig & InputConfig\`, which meant callers could technically pass an \`outputDeviceId\` to a method that changes the *input* device — a meaningless combination that TypeScript had no reason to reject.

## Breaking changes

### \`FormatConfig.outputDeviceId\` removed ([@elevenlabs/client](https://www.npmjs.com/package/@elevenlabs/client))

**Before:**
```ts
const config: FormatConfig = {
  format: "pcm",
  sampleRate: 16000,
  outputDeviceId: "my-device", // was accepted
};
```

**After:** TypeScript will reject \`outputDeviceId\` on a plain \`FormatConfig\`. Pass it separately via \`OutputConfig\` where needed:
```ts
await conversation.changeOutputDevice({
  format: "pcm",
  sampleRate: 16000,
  outputDeviceId: "my-device", // still accepted — from OutputConfig
});
```

**Why:** \`FormatConfig\` describes codec and sample rate — properties of the audio *stream format*, not the output device. Mixing device selection into the format type caused \`FormatConfig & InputConfig\` to silently accept \`outputDeviceId\` when changing the *input* device, which makes no sense. Removing it makes the type accurately reflect what it describes.

---

### \`DeviceFormatConfig.outputDeviceId\` removed ([@elevenlabs/react](https://www.npmjs.com/package/@elevenlabs/react))

Same rationale as above, applied to the React package's mirror type. The \`changeOutputDevice\` callback signature is updated from \`DeviceFormatConfig\` to \`DeviceFormatConfig & OutputConfig\` so the field is still accepted at call sites — it has simply moved to the right type.

## Changes

- `packages/client/src/utils/BaseConnection.ts` — remove \`outputDeviceId?: string\` from \`FormatConfig\`
- `packages/react/src/index.ts` — remove \`outputDeviceId?: string\` from \`DeviceFormatConfig\`; update \`changeOutputDevice\` parameter type to \`DeviceFormatConfig & OutputConfig\`

## Test plan

- [x] \`npx turbo run test --filter @elevenlabs/client -- run --browser.headless\` — 126/126 tests pass
- [x] Pre-commit hooks (lint, type-check) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)