### PR TITLE
Migrate react package to TypeScript compiler for ESM builds

### DIFF
--- a/packages/react/jest.config.cjs
+++ b/packages/react/jest.config.cjs
@@ -13,7 +13,7 @@ module.exports = {
         allowSyntheticDefaultImports: true,
         esModuleInterop: true,
         skipLibCheck: true,
-        jsx: 'react',
+        jsx: 'react-jsx',
       },
     }],
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,26 +2,25 @@
   "name": "@elevenlabs/react",
   "version": "0.14.1",
   "description": "ElevenLabs React Library",
-  "main": "./dist/lib.umd.js",
-  "module": "./dist/lib.module.js",
-  "source": "src/index.ts",
   "type": "module",
-  "unpkg": "./dist/lib.umd.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/lib.modern.js",
-      "require": "./dist/lib.cjs"
+      "unpkg": "./dist/lib.umd.js",
+      "default": "./dist/index.js"
     }
   },
+  "files": ["dist"],
   "scripts": {
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
     "prebuild": "npm run generate-version",
-    "build": "BROWSERSLIST_ENV=modern microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react src/index.ts",
-    "clean": "rm -rf ./dist",
-    "dev": "pnpm run clean && pnpm run generate-version && BROWSERSLIST_ENV=development microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react src/index.ts -w -f modern",
-    "check-types": "tsc --noEmit --skipLibCheck",
+    "build:esm": "tsc --build tsconfig.build.json",
+    "build:umd": "microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --target web --format umd --no-generateTypes --output dist/lib.umd.js src/index.ts",
+    "build": "node --run build:esm && BROWSERSLIST_ENV=modern node --run build:umd",
+    "clean": "tsc --build tsconfig.build.json --clean && rm -rf ./dist",
+    "dev": "tsc --build tsconfig.build.json --watch",
+    "check-types": "tsc --noEmit --project tsconfig.build.json && tsc --noEmit --project tsconfig.test.json",
     "lint:es": "pnpm exec eslint .",
     "lint:prettier": "prettier 'src/**/*.ts' --check",
     "test": "jest"

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "strict": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,16 +1,7 @@
 {
-  "compilerOptions": {
-    "lib": [ "es2015", "dom"],
-    "target": "es5",
-    "module": "esnext",
-    "jsx": "react",
-    "sourceMap": true,
-    "outDir": "dist",
-    "strict": true,
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  }
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/packages/react/tsconfig.test.json
+++ b/packages/react/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**/*.ts", "src/**/__tests__/**/*.tsx"],
+  "exclude": [],
+  "references": [
+    { "path": "./tsconfig.build.json" }
+  ]
+}


### PR DESCRIPTION
## Summary

- tsc now handles ESM output and type declarations for `@elevenlabs/react`
- microbundle is retained only for the UMD bundle
- Drops the CJS (`require`) export and renames the ESM entry point

## Context

Applies the same migration pattern from PR #525 (`@elevenlabs/client`) and follow-up fix #550 to `@elevenlabs/react`. Previously the react package used microbundle for all output formats (ESM, CJS, UMD).

## Breaking changes

### CJS (`require`) export removed (`@elevenlabs/react`)

**Before:**
```ts
// worked in CommonJS environments
const { useConversation } = require('@elevenlabs/react');
```

**After:** No CJS build is produced. ESM-only (or use the UMD bundle for non-module environments).

**Why:** The CJS format is not the right fit for a React hooks library — hooks require a single React instance, and dual ESM+CJS builds introduce the risk of bundling two copies. Dropping CJS aligns with the direction of the ecosystem and removes a footgun. The UMD bundle (`dist/lib.umd.js`) remains available for environments unpkg / CDN consumption.

---

### ESM entry point path changed (`@elevenlabs/react`)

**Before:** `dist/lib.modern.js` (via the `import` export condition)

**After:** `dist/index.js` (via the `default` export condition)

**Why:** The old path was a microbundle-specific naming convention. The new path follows standard tsc output conventions (`index.js` from `src/index.ts`), matching the `@elevenlabs/client` package. Consumers using the package name (not a direct file path) are unaffected — bundlers resolve through the `exports` map automatically.

## Changes

- **`tsconfig.json`** — Replaced monolithic config with a project references root (delegates to `tsconfig.build.json` and `tsconfig.test.json`)
- **`tsconfig.build.json`** (new) — Production build config: composite, ES2022, `react-jsx`, declarations + source maps, `moduleResolution: bundler`
- **`tsconfig.test.json`** (new) — Test config extending build config with `noEmit: true` and `types: ["jest"]`
- **`package.json`** — Split `build` into `build:esm` (tsc) + `build:umd` (microbundle); updated `exports` to drop `require`/`import` in favour of `default`; removed legacy top-level `main`, `module`, `source` fields; added `files: ["dist"]`
- **`jest.config.cjs`** — Changed `jsx: 'react'` → `jsx: 'react-jsx'` to match the new build config

## Test plan

- [x] `npx turbo run build --filter @elevenlabs/react` — builds successfully; clean dist contains `index.js`, `index.d.ts`, `scribe.js`, `scribe.d.ts`, `version.js`, `version.d.ts` (tsc) and `lib.umd.js` (microbundle)
- [x] `tsc --noEmit --project tsconfig.build.json` — passes
- [x] `tsc --noEmit --project tsconfig.test.json` — passes
- [x] `jest` — 2/2 tests pass
- [x] Pre-commit lint hooks — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)