### PR TITLE
Convert eslint configs from .cjs to ESM (.mjs)

### DIFF
--- a/packages/client/eslint.config.cjs
+++ b/packages/client/eslint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/packages/client/eslint.config.mjs
+++ b/packages/client/eslint.config.mjs
@@ -1,0 +1,1 @@
+export default [{ ignores: ["dist/**"] }];

--- a/packages/convai-widget-core/eslint.config.cjs
+++ b/packages/convai-widget-core/eslint.config.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  ignores: ["dist/**"],
-};

--- a/packages/convai-widget-core/eslint.config.mjs
+++ b/packages/convai-widget-core/eslint.config.mjs
@@ -1,0 +1,1 @@
+export default [{ ignores: ["dist/**"] }];

--- a/packages/convai-widget-embed/eslint.config.cjs
+++ b/packages/convai-widget-embed/eslint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/packages/convai-widget-embed/eslint.config.mjs
+++ b/packages/convai-widget-embed/eslint.config.mjs
@@ -1,0 +1,1 @@
+export default [{ ignores: ["dist/**"] }];

--- a/packages/react-native/eslint.config.cjs
+++ b/packages/react-native/eslint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/packages/react-native/eslint.config.mjs
+++ b/packages/react-native/eslint.config.mjs
@@ -1,0 +1,1 @@
+export default [{ ignores: ["dist/**"] }];

--- a/packages/react/eslint.config.cjs
+++ b/packages/react/eslint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/packages/react/eslint.config.mjs
+++ b/packages/react/eslint.config.mjs
@@ -1,0 +1,1 @@
+export default [{ ignores: ["dist/**"] }];

--- a/packages/types/eslint.config.cjs
+++ b/packages/types/eslint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/packages/types/eslint.config.mjs
+++ b/packages/types/eslint.config.mjs
@@ -1,0 +1,1 @@
+export default [{ ignores: ["dist/**"] }];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

All packages currently have `eslint.config.cjs` files using `module.exports = {}`. These were converted to ESM (`eslint.config.mjs` with `export default`) for consistency with the rest of the codebase.

This also adds `ignores: ["dist/**"]` so `eslint .` from package roots does not lint compiled output in `dist/`.

## Changes

Updated these packages:

- `packages/client`
- `packages/react`
- `packages/convai-widget-core`
- `packages/convai-widget-embed`
- `packages/react-native`
- `packages/types`

For each package:

1. Deleted `eslint.config.cjs`
2. Added `eslint.config.mjs` with:

```js
export default [{ ignores: ["dist/**"] }];
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14ebf811-526e-4ce2-b12a-8aa750d9778d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14ebf811-526e-4ce2-b12a-8aa750d9778d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

