### PR TITLE
[agents] add pinnedDynamicVariables to conversation initiation

### DIFF
--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -51,6 +51,7 @@ export type BaseSessionConfig = {
   };
   customLlmExtraBody?: unknown;
   dynamicVariables?: Record<string, string | number | boolean>;
+  pinnedDynamicVariables?: string[];
   useWakeLock?: boolean;
   connectionDelay?: DelayConfig;
   textOnly?: boolean;

--- a/packages/client/src/utils/overrides.ts
+++ b/packages/client/src/utils/overrides.ts
@@ -38,6 +38,10 @@ export function constructOverrides(
     overridesEvent.dynamic_variables = config.dynamicVariables;
   }
 
+  if (config.pinnedDynamicVariables) {
+    overridesEvent.pinned_dynamic_variables = config.pinnedDynamicVariables;
+  }
+
   if (config.userId) {
     overridesEvent.user_id = config.userId;
   }

--- a/packages/react-native/src/ElevenLabsProvider.tsx
+++ b/packages/react-native/src/ElevenLabsProvider.tsx
@@ -127,6 +127,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
     overrides,
     customLlmExtraBody,
     dynamicVariables,
+    pinnedDynamicVariables,
     userId,
     textOnly,
   } = useConversationSession(callbacksRef, setStatus, setConnect, setToken, setConversationId, tokenFetchUrl);
@@ -217,6 +218,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
       overrides,
       customLlmExtraBody,
       dynamicVariables,
+      pinnedDynamicVariables,
       userId,
     });
 
@@ -230,7 +232,7 @@ export const ElevenLabsProvider: React.FC<ElevenLabsProviderProps> = ({ children
         callbacksRef.current.onError?.(error as string);
       }
     }
-  }, [handleParticipantReady, overrides, customLlmExtraBody, dynamicVariables, userId, callbacksRef]);
+  }, [handleParticipantReady, overrides, customLlmExtraBody, dynamicVariables, pinnedDynamicVariables, userId, callbacksRef]);
 
   // Create setClientTools function that only updates ref
   const setClientTools = React.useCallback((tools: ClientToolsConfig['clientTools']) => {

--- a/packages/react-native/src/hooks/useConversationSession.ts
+++ b/packages/react-native/src/hooks/useConversationSession.ts
@@ -26,6 +26,8 @@ export const useConversationSession = (
   const [dynamicVariables, setDynamicVariables] = useState<
     ConversationConfig["dynamicVariables"]
   >({});
+  const [pinnedDynamicVariables, setPinnedDynamicVariables] =
+    useState<ConversationConfig["pinnedDynamicVariables"]>(undefined);
   const [userId, setUserId] = useState<ConversationConfig["userId"]>(undefined);
   const [textOnly, setTextOnly] =
     useState<ConversationConfig["textOnly"]>(false);
@@ -47,6 +49,7 @@ export const useConversationSession = (
         });
         setCustomLlmExtraBody(config.customLlmExtraBody || null);
         setDynamicVariables(config.dynamicVariables || {});
+        setPinnedDynamicVariables(config.pinnedDynamicVariables);
         setUserId(config.userId);
         setTextOnly(textOnly);
 
@@ -105,6 +108,7 @@ export const useConversationSession = (
         setOverrides({});
         setCustomLlmExtraBody(null);
         setDynamicVariables({});
+        setPinnedDynamicVariables(undefined);
         setUserId(undefined);
         setConversationId("");
 
@@ -124,6 +128,7 @@ export const useConversationSession = (
     overrides,
     customLlmExtraBody,
     dynamicVariables,
+    pinnedDynamicVariables,
     userId,
     textOnly,
   };

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -85,6 +85,7 @@ export type ConversationConfig = {
   };
   customLlmExtraBody?: unknown;
   dynamicVariables?: Record<string, string | number | boolean>;
+  pinnedDynamicVariables?: string[];
   textOnly?: boolean;
   userId?: string;
   environment?: string;

--- a/packages/react-native/src/utils/overrides.ts
+++ b/packages/react-native/src/utils/overrides.ts
@@ -40,6 +40,10 @@ export function constructOverrides(
     overridesEvent.dynamic_variables = config.dynamicVariables;
   }
 
+  if (config.pinnedDynamicVariables) {
+    overridesEvent.pinned_dynamic_variables = config.pinnedDynamicVariables;
+  }
+
   if (config.userId) {
     overridesEvent.user_id = String(config.userId);
   }

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -52,6 +52,7 @@ export interface ConversationInitiation {
   conversation_config_override?: ConversationConfigOverride;
   custom_llm_extra_body?: Record<string, any>;
   dynamic_variables?: Record<string, any>;
+  pinned_dynamic_variables?: string[];
   user_id?: string;
   source_info?: SourceInfo;
 }
@@ -632,6 +633,7 @@ export interface ConversationInitiationClientToOrchestratorEvent {
   conversation_config_override?: ConversationConfigOverride;
   custom_llm_extra_body?: Record<string, any>;
   dynamic_variables?: Record<string, any>;
+  pinned_dynamic_variables?: string[];
   user_id?: string;
   source_info?: SourceInfo;
 }

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -652,6 +652,11 @@ components:
         dynamic_variables:
           type: object
           description: Dynamic variables available in the conversation context
+        pinned_dynamic_variables:
+          type: array
+          items:
+            type: string
+          description: Variable names whose placeholder values should not be overwritten by tool assignments
         user_id:
           type: string
           nullable: true


### PR DESCRIPTION
## Summary
- Adds `pinnedDynamicVariables` support across the SDK so callers can specify dynamic variable names that should not be overwritten by tool assignments during a conversation.
- This pairs with the backend change in [elevenlabs/xi#29274](https://github.com/elevenlabs/xi/pull/29274) which accepts `pinned_dynamic_variables` on `ConversationInitiationClientDataRequest` and skips tool assignments for pinned variables.
- Once this SDK is released, the xi frontend can re-add lock toggles in the Dynamic Variables editor that pass pinned variables through `startSession`.

### Changes
- **`packages/types`**: Added `pinned_dynamic_variables` to `ConversationInitiationPayload` in the asyncapi schema; regenerated TypeScript types
- **`packages/client`**: Added `pinnedDynamicVariables?: string[]` to `BaseSessionConfig`; mapped to `pinned_dynamic_variables` in `constructOverrides`
- **`packages/react-native`**: Added `pinnedDynamicVariables` to `ConversationConfig`, `overrides.ts`, `ElevenLabsProvider`, and `useConversationSession` hook

## Test plan
- [ ] Verify type checks pass across all packages
- [ ] Start a conversation with `pinnedDynamicVariables: ["var_name"]` and verify `pinned_dynamic_variables` appears in the WebSocket init message
- [ ] Confirm pinned variables are not overwritten by tool assignments during the conversation


Made with [Cursor](https://cursor.com)