### PR TITLE
feat: add optional environment param to convai endpoints

### DIFF
--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -55,6 +55,7 @@ export type BaseSessionConfig = {
   connectionDelay?: DelayConfig;
   textOnly?: boolean;
   userId?: string;
+  environment?: string;
 };
 
 export type ConnectionType = "websocket" | "webrtc";

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -85,7 +85,10 @@ export class WebRTCConnection extends BaseConnection {
         const source = config.overrides?.client?.source || "js_sdk";
         const configOrigin = config.origin ?? HTTPS_API_ORIGIN;
         const origin = convertWssToHttps(configOrigin); //origin is wss, not https
-        const url = `${origin}/v1/convai/conversation/token?agent_id=${config.agentId}&source=${source}&version=${version}`;
+        let url = `${origin}/v1/convai/conversation/token?agent_id=${config.agentId}&source=${source}&version=${version}`;
+        if (config.environment) {
+          url += `&environment=${encodeURIComponent(config.environment)}`;
+        }
         const response = await fetch(url);
 
         if (!response.ok) {

--- a/packages/client/src/utils/WebSocketConnection.ts
+++ b/packages/client/src/utils/WebSocketConnection.ts
@@ -110,6 +110,10 @@ export class WebSocketConnection extends BaseConnection {
         url = `${origin}${WSS_API_PATHNAME}${config.agentId}&source=${source}&version=${version}`;
       }
 
+      if (config.environment) {
+        url += `&environment=${encodeURIComponent(config.environment)}`;
+      }
+
       const protocols = [MAIN_PROTOCOL];
       if (config.authorization) {
         protocols.push(`bearer.${config.authorization}`);

--- a/packages/convai-widget-core/src/contexts/session-config.tsx
+++ b/packages/convai-widget-core/src/contexts/session-config.tsx
@@ -76,6 +76,7 @@ export function SessionConfigProvider({
   const { webSocketUrl } = useServerLocation();
   const agentId = useAttribute("agent-id");
   const signedUrl = useAttribute("signed-url");
+  const environment = useAttribute("environment");
   const textOnly = useTextOnly();
   const useWebRTCEnabled = useWebRTC();
   const value = useComputed<SessionConfig | null>(() => {
@@ -86,6 +87,7 @@ export function SessionConfigProvider({
       connectionDelay: { default: 300 },
       textOnly: textOnly.value,
       userId: userId.value || undefined,
+      environment: environment.value || undefined,
       libsampleratePath: libsamplerate.value,
       workletPaths: {
         rawAudioProcessor: rawAudioProcessor.value,

--- a/packages/convai-widget-core/src/types/attributes.ts
+++ b/packages/convai-widget-core/src/types/attributes.ts
@@ -55,6 +55,7 @@ export const CustomAttributeList = [
   "markdown-link-allow-http",
   "show-agent-status",
   "show-conversation-id",
+  "environment",
 ] as const;
 
 export type CustomAttributes = {

--- a/packages/react-native/src/hooks/useConversationSession.ts
+++ b/packages/react-native/src/hooks/useConversationSession.ts
@@ -63,7 +63,8 @@ export const useConversationSession = (
           const urlToUse = config.tokenFetchUrl || tokenFetchUrl;
           conversationToken = await getConversationToken(
             config.agentId,
-            urlToUse
+            urlToUse,
+            config.environment
           );
         } else {
           throw new Error("Either conversationToken or agentId is required");

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -87,6 +87,7 @@ export type ConversationConfig = {
   dynamicVariables?: Record<string, string | number | boolean>;
   textOnly?: boolean;
   userId?: string;
+  environment?: string;
 };
 
 // Incoming event types

--- a/packages/react-native/src/utils/tokenUtils.ts
+++ b/packages/react-native/src/utils/tokenUtils.ts
@@ -14,14 +14,17 @@ export const extractConversationIdFromToken = (token: string): string => {
 
 export const getConversationToken = async (
   agentId: string,
-  tokenFetchUrl?: string
+  tokenFetchUrl?: string,
+  environment?: string
 ): Promise<string> => {
   try {
     const baseUrl =
       tokenFetchUrl || "https://api.elevenlabs.io/v1/convai/conversation/token";
-    const response = await fetch(
-      `${baseUrl}?agent_id=${agentId}&source=react_native_sdk&version=${PACKAGE_VERSION}`
-    );
+    let url = `${baseUrl}?agent_id=${agentId}&source=react_native_sdk&version=${PACKAGE_VERSION}`;
+    if (environment) {
+      url += `&environment=${encodeURIComponent(environment)}`;
+    }
+    const response = await fetch(url);
 
     const data = await response.json();
 


### PR DESCRIPTION
## Summary
- Adds an optional `environment` query parameter to WebSocket connection, token fetch, and signed URL endpoints across all SDK packages
- The parameter is optional and defaults to `"production"` on the server side, so no breaking changes
- Supported in: `@elevenlabs/client`, `@elevenlabs/react`, `@elevenlabs/react-native`, `@elevenlabs/convai-widget-core`

## Changes
- **client**: `BaseSessionConfig.environment` added; appended as `&environment=` query param in `WebSocketConnection.create()` and `WebRTCConnection.create()` token fetch
- **react**: Passes through via `SessionConfig` (no extra code needed since it spreads into client)
- **react-native**: `ConversationConfig.environment` added; passed through `getConversationToken()` and `useConversationSession`
- **convai-widget-core**: New `environment` HTML attribute; passed into session config

## Test plan
copy of what we already have in xi which has had no issues 

🤖 Generated with [Claude Code](https://claude.com/claude-code)