### PR TITLE
chore: enable disabled eslint rules in client package

### DIFF
--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -27,7 +27,7 @@ const ConversationScreen = () => {
       console.log("❌ Disconnected from conversation", details);
       setCurrentConversationId(null);
     },
-    onError: (message: string, context?: Record<string, unknown>) => {
+    onError: (message, context) => {
       console.error("❌ Conversation error:", message, context);
     },
     onMessage: ({ message, role }) => {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "turbo test",
     "build": "turbo build",
     "check-types": "turbo check-types",
-    "ci": "turbo check-types lint test build",
+    "ci": "CI=true turbo check-types lint test build",
     "generate:types": "turbo run generate --filter=@elevenlabs/types",
     "prepare": "husky install",
     "dev": "turbo dev",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "create": "node scripts/create",
     "lint": "turbo lint",
+    "lint:prettier": "turbo lint:prettier",
     "test": "turbo test",
     "build": "turbo build",
     "check-types": "turbo check-types",

--- a/packages/client/eslint.config.cjs
+++ b/packages/client/eslint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -14,6 +14,7 @@ export default defineConfig(
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
+      "preserve-caught-error": "error",
     },
   }
 );

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import { defineConfig, globalIgnores } from "eslint/config";
+import tseslint from "typescript-eslint";
+
+export default defineConfig(
+  globalIgnores(["dist/**", "scripts/**", "worklets/**"]),
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      // Pre-existing issues — enable incrementally (see #583)
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "no-empty": "off",
+    },
+  }
+);

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -14,8 +14,6 @@ export default defineConfig(
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      // Pre-existing issues — enable incrementally (see #583)
-      "no-empty": "off",
     },
   }
 );

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -15,7 +15,6 @@ export default defineConfig(
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
       // Pre-existing issues — enable incrementally (see #583)
-      "@typescript-eslint/ban-ts-comment": "off",
       "no-empty": "off",
     },
   }

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -15,7 +15,6 @@ export default defineConfig(
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
       // Pre-existing issues — enable incrementally (see #583)
-      "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/ban-ts-comment": "off",
       "no-empty": "off",
     },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,6 +31,7 @@
   "author": "ElevenLabs",
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^9.39.1",
     "@types/node-wav": "^0.0.3",
     "@vitest/browser": "^3.0.5",
     "eslint": "^9.8.0",
@@ -39,6 +40,7 @@
     "node-wav": "^0.0.2",
     "playwright": "^1.54.1",
     "typescript": "^5.5.4",
+    "typescript-eslint": "^8.55.0",
     "vitest": "^3.0.5"
   },
   "repository": {

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -56,7 +56,7 @@ export type ClientToolsConfig = {
   clientTools: Record<
     string,
     (
-      parameters: any
+      parameters: Record<string, unknown>
     ) => Promise<string | number | void> | string | number | void
   >;
 };
@@ -467,7 +467,7 @@ export class BaseConversation {
     }
   };
 
-  private onError(message: string, context?: any) {
+  private onError(message: string, context?: unknown) {
     console.error(message, context);
     if (this.options.onError) {
       this.options.onError(message, context);

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -291,7 +291,7 @@ export class BaseConversation {
     }
   }
 
-  protected handleAudio(event: AgentAudioEvent) {}
+  protected handleAudio(_event: AgentAudioEvent) {}
 
   protected handleMCPToolCall(event: MCPToolCallClientEvent) {
     if (this.options.onMCPToolCall) {

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -98,7 +98,9 @@ export class VoiceConversation extends BaseConversation {
       try {
         await wakeLock?.release();
         wakeLock = null;
-      } catch {}
+      } catch {
+        // Wake lock may fail — proceed if it does
+      }
       throw error;
     }
   }
@@ -148,7 +150,9 @@ export class VoiceConversation extends BaseConversation {
     try {
       await this.wakeLock?.release();
       this.wakeLock = null;
-    } catch {}
+    } catch {
+      // Wake lock may fail — proceed if it does
+    }
 
     await this.input.close();
     await this.output.close();

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -19,7 +19,7 @@ export class VoiceConversation extends BaseConversation {
       // unavailable without HTTPS, including localhost in dev
       try {
         return await navigator.wakeLock.request("screen");
-      } catch (_e) {
+      } catch {
         // Wake Lock is not required for the conversation to work
       }
     }
@@ -98,7 +98,7 @@ export class VoiceConversation extends BaseConversation {
       try {
         await wakeLock?.release();
         wakeLock = null;
-      } catch (_e) {}
+      } catch {}
       throw error;
     }
   }
