### PR TITLE
Sync ConversationProvider state on external disconnect

### DIFF
--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -292,6 +292,51 @@ describe("ConversationProvider", () => {
     expect(sessionCalls).toEqual(["session"]);
   });
 
+  it("clears conversation when onDisconnect fires (external disconnect)", async () => {
+    const mockConversation = createMockConversation();
+    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    expect(result.current.conversation).toBe(mockConversation);
+
+    // Simulate an external disconnect (agent hangs up, raw endSession(), etc.)
+    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
+    act(() => {
+      opts.onDisconnect!({ reason: "agent" });
+    });
+
+    expect(result.current.conversation).toBeNull();
+  });
+
+  it("composes internal onDisconnect with user-provided onDisconnect", async () => {
+    const userOnDisconnect = vi.fn();
+    const mockConversation = createMockConversation();
+    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper({ onDisconnect: userOnDisconnect }),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
+    act(() => {
+      opts.onDisconnect!({ reason: "agent" });
+    });
+
+    expect(userOnDisconnect).toHaveBeenCalledWith({ reason: "agent" });
+    expect(result.current.conversation).toBeNull();
+  });
+
   it("passes stable callbacks that always call the latest prop value", async () => {
     const wrapper = ({ children }: React.PropsWithChildren) => (
       <ConversationProvider>{children}</ConversationProvider>

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Conversation,
   CALLBACK_KEYS,
@@ -88,6 +88,18 @@ export function ConversationProvider({
       listenerMap.register(callbacks),
     [listenerMap]
   );
+
+  // Sync provider state when session ends externally (agent disconnect,
+  // raw instance endSession(), etc.). Uses the listener map so it composes
+  // with user-provided onDisconnect callbacks.
+  useLayoutEffect(() => {
+    return listenerMap.register({
+      onDisconnect: () => {
+        conversationRef.current = null;
+        setConversation(null);
+      },
+    });
+  }, [listenerMap]);
 
   const startSession = useCallback(
     (options?: HookOptions) => {


### PR DESCRIPTION
## Summary

- Registers an internal `onDisconnect` listener via the `ListenerMap` so the provider clears `conversationRef` and `conversation` state when the session ends externally (agent hangs up, raw `endSession()` call, etc.)
- Composes cleanly with user-provided `onDisconnect` callbacks — both fire
- Prevents stale conversation references from lingering after external disconnects

## Test plan

- [x] Test: clears conversation when onDisconnect fires (external disconnect)
- [x] Test: composes internal onDisconnect with user-provided onDisconnect
- [x] All existing ConversationProvider tests pass (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)