### PR TITLE
Expose conversationRef from ConversationContext

### DIFF
--- a/packages/react/src/conversation/ConversationContext.test.tsx
+++ b/packages/react/src/conversation/ConversationContext.test.tsx
@@ -18,6 +18,7 @@ describe("useRawConversation", () => {
     const mockConversation = { getId: vi.fn() } as unknown as Conversation;
     const value: ConversationContextValue = {
       conversation: mockConversation,
+      conversationRef: { current: mockConversation },
       startSession: vi.fn(),
       endSession: vi.fn(),
     };
@@ -35,6 +36,7 @@ describe("useRawConversation", () => {
   it("returns null when conversation is null in context", () => {
     const value: ConversationContextValue = {
       conversation: null,
+      conversationRef: { current: null },
       startSession: vi.fn(),
       endSession: vi.fn(),
     };

--- a/packages/react/src/conversation/ConversationContext.tsx
+++ b/packages/react/src/conversation/ConversationContext.tsx
@@ -1,9 +1,11 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, type RefObject } from "react";
 import type { Conversation } from "@elevenlabs/client";
 import type { HookOptions } from "../index";
 
 export type ConversationContextValue = {
   conversation: Conversation | null;
+  /** Stable ref to the active conversation — use in callbacks to avoid re-renders. */
+  conversationRef: RefObject<Conversation | null>;
   startSession: (options?: HookOptions) => void;
   endSession: () => void;
 };

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -183,7 +183,7 @@ export function ConversationProvider({
   }, []);
 
   const contextValue = useMemo<ConversationContextValue>(
-    () => ({ conversation, startSession, endSession }),
+    () => ({ conversation, conversationRef, startSession, endSession }),
     [conversation, startSession, endSession]
   );
 


### PR DESCRIPTION
## Summary

- Adds `conversationRef` (a stable `RefObject<Conversation | null>`) to `ConversationContextValue`
- `ConversationProvider` already maintains this ref internally — now it passes it through the context
- Sub-providers (Controls, Input, Feedback) can use `ctx.conversationRef` directly in stable callbacks instead of duplicating a local ref + eslint-disable pattern

## Test plan

- [x] All existing `ConversationContext` tests updated and passing
- [x] All `ConversationProvider` tests passing (17 total)
- [x] Lint + type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)