### PR TITLE
[Agents] Fix convai-widget crash on Wix sites

### DIFF
--- a/.changeset/fix-wix-compat.md
+++ b/.changeset/fix-wix-compat.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix widget crash on Wix sites where addEventListener is made non-writable by Wix security hardening

--- a/patches/livekit-client@2.16.0.patch
+++ b/patches/livekit-client@2.16.0.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/livekit-client.esm.mjs b/dist/livekit-client.esm.mjs
+index 6fe677d11b9a5caed7737da899375dc3745144e8..a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 100644
+--- a/dist/livekit-client.esm.mjs
++++ b/dist/livekit-client.esm.mjs
+@@ -8471,6 +8471,12 @@ function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
+     return;
+   }
+   const proto = window.RTCPeerConnection.prototype;
++  // Guard: skip if addEventListener is non-writable (e.g. Wix security hardening)
++  try { proto.addEventListener = proto.addEventListener; }
++  catch (e) {
++    console.warn('livekit-client: skipping RTCPeerConnection event patching — addEventListener is non-writable', e);
++    return;
++  }
+   const nativeAddEventListener = proto.addEventListener;
+   proto.addEventListener = function (nativeEventName, cb) {
+     if (nativeEventName !== eventNameToWrap) {


### PR DESCRIPTION
## Summary

Follow-up to #532 — the previous fix used `Object.isFrozen(proto)` which I later 😓  discovered **does not actually work** on Wix sites with security hardening.

### What I discovered

- Wix doesn't freeze `RTCPeerConnection.prototype` itself — `Object.isFrozen(RTCPeerConnection.prototype)` returns `false`
- Instead, Wix makes `EventTarget.prototype.addEventListener` individually non-writable: `{writable: false, configurable: false}`
- Since `RTCPeerConnection.prototype` inherits `addEventListener` from `EventTarget.prototype`, the assignment throws `TypeError` in strict mode (ESM), but the `Object.isFrozen` guard never triggers
- The previous `@next` build appeared to work because the test Wix site didn't have the hardening enabled — feature flag or paid only stuff

### Fix

Replace `Object.isFrozen(proto)` with a try-catch that tests writability by attempting a no-op assignment (`proto.addEventListener = proto.addEventListener`). If it throws, skip patching and log a warning.

We do not really use WebRTC part, so with/without shims is fine for us.

### Upstream trace

The crash originates from `webrtc-adapter`, lib bundled in `livekit-client`

```
livekit-client (bundles) → webrtc-adapter → wrapPeerConnectionEvent() → proto.addEventListener = ... → TypeError
```

- https://github.com/livekit/client-sdk-js/issues/1806#issuecomment-4010454366
- https://github.com/webrtcHacks/adapter/issues/1177

## Test plan

- [x] Verified fix on hardened Wix site via local bundle injection
- [x] Widget renders, warning logged instead of crash

Tested on a real Wix site with hardening enabled via DevTools script injection — widget renders successfully and logs:

```
livekit-client: skipping RTCPeerConnection event patching — addEventListener is non-writable
```