### PR TITLE
Add changeset for @elevenlabs/types CALLBACK_KEYS export

### DIFF
--- a/.changeset/types-callback-keys.md
+++ b/.changeset/types-callback-keys.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/types": minor
+---
+
+Export `CALLBACK_KEYS` runtime array of all `Callbacks` keys, used by the React SDK for callback composition


### PR DESCRIPTION
## Summary
- Adds missing changeset for the `CALLBACK_KEYS` runtime array export added to `@elevenlabs/types`
- Bumps `@elevenlabs/types` as a `minor` since it's a new export

## Context
The `CALLBACK_KEYS` array was added to `@elevenlabs/types` but no changeset was created for it. This ensures it gets a proper version bump on release.

## Test plan
- [x] Changeset file is valid and references the correct package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a Changesets metadata file to bump `@elevenlabs/types` minor for an existing new export; no runtime or build logic changes.
> 
> **Overview**
> Adds a Changesets entry to publish a **minor** version bump for `@elevenlabs/types`, documenting the new `CALLBACK_KEYS` runtime export (used for React SDK callback composition).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5062f66bb8bffc35c671da35de81d7a136b2e813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->