### PR TITLE
chore: use "beta" as preid / tag on the `next` branch

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "next",
+  "tag": "beta",
   "initialVersions": {
     "elevenlabs-react-native-example": "1.0.3",
     "@elevenlabs/agents-cli": "0.6.2",


### PR DESCRIPTION
With the exception of [convai-widget-core@v0.10.1-next.0](https://www.npmjs.com/package/@elevenlabs/convai-widget-core/v/0.10.1-next.0) and [convai-widget-embed@v0.10.1-next.0](https://www.npmjs.com/package/@elevenlabs/convai-widget-embed/v/0.10.1-next.0) the existing pre-released versions of our packages use `beta` instead of `next`.

If we want to align further, I suggest we remove the "next" release tag from the widget-core and widget-embed package entry in NPM, once the v0.10.1 release is officially out.