@@ -148,7 +148,7 @@ export class VoiceConversation extends BaseConversation {
     try {
       await this.wakeLock?.release();
       this.wakeLock = null;
-    } catch (_e) {}
+    } catch {}
 
     await this.input.close();
     await this.output.close();

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -897,7 +897,7 @@ describe("WebRTC Volume Control", () => {
       expect(mockElement2.volume).toBe(0.8);
 
       connection.close();
-    } catch (error) {
+    } catch {
       // If WebRTC creation fails (which is expected in test env),
       // we can still test the volume logic separately
       console.log("WebRTC creation failed as expected in test environment");

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -618,7 +618,9 @@ describe("Volume Control", () => {
       vi.spyOn(
         globalThis.navigator.mediaDevices,
         "getUserMedia"
-      ).mockImplementation(() => Promise.resolve(mockMediaStream as any));
+      ).mockImplementation(() =>
+        Promise.resolve(mockMediaStream as unknown as MediaStream)
+      );
     }
 
     // Mock document methods we need for audio element tests
@@ -885,7 +887,9 @@ describe("WebRTC Volume Control", () => {
 
       // Directly test the setAudioVolume method by adding mock elements
       // Access the private audioElements array through type assertion
-      (connection as any).audioElements = [mockElement1, mockElement2];
+      (
+        connection as unknown as { audioElements: (typeof mockElement1)[] }
+      ).audioElements = [mockElement1, mockElement2];
 
       // Test volume control
       connection.setAudioVolume(0.5);
@@ -1254,16 +1258,16 @@ describe("Wake Lock", () => {
     originalWakeLock = navigator.wakeLock;
 
     vi.spyOn(document, "addEventListener").mockImplementation(
-      (type: string, listener: any) => {
-        if (type === "visibilitychange") {
-          visibilityChangeListeners.push(listener);
+      (type: string, listener: EventListenerOrEventListenerObject | null) => {
+        if (type === "visibilitychange" && typeof listener === "function") {
+          visibilityChangeListeners.push(listener as () => void);
         }
       }
     );
 
     vi.spyOn(document, "removeEventListener").mockImplementation(
-      (type: string, listener: any) => {
-        if (type === "visibilitychange") {
+      (type: string, listener: EventListenerOrEventListenerObject | null) => {
+        if (type === "visibilitychange" && typeof listener === "function") {
           visibilityChangeListeners = visibilityChangeListeners.filter(
             l => l !== listener
           );

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Track mock calls using a global object that can be accessed after mocking
-const mockCalls = {
-  setMicrophoneEnabled: [] as boolean[],
+type MockCalls = {
+  setMicrophoneEnabled: boolean[];
 };
 
 vi.mock("livekit-client", () => {
@@ -12,8 +12,7 @@ vi.mock("livekit-client", () => {
         setMicrophoneEnabled: [],
       };
       (
-        (globalThis as Record<string, unknown>)
-          .__mockCalls__ as typeof mockCalls
+        (globalThis as Record<string, unknown>).__mockCalls__ as MockCalls
       ).setMicrophoneEnabled.push(enabled);
       return Promise.resolve();
     }),
@@ -90,8 +89,7 @@ describe("WebRTCConnection", () => {
       }
 
       const calls = (
-        (globalThis as Record<string, unknown>)
-          .__mockCalls__ as typeof mockCalls
+        (globalThis as Record<string, unknown>).__mockCalls__ as MockCalls
       ).setMicrophoneEnabled;
 
       if (shouldEnableMic) {

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -111,7 +111,8 @@ export class WebRTCConnection extends BaseConnection {
         }
 
         throw new Error(
-          `Failed to fetch conversation token for agent ${config.agentId}: ${msg}`
+          `Failed to fetch conversation token for agent ${config.agentId}: ${msg}`,
+          { cause: error }
         );
       }
     } else {

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -206,28 +206,25 @@ export class WebRTCConnection extends BaseConnection {
     });
 
     // Handle incoming data messages
-    this.room.on(
-      RoomEvent.DataReceived,
-      (payload: Uint8Array, _participant) => {
-        try {
-          const message = JSON.parse(new TextDecoder().decode(payload));
+    this.room.on(RoomEvent.DataReceived, (payload: Uint8Array) => {
+      try {
+        const message = JSON.parse(new TextDecoder().decode(payload));
 
-          // Filter out audio messages for WebRTC - they're handled via audio tracks
-          if (message.type === "audio") {
-            return;
-          }
-
-          if (isValidSocketEvent(message)) {
-            this.handleMessage(message);
-          } else {
-            console.warn("Invalid socket event received:", message);
-          }
-        } catch (error) {
-          console.warn("Failed to parse incoming data message:", error);
-          console.warn("Raw payload:", new TextDecoder().decode(payload));
+        // Filter out audio messages for WebRTC - they're handled via audio tracks
+        if (message.type === "audio") {
+          return;
         }
+
+        if (isValidSocketEvent(message)) {
+          this.handleMessage(message);
+        } else {
+          console.warn("Invalid socket event received:", message);
+        }
+      } catch (error) {
+        console.warn("Failed to parse incoming data message:", error);
+        console.warn("Raw payload:", new TextDecoder().decode(payload));
       }
-    );
+    });
 
     this.room.on(
       RoomEvent.TrackSubscribed,
@@ -395,7 +392,7 @@ export class WebRTCConnection extends BaseConnection {
         } else {
           await micTrackPublication.track.unmute();
         }
-      } catch (_error) {
+      } catch {
         // If track muting fails, fall back to participant-level control
         await this.room.localParticipant.setMicrophoneEnabled(!isMuted);
       }

--- a/packages/client/src/utils/WebSocketConnection.ts
+++ b/packages/client/src/utils/WebSocketConnection.ts
@@ -133,7 +133,7 @@ export class WebSocketConnection extends BaseConnection {
           { once: true }
         );
 
-        socket!.addEventListener("error", () => {
+        socket!.addEventListener("error", _event => {
           // In case the error event is followed by a close event, we want the
           // latter to be the one that rejects the promise as it contains more
           // useful information.

--- a/packages/client/src/utils/WebSocketConnection.ts
+++ b/packages/client/src/utils/WebSocketConnection.ts
@@ -133,7 +133,7 @@ export class WebSocketConnection extends BaseConnection {
           { once: true }
         );
 
-        socket!.addEventListener("error", event => {
+        socket!.addEventListener("error", () => {
           // In case the error event is followed by a close event, we want the
           // latter to be the one that rejects the promise as it contains more
           // useful information.

--- a/packages/client/src/utils/audio.test.ts
+++ b/packages/client/src/utils/audio.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { arrayBufferToBase64, base64ToArrayBuffer } from "./audio";
+
+describe("audio utils", () => {
+  it("arrayBufferToBase64 encodes correctly", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+    const base64 = arrayBufferToBase64(bytes.buffer);
+    expect(base64).toBe("SGVsbG8=");
+    expect(atob(base64)).toBe("Hello");
+  });
+
+  it("base64ToArrayBuffer decodes correctly", () => {
+    const buffer = base64ToArrayBuffer("SGVsbG8=");
+    expect(new Uint8Array(buffer)).toEqual(
+      new Uint8Array([72, 101, 108, 108, 111])
+    );
+  });
+
+  it("roundtrips correctly", () => {
+    const original = new Uint8Array([0, 1, 127, 128, 255]);
+    const base64 = arrayBufferToBase64(original.buffer);
+    const decoded = new Uint8Array(base64ToArrayBuffer(base64));
+    expect(decoded).toEqual(original);
+  });
+
+  it("handles empty buffer", () => {
+    const empty = new Uint8Array(0);
+    const base64 = arrayBufferToBase64(empty.buffer);
+    expect(base64).toBe("");
+    expect(new Uint8Array(base64ToArrayBuffer(base64))).toEqual(empty);
+  });
+
+  it("handles large buffer without stack overflow", () => {
+    const large = new Uint8Array(100_000);
+    for (let i = 0; i < large.length; i++) {
+      large[i] = i % 256;
+    }
+    const base64 = arrayBufferToBase64(large.buffer);
+    const decoded = new Uint8Array(base64ToArrayBuffer(base64));
+    expect(decoded).toEqual(large);
+  });
+});

--- a/packages/client/src/utils/audio.ts
+++ b/packages/client/src/utils/audio.ts
@@ -1,7 +1,10 @@
 export function arrayBufferToBase64(b: ArrayBufferLike) {
   const buffer = new Uint8Array(b);
-  // @ts-ignore
-  const base64Data = window.btoa(String.fromCharCode(...buffer));
+  let binary = "";
+  for (let i = 0; i < buffer.length; i++) {
+    binary += String.fromCharCode(buffer[i]);
+  }
+  const base64Data = window.btoa(binary);
   return base64Data;
 }
 

--- a/packages/client/src/utils/createWorkletModuleLoader.ts
+++ b/packages/client/src/utils/createWorkletModuleLoader.ts
@@ -38,7 +38,7 @@ export function createWorkletModuleLoader(name: string, sourceCode: string) {
       const moduleURL = `data:application/javascript;base64,${base64}`;
       await worklet.addModule(moduleURL);
       URLCache.set(name, moduleURL);
-    } catch (error) {
+    } catch {
       throw new Error(
         `Failed to load the ${name} worklet module. Make sure the browser supports AudioWorklets. If you are using a strict CSP, you may need to self-host the worklet files.`
       );

--- a/packages/client/src/utils/createWorkletModuleLoader.ts
+++ b/packages/client/src/utils/createWorkletModuleLoader.ts
@@ -15,7 +15,8 @@ export function createWorkletModuleLoader(name: string, sourceCode: string) {
         return;
       } catch (error) {
         throw new Error(
-          `Failed to load the ${name} worklet module from path: ${path}. Error: ${error}`
+          `Failed to load the ${name} worklet module from path: ${path}.`,
+          { cause: error }
         );
       }
     }
@@ -38,9 +39,10 @@ export function createWorkletModuleLoader(name: string, sourceCode: string) {
       const moduleURL = `data:application/javascript;base64,${base64}`;
       await worklet.addModule(moduleURL);
       URLCache.set(name, moduleURL);
-    } catch {
+    } catch (error) {
       throw new Error(
-        `Failed to load the ${name} worklet module. Make sure the browser supports AudioWorklets. If you are using a strict CSP, you may need to self-host the worklet files.`
+        `Failed to load the ${name} worklet module. Make sure the browser supports AudioWorklets. If you are using a strict CSP, you may need to self-host the worklet files.`,
+        { cause: error }
       );
     }
   };

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -91,6 +91,13 @@ export type OutgoingSocketEvent =
   | MCPToolApprovalResultEvent
   | MultimodalMessageEvent;
 
-export function isValidSocketEvent(event: any): event is IncomingSocketEvent {
-  return !!event.type;
+export function isValidSocketEvent(
+  event: unknown
+): event is IncomingSocketEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    !!event.type
+  );
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es2015", "dom"],
+    "lib": ["es2022", "dom"],
     "target": "es5",
     "module": "esnext",
     "jsx": "react",

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -58,7 +58,7 @@ export interface MessagePayload {
 export type Callbacks = {
   onConnect?: (props: { conversationId: string }) => void;
   onDisconnect?: (details: DisconnectionDetails) => void;
-  onError?: (message: string, context?: any) => void;
+  onError?: (message: string, context?: unknown) => void;
   onMessage?: (props: MessagePayload) => void;
   onAudio?: (base64Audio: string) => void;
   onModeChange?: (prop: { mode: Mode }) => void;
@@ -92,9 +92,7 @@ export type Callbacks = {
   onAgentChatResponsePart?: (
     props: Generated.AgentChatResponsePartClientEvent["text_response_part"]
   ) => void;
-  onAudioAlignment?: (
-    props: AudioAlignmentEvent
-  ) => void;
+  onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   // internal debug events, not to be used
   onDebug?: (props: any) => void;
 };

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -94,5 +94,5 @@ export type Callbacks = {
   ) => void;
   onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   // internal debug events, not to be used
-  onDebug?: (props: any) => void;
+  onDebug?: (props: unknown) => void;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
         specifier: ^2.11.4
         version: 2.16.0(patch_hash=9017aa1cb7fee2ea056f4126969008ea86ed7876e3f35563fc967ff3adb4847e)(@types/dom-mediacapture-record@1.0.22)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.1
+        version: 9.39.1
       '@types/node-wav':
         specifier: ^0.0.3
         version: 0.0.3
@@ -244,6 +247,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.55.0
+        version: 8.55.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.2)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.4(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)


### PR DESCRIPTION
  **Summary:**

  Closes #583
  
  Adds a proper ESLint config to `packages/client` (replacing the empty stub) and enables all 5 rules that were
  identified as disabled:
  - `@typescript-eslint/no-unused-vars` — removed unused params/variables, prefixed intentionally unused ones with `_`,
  converted unused catch bindings to bare `catch {}`
  - `@typescript-eslint/no-explicit-any` — replaced `any` with `unknown` or `Record<string, unknown>` across source and types
  - `@typescript-eslint/ban-ts-comment` — already clean, just enabled
  - `no-empty` — added comments to intentionally empty catch blocks (wake lock release)
  - `preserve-caught-error` — preserved original errors via `{ cause: error }` when rethrowing

  **Other changes:**
  - Added `@eslint/js` and `typescript-eslint` as devDependencies to `client` package
  - Updated `tsconfig.json` lib from `es2015` to `es2022` to support `Error` `cause` option
  - Fixed `onError` callback type in `@elevenlabs/types` (`any` → `unknown`) and updated the react-native example accordingly
  - Replaced `String.fromCharCode(...buffer)` spread in `audio.ts` with a loop (fixes TS downlevel iteration error + avoids
  stack overflow on large buffers)
  - Added unit tests for `arrayBufferToBase64` / `base64ToArrayBuffer`
  - Set `CI=true` in the root `ci` script so `vitest` doesn't hang in watch mode locally