### PR TITLE
Fix microbundle overwriting tsc-generated types in client build

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,7 +15,7 @@
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
     "generate-worklets": "node scripts/generateWorklets.js",
     "build:esm": "tsc --build tsconfig.build.json",
-    "build:umd": "microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --target web --format umd --output dist/lib.umd.js src/index.ts",
+    "build:umd": "microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --target web --format umd --no-generateTypes --output dist/lib.umd.js src/index.ts",
     "build": "node --run build:esm && BROWSERSLIST_ENV=modern node --run build:umd",
     "dev": "tsc --build tsconfig.build.json --watch",
     "clean": "tsc --build tsconfig.build.json --clean && rm -rf ./dist",


### PR DESCRIPTION
## Summary

- microbundle's `--generateTypes` defaults to `true` when a `types` field exists in `package.json`
- This caused it to overwrite `dist/index.d.ts` after `tsc` emitted it, stripping the `//# sourceMappingURL=index.d.ts.map` reference
- The `.d.ts.map` file (generated by tsc) was left orphaned, breaking IDE "Go to Definition" back to source
- Fix: add `--no-generateTypes` so tsc remains the sole source of truth for type declarations

## Test plan

- [x] Run `build:esm` then `build:umd` and verify `dist/index.d.ts` is unchanged between the two steps
- [x] Verify `dist/index.d.ts` still contains the `//# sourceMappingURL=index.d.ts.map` reference after the full `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)