### PR TITLE
add multimodal_message WebSocket event

### DIFF
--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -552,4 +552,16 @@ export class BaseConversation {
       is_approved: isApproved,
     });
   }
+
+  public sendMultimodalMessage(options: { text?: string; fileId?: string }) {
+    this.connection.sendMessage({
+      type: "multimodal_message",
+      text: options.text
+        ? { type: "user_message" as const, text: options.text }
+        : undefined,
+      file: options.fileId
+        ? { type: "file_input" as const, file_id: options.fileId }
+        : undefined,
+    });
+  }
 }

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -76,6 +76,8 @@ export type UserMessageEvent = Outgoing.UserMessageClientToOrchestratorEvent;
 export type UserActivityEvent = Outgoing.UserActivityClientToOrchestratorEvent;
 export type MCPToolApprovalResultEvent =
   Outgoing.McpToolApprovalResultClientToOrchestratorEvent;
+export type MultimodalMessageEvent =
+  Outgoing.MultimodalMessageClientToOrchestratorEvent;
 
 export type OutgoingSocketEvent =
   | PongEvent
@@ -86,7 +88,8 @@ export type OutgoingSocketEvent =
   | ContextualUpdateEvent
   | UserMessageEvent
   | UserActivityEvent
-  | MCPToolApprovalResultEvent;
+  | MCPToolApprovalResultEvent
+  | MultimodalMessageEvent;
 
 export function isValidSocketEvent(event: any): event is IncomingSocketEvent {
   return !!event.type;

--- a/packages/react-native/src/ElevenLabsProvider.tsx
+++ b/packages/react-native/src/ElevenLabsProvider.tsx
@@ -29,6 +29,7 @@ export interface Conversation {
   sendContextualUpdate: (text: string) => void;
   sendUserMessage: (text: string) => void;
   sendUserActivity: () => void;
+  sendMultimodalMessage: (options: { text?: string; fileId?: string }) => void;
   setMicMuted: (muted: boolean) => void;
 }
 
@@ -257,6 +258,18 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
     });
   }, [sendMessage]);
 
+  const sendMultimodalMessage = React.useCallback((options: { text?: string; fileId?: string }) => {
+    sendMessage({
+      type: "multimodal_message",
+      text: options.text
+        ? { type: "user_message" as const, text: options.text }
+        : undefined,
+      file: options.fileId
+        ? { type: "file_input" as const, file_id: options.fileId }
+        : undefined,
+    });
+  }, [sendMessage]);
+
   // Store all conversation values/functions in refs for stable access
   const conversationValuesRef = React.useRef({
     startSession,
@@ -270,6 +283,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
     sendContextualUpdate,
     sendUserMessage,
     sendUserActivity,
+    sendMultimodalMessage,
   });
 
   // Update ref on every render
@@ -285,6 +299,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
     sendContextualUpdate,
     sendUserMessage,
     sendUserActivity,
+    sendMultimodalMessage,
   };
 
   // Create a stable conversation object that never changes reference
@@ -301,6 +316,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
     get sendContextualUpdate() { return conversationValuesRef.current.sendContextualUpdate; },
     get sendUserMessage() { return conversationValuesRef.current.sendUserMessage; },
     get sendUserActivity() { return conversationValuesRef.current.sendUserActivity; },
+    get sendMultimodalMessage() { return conversationValuesRef.current.sendMultimodalMessage; },
   }), []); // Empty deps - object is created once and never recreated
 
   // Memoize the context value to prevent unnecessary re-renders of consumers

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -352,6 +352,9 @@ export function useConversation<T extends HookOptions & ControlledState>(
         isApproved
       );
     },
+    sendMultimodalMessage: (options: { text?: string; fileId?: string }) => {
+      conversationRef.current?.sendMultimodalMessage(options);
+    },
     changeInputDevice: async (
       config: DeviceFormatConfig & DeviceInputConfig
     ) => {

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -184,6 +184,22 @@ export interface SourceInfo {
   version?: string;
 }
 
+export interface MultimodalMessage {
+  type: "multimodal_message";
+  text?: ReservedText;
+  file?: File;
+}
+
+export interface ReservedText {
+  type: "user_message";
+  text?: string;
+}
+
+export interface File {
+  type: "file_input";
+  file_id: string;
+}
+
 export interface Audio {
   type: "audio";
   audio_event: AudioEvent;
@@ -618,6 +634,12 @@ export interface ConversationInitiationClientToOrchestratorEvent {
   dynamic_variables?: Record<string, any>;
   user_id?: string;
   source_info?: SourceInfo;
+}
+
+export interface MultimodalMessageClientToOrchestratorEvent {
+  type: "multimodal_message";
+  text?: ReservedText;
+  file?: File;
 }
 
 export interface InputAudioChunk {

--- a/packages/types/generated/types/outgoing.ts
+++ b/packages/types/generated/types/outgoing.ts
@@ -5,6 +5,7 @@ export type {
   ConversationInitiationClientToOrchestratorEvent,
   InputAudioChunk,
   McpToolApprovalResultClientToOrchestratorEvent,
+  MultimodalMessageClientToOrchestratorEvent,
   PongClientToOrchestratorEvent,
   UserActivityClientToOrchestratorEvent,
   UserAudio,

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -79,6 +79,7 @@ channels:
           - $ref: "#/components/messages/MCPToolApprovalResult"
           - $ref: "#/components/messages/ContextualUpdate"
           - $ref: "#/components/messages/ConversationInitiation"
+          - $ref: "#/components/messages/MultimodalMessage"
 components:
   messages:
     # ===== CLIENT → SERVER MESSAGES =====
@@ -154,6 +155,14 @@ components:
       contentType: application/json
       payload:
         $ref: "#/components/schemas/ConversationInitiationPayload"
+
+    MultimodalMessage:
+      name: MultimodalMessageClientToOrchestratorEvent
+      title: Multimodal Message
+      summary: Multimodal message combining text and a file reference
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/MultimodalMessagePayload"
 
     # ===== SERVER → CLIENT MESSAGES =====
 
@@ -649,6 +658,33 @@ components:
           description: Unique identifier for the user
         source_info:
           $ref: "#/components/schemas/SourceInfo"
+
+    MultimodalMessageFileData:
+      type: object
+      required: [type, file_id]
+      properties:
+        type:
+          type: string
+          const: file_input
+        file_id:
+          type: string
+          description: The unique identifier of the file to include in the message
+
+    MultimodalMessagePayload:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          const: multimodal_message
+        text:
+          $ref: "#/components/schemas/UserMessagePayload"
+          nullable: true
+          description: The text component of the multimodal message
+        file:
+          $ref: "#/components/schemas/MultimodalMessageFileData"
+          nullable: true
+          description: The file component of the multimodal message
 
     # ===== SERVER MESSAGE PAYLOADS =====
 


### PR DESCRIPTION
## Summary
- Add support for the multimodal_message client-to-server WebSocket event, enabling users to send messages that combine text and file references (per the [Agents WebSocket API](https://elevenlabs.io/docs/eleven-agents/api-reference/eleven-agents/websocket))
- Define MultimodalMessage, MultimodalMessagePayload, and MultimodalMessageFileData schemas in the AsyncAPI spec and auto-generate corresponding TypeScript types
- Expose sendMultimodalMessage({ text?, fileId? }) across @elevenlabs/client, @elevenlabs/react, and @elevenlabs/react-native