### PR TITLE
Add SDK migration skill for next major version

### DIFF
--- a/.agents/skills/elevenlabs:sdk-migration/SKILL.md
+++ b/.agents/skills/elevenlabs:sdk-migration/SKILL.md
@@ -8,6 +8,15 @@ license: MIT
 
 Migration guide for `@elevenlabs/client`, `@elevenlabs/react`, and `@elevenlabs/react-native` breaking changes in the next major release.
 
+## Migration instructions
+
+When migrating a codebase that contains **multiple components using `useConversation`** (or other hooks requiring `ConversationProvider`), ask the user whether they want:
+
+1. **A single shared `ConversationProvider`** wrapping all conversation components higher in the tree (all components share one session), or
+2. **Individual `ConversationProvider` wrappers** for each component (each component manages its own independent session).
+
+This choice affects session sharing, state isolation, and component architecture. Do not assume — ask before proceeding.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a new Claude Code skill (`.agents/skills/elevenlabs:sdk-migration/SKILL.md`) documenting the migration guide for the next major version of `@elevenlabs/client`, `@elevenlabs/react`, and `@elevenlabs/react-native`
- Covers breaking changes: `Conversation` class removal, `Input`/`Output` removal, `useConversation` provider requirement, granular hooks, `useConversationClientTool`, and React Native API rewrite

## Test plan
- [x] Skill file renders correctly as markdown
- [ ] Verify skill is discoverable by Claude Code agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation-only guidance for migrating to the next major ElevenLabs SDKs; no runtime code or behavior changes.
> 
> **Overview**
> Adds a new Claude Code skill document, `.agents/skills/elevenlabs:sdk-migration/SKILL.md`, describing how to migrate to the next major `@elevenlabs/client`, `@elevenlabs/react`, and `@elevenlabs/react-native` APIs.
> 
> The guide covers key breaking changes (e.g., `Conversation` no longer being a class, removal of `Input`/`Output` accessors, `useConversation` now requiring `ConversationProvider`, new granular React hooks including `useConversationClientTool`, and the React Native API shifting to re-exports from `@elevenlabs/react`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f157e9ff498948e908ab8dc0bc64b5c15e1b0c28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->