### PR TITLE
Clean up conversation test wrappers

### DIFF
--- a/packages/react/src/conversation/ConversationContext.test.tsx
+++ b/packages/react/src/conversation/ConversationContext.test.tsx
@@ -26,7 +26,7 @@ describe("useRawConversation", () => {
       registerCallbacks: vi.fn(),
     };
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: React.PropsWithChildren) => (
       <ConversationContext.Provider value={value}>
         {children}
       </ConversationContext.Provider>
@@ -45,7 +45,7 @@ describe("useRawConversation", () => {
       registerCallbacks: vi.fn(),
     };
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: React.PropsWithChildren) => (
       <ConversationContext.Provider value={value}>
         {children}
       </ConversationContext.Provider>

--- a/packages/react/src/conversation/ConversationControls.test.tsx
+++ b/packages/react/src/conversation/ConversationControls.test.tsx
@@ -29,9 +29,9 @@ const createMockConversation = (id = "test-id") =>
   }) as unknown as Conversation;
 
 function createWrapper(props: Record<string, unknown> = {}) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
+  return function Wrapper({ children }: React.PropsWithChildren) {
     return (
-      <ConversationProvider signedUrl="wss://test.example.com" {...props}>
+      <ConversationProvider {...props}>
         {children}
       </ConversationProvider>
     );
@@ -278,7 +278,7 @@ describe("useConversationControls", () => {
     }
 
     render(
-      <ConversationProvider signedUrl="wss://test.example.com">
+      <ConversationProvider>
         <Root />
         <ControlsConsumer onRender={v => (capturedControls = v)} />
       </ConversationProvider>

--- a/packages/react/src/conversation/ConversationInput.test.tsx
+++ b/packages/react/src/conversation/ConversationInput.test.tsx
@@ -30,9 +30,9 @@ function useTestHook() {
 }
 
 function createWrapper(props: Record<string, unknown> = {}) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
+  return function Wrapper({ children }: React.PropsWithChildren) {
     return (
-      <ConversationProvider signedUrl="wss://test.example.com" {...props}>
+      <ConversationProvider {...props}>
         {children}
       </ConversationProvider>
     );

--- a/packages/react/src/conversation/ConversationInput.tsx
+++ b/packages/react/src/conversation/ConversationInput.tsx
@@ -5,15 +5,19 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useRawConversationRef, useRegisterCallbacks } from "./ConversationContext";
+import {
+  useRawConversationRef,
+  useRegisterCallbacks,
+} from "./ConversationContext";
 
 export type ConversationInputValue = {
   isMuted: boolean;
   setMuted: (isMuted: boolean) => void;
 };
 
-const ConversationInputContext =
-  createContext<ConversationInputValue | null>(null);
+const ConversationInputContext = createContext<ConversationInputValue | null>(
+  null
+);
 
 /**
  * Reads from `ConversationContext` and manages microphone mute state.
@@ -30,14 +34,17 @@ export function ConversationInputProvider({
     onDisconnect: () => setIsMuted(false),
   });
 
-  const setMuted = useCallback((muted: boolean) => {
-    const conversation = conversationRef.current;
-    if (!conversation) {
-      throw new Error("No active conversation. Call startSession() first.");
-    }
-    conversation.setMicMuted(muted);
-    setIsMuted(muted);
-  }, [conversationRef]);
+  const setMuted = useCallback(
+    (muted: boolean) => {
+      const conversation = conversationRef.current;
+      if (!conversation) {
+        throw new Error("No active conversation. Call startSession() first.");
+      }
+      conversation.setMicMuted(muted);
+      setIsMuted(muted);
+    },
+    [conversationRef]
+  );
 
   const value = useMemo<ConversationInputValue>(
     () => ({ isMuted, setMuted }),

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -34,9 +34,9 @@ const createMockConversation = (id = "test-id") =>
   }) as unknown as Conversation;
 
 function createWrapper(props: Record<string, unknown> = {}) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
+  return function Wrapper({ children }: React.PropsWithChildren) {
     return (
-      <ConversationProvider signedUrl="wss://test.example.com" {...props}>
+      <ConversationProvider {...props}>
         {children}
       </ConversationProvider>
     );
@@ -293,10 +293,8 @@ describe("ConversationProvider", () => {
   });
 
   it("passes stable callbacks that always call the latest prop value", async () => {
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ConversationProvider signedUrl="wss://test.example.com">
-        {children}
-      </ConversationProvider>
+    const wrapper = ({ children }: React.PropsWithChildren) => (
+      <ConversationProvider>{children}</ConversationProvider>
     );
 
     // We test the stable callback pattern by checking that

--- a/packages/react/src/conversation/ConversationStatus.test.tsx
+++ b/packages/react/src/conversation/ConversationStatus.test.tsx
@@ -30,9 +30,9 @@ function useTestHook() {
 }
 
 function createWrapper(props: Record<string, unknown> = {}) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
+  return function Wrapper({ children }: React.PropsWithChildren) {
     return (
-      <ConversationProvider signedUrl="wss://test.example.com" {...props}>
+      <ConversationProvider {...props}>
         {children}
       </ConversationProvider>
     );

--- a/packages/react/src/conversation/ConversationStatus.tsx
+++ b/packages/react/src/conversation/ConversationStatus.tsx
@@ -7,8 +7,9 @@ export type ConversationStatusValue = {
   message?: string;
 };
 
-const ConversationStatusContext =
-  createContext<ConversationStatusValue | null>(null);
+const ConversationStatusContext = createContext<ConversationStatusValue | null>(
+  null
+);
 
 /**
  * Reads from `ConversationContext` and registers `onStatusChange` + `onError`
@@ -18,7 +19,8 @@ const ConversationStatusContext =
 export function ConversationStatusProvider({
   children,
 }: React.PropsWithChildren) {
-  const [status, setStatus] = useState<ConversationStatusValue["status"]>("disconnected");
+  const [status, setStatus] =
+    useState<ConversationStatusValue["status"]>("disconnected");
   const [message, setMessage] = useState<string | undefined>(undefined);
 
   useRegisterCallbacks({


### PR DESCRIPTION
## Summary

- Remove unnecessary `signedUrl` prop from `ConversationProvider` wrappers (mocked, never used)
- Replace `{ children: React.ReactNode }` with `React.PropsWithChildren`

## Test plan

- [x] All 56 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)