### PR TITLE
fix: return 0 from getInputVolume/getOutputVolume instead of throwing

### DIFF
--- a/.changeset/fix-volume-no-throw.md
+++ b/.changeset/fix-volume-no-throw.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react": patch
+---
+
+Return 0 from `getInputVolume()`/`getOutputVolume()` and empty `Uint8Array` from `getInputByteFrequencyData()`/`getOutputByteFrequencyData()` instead of throwing when no active conversation or analyser is available. This avoids forcing consumers (e.g., animation loops) to wrap every call in try-catch.

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -17,6 +17,8 @@ import type { InputController } from "./InputController";
 import type { OutputController } from "./OutputController";
 import { setupStrategy } from "./platform/VoiceSessionSetup";
 
+const EMPTY_FREQUENCY_DATA = new Uint8Array(0) as Uint8Array<ArrayBuffer>;
+
 export class VoiceConversation extends BaseConversation {
   private static async requestWakeLock(): Promise<WakeLockSentinel | null> {
     if ("wakeLock" in navigator) {
@@ -208,7 +210,7 @@ export class VoiceConversation extends BaseConversation {
   public getInputByteFrequencyData(): Uint8Array<ArrayBuffer> {
     const analyser = this.input.getAnalyser();
     if (!analyser) {
-      throw new Error("Input analyser is not available");
+      return EMPTY_FREQUENCY_DATA;
     }
     this.inputFrequencyData ??= new Uint8Array(
       analyser.frequencyBinCount
@@ -230,7 +232,7 @@ export class VoiceConversation extends BaseConversation {
 
     const analyser = this.output.getAnalyser();
     if (!analyser) {
-      throw new Error("Output analyser is not available");
+      return EMPTY_FREQUENCY_DATA;
     }
 
     this.outputFrequencyData ??= new Uint8Array(

--- a/packages/react/src/conversation/ConversationControls.test.tsx
+++ b/packages/react/src/conversation/ConversationControls.test.tsx
@@ -205,10 +205,22 @@ describe("useConversationControls", () => {
     expect(() => result.current.setVolume({ volume: 0.5 })).toThrow(
       "No active conversation"
     );
-    expect(() => result.current.getInputVolume()).toThrow(
-      "No active conversation"
-    );
     expect(() => result.current.getId()).toThrow("No active conversation");
+  });
+
+  it("returns default values for volume and frequency data without an active session", () => {
+    const { result } = renderHook(() => useConversationControls(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.getInputVolume()).toBe(0);
+    expect(result.current.getOutputVolume()).toBe(0);
+    expect(result.current.getInputByteFrequencyData()).toEqual(
+      new Uint8Array(0)
+    );
+    expect(result.current.getOutputByteFrequencyData()).toEqual(
+      new Uint8Array(0)
+    );
   });
 
   it("changeInputDevice throws for text-only conversations", async () => {

--- a/packages/react/src/conversation/ConversationControls.tsx
+++ b/packages/react/src/conversation/ConversationControls.tsx
@@ -8,6 +8,8 @@ import {
 import type { HookOptions } from "./types";
 import { ConversationContext } from "./ConversationContext";
 
+const EMPTY_FREQUENCY_DATA = new Uint8Array(0);
+
 export type ConversationControlsValue = {
   startSession: (options?: HookOptions) => void;
   endSession: () => void;
@@ -107,20 +109,20 @@ export function ConversationControlsProvider({
   );
 
   const getInputByteFrequencyData = useCallback(() => {
-    return getConversation().getInputByteFrequencyData();
-  }, [getConversation]);
+    return conversationRef.current?.getInputByteFrequencyData() ?? EMPTY_FREQUENCY_DATA;
+  }, [conversationRef]);
 
   const getOutputByteFrequencyData = useCallback(() => {
-    return getConversation().getOutputByteFrequencyData();
-  }, [getConversation]);
+    return conversationRef.current?.getOutputByteFrequencyData() ?? EMPTY_FREQUENCY_DATA;
+  }, [conversationRef]);
 
   const getInputVolume = useCallback(() => {
-    return getConversation().getInputVolume();
-  }, [getConversation]);
+    return conversationRef.current?.getInputVolume() ?? 0;
+  }, [conversationRef]);
 
   const getOutputVolume = useCallback(() => {
-    return getConversation().getOutputVolume();
-  }, [getConversation]);
+    return conversationRef.current?.getOutputVolume() ?? 0;
+  }, [conversationRef]);
 
   const getId = useCallback(() => {
     return getConversation().getId();


### PR DESCRIPTION
## Summary

Closes #618

- `getInputVolume()` and `getOutputVolume()` now return `0` instead of throwing when called without an active conversation session
- `getInputByteFrequencyData()` and `getOutputByteFrequencyData()` now return an empty `Uint8Array` instead of throwing when no analyser or session is available
- These functions are commonly used in animation loops (e.g., orb visualizers) that poll every frame — throwing forced consumers to wrap every call in try-catch

## Changes

- **`packages/client/src/VoiceConversation.ts`**: Return empty `Uint8Array` instead of throwing `"Input/Output analyser is not available"` when analyser is null
- **`packages/react/src/conversation/ConversationControls.tsx`**: Return `0` / empty `Uint8Array` when `conversationRef.current` is null, instead of going through `getConversation()` which throws
- **`packages/react/src/conversation/ConversationControls.test.tsx`**: Updated test expectations and added a dedicated test for default return values without an active session

## Test plan

- [x] Existing tests continue to pass (`pnpm --filter @elevenlabs/react run test` — 113 tests)
- [x] Existing client tests continue to pass (`pnpm --filter @elevenlabs/client run test` — 162 tests)
- [x] New test verifies `getInputVolume()`, `getOutputVolume()`, `getInputByteFrequencyData()`, and `getOutputByteFrequencyData()` return defaults without a session
- [x] Imperative actions (`sendUserMessage`, `setVolume`, `getId`, etc.) still throw when no session is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior change that avoids exceptions in polling/animation loops; main risk is silent failure for callers that previously relied on thrown errors.
> 
> **Overview**
> **Prevents runtime exceptions from polling audio metrics.** `getInputVolume()`/`getOutputVolume()` and `getInputByteFrequencyData()`/`getOutputByteFrequencyData()` now return **0** or an **empty `Uint8Array`** when there’s no active conversation/analyser, instead of throwing.
> 
> This updates both the client `VoiceConversation` analyser accessors and the React `useConversationControls` wrappers to use null-safe reads, and adjusts tests/adds coverage to ensure default values are returned while other imperative controls still throw without a session.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20a8f7e860a867a0191b63b59eb7508361138e61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->