### PR TITLE
Fix getInputVolume/getOutputVolume returning 0 in React Native

### DIFF
--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import {
   View,
   Text,
@@ -7,6 +7,8 @@ import {
   Keyboard,
   TextInput,
 } from "react-native";
+import { VolumeBar } from "./VolumeBar";
+import { FrequencyBands } from "./FrequencyBands";
 import {
   ConversationProvider,
   useConversationControls,
@@ -35,58 +37,8 @@ const ConversationScreen = () => {
     sendContextualUpdate,
     sendUserActivity,
     getId,
-    getInputVolume,
-    getOutputVolume,
-    getInputByteFrequencyData,
-    getOutputByteFrequencyData,
   } = useConversationControls();
   const isStarting = status === "connecting";
-
-  const [inputVolume, setInputVolume] = useState(0);
-  const [outputVolume, setOutputVolume] = useState(0);
-
-  const BAND_COUNT = 32;
-  const [inputBands, setInputBands] = useState<number[]>(() =>
-    Array(BAND_COUNT).fill(0)
-  );
-  const [outputBands, setOutputBands] = useState<number[]>(() =>
-    Array(BAND_COUNT).fill(0)
-  );
-
-  const downsample = useCallback(
-    (data: Uint8Array, bands: number): number[] => {
-      if (data.length === 0) return Array(bands).fill(0);
-      const step = data.length / bands;
-      const result: number[] = [];
-      for (let i = 0; i < bands; i++) {
-        const start = Math.floor(i * step);
-        const end = Math.floor((i + 1) * step);
-        let sum = 0;
-        for (let j = start; j < end; j++) sum += data[j];
-        result.push(sum / (end - start) / 255);
-      }
-      return result;
-    },
-    []
-  );
-
-  useEffect(() => {
-    if (status !== "connected") return;
-    const id = setInterval(() => {
-      setInputVolume(getInputVolume());
-      setOutputVolume(getOutputVolume());
-      setInputBands(downsample(getInputByteFrequencyData(), BAND_COUNT));
-      setOutputBands(downsample(getOutputByteFrequencyData(), BAND_COUNT));
-    }, 100);
-    return () => clearInterval(id);
-  }, [
-    status,
-    getInputVolume,
-    getOutputVolume,
-    getInputByteFrequencyData,
-    getOutputByteFrequencyData,
-    downsample,
-  ]);
 
   const handleSubmitText = () => {
     if (textInput.trim()) {
@@ -193,58 +145,10 @@ const ConversationScreen = () => {
       {/* Volume & Frequency Indicators */}
       {status === "connected" && (
         <View style={styles.volumeContainer}>
-          <Text style={styles.volumeText}>
-            Input: {(inputVolume * 100).toFixed(0)}%
-          </Text>
-          <View style={styles.volumeBarBackground}>
-            <View
-              style={[
-                styles.volumeBarFill,
-                { width: `${inputVolume * 100}%`, backgroundColor: "#3B82F6" },
-              ]}
-            />
-          </View>
-          <View style={styles.frequencyContainer}>
-            {inputBands.map((v, i) => (
-              <View key={i} style={styles.frequencyBarWrapper}>
-                <View
-                  style={[
-                    styles.frequencyBar,
-                    {
-                      height: `${Math.max(v * 100, 2)}%`,
-                      backgroundColor: "#3B82F6",
-                    },
-                  ]}
-                />
-              </View>
-            ))}
-          </View>
-          <Text style={styles.volumeText}>
-            Output: {(outputVolume * 100).toFixed(0)}%
-          </Text>
-          <View style={styles.volumeBarBackground}>
-            <View
-              style={[
-                styles.volumeBarFill,
-                { width: `${outputVolume * 100}%`, backgroundColor: "#8B5CF6" },
-              ]}
-            />
-          </View>
-          <View style={styles.frequencyContainer}>
-            {outputBands.map((v, i) => (
-              <View key={i} style={styles.frequencyBarWrapper}>
-                <View
-                  style={[
-                    styles.frequencyBar,
-                    {
-                      height: `${Math.max(v * 100, 2)}%`,
-                      backgroundColor: "#8B5CF6",
-                    },
-                  ]}
-                />
-              </View>
-            ))}
-          </View>
+          <VolumeBar label="Input" color="#3B82F6" direction="input" />
+          <FrequencyBands color="#3B82F6" direction="input" />
+          <VolumeBar label="Output" color="#8B5CF6" direction="output" />
+          <FrequencyBands color="#8B5CF6" direction="output" />
         </View>
       )}
 
@@ -621,39 +525,6 @@ const styles = StyleSheet.create({
     width: "100%",
     marginBottom: 16,
     gap: 4,
-  },
-  volumeText: {
-    fontSize: 12,
-    fontWeight: "500",
-    color: "#6B7280",
-  },
-  volumeBarBackground: {
-    height: 8,
-    backgroundColor: "#E5E7EB",
-    borderRadius: 4,
-    overflow: "hidden",
-  },
-  volumeBarFill: {
-    height: "100%",
-    borderRadius: 4,
-  },
-  frequencyContainer: {
-    flexDirection: "row",
-    height: 48,
-    gap: 2,
-    alignItems: "flex-end",
-    marginTop: 4,
-    marginBottom: 8,
-  },
-  frequencyBarWrapper: {
-    flex: 1,
-    height: "100%",
-    justifyContent: "flex-end",
-  },
-  frequencyBar: {
-    width: "100%",
-    borderRadius: 2,
-    minHeight: 1,
   },
   toggleControlContainer: {
     flexDirection: "row",

--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -20,7 +20,9 @@ import {
 const ConversationScreen = () => {
   const [textInput, setTextInput] = useState("");
   const [isTextOnly, setIsTextOnly] = useState(false);
-  const [connectionType, setConnectionType] = useState<"webrtc" | "websocket">("webrtc");
+  const [connectionType, setConnectionType] = useState<"webrtc" | "websocket">(
+    "webrtc"
+  );
 
   const { status, message: statusMessage } = useConversationStatus();
   const { isSpeaking } = useConversationMode();
@@ -35,20 +37,56 @@ const ConversationScreen = () => {
     getId,
     getInputVolume,
     getOutputVolume,
+    getInputByteFrequencyData,
+    getOutputByteFrequencyData,
   } = useConversationControls();
   const isStarting = status === "connecting";
 
   const [inputVolume, setInputVolume] = useState(0);
   const [outputVolume, setOutputVolume] = useState(0);
 
+  const BAND_COUNT = 32;
+  const [inputBands, setInputBands] = useState<number[]>(() =>
+    Array(BAND_COUNT).fill(0)
+  );
+  const [outputBands, setOutputBands] = useState<number[]>(() =>
+    Array(BAND_COUNT).fill(0)
+  );
+
+  const downsample = useCallback(
+    (data: Uint8Array, bands: number): number[] => {
+      if (data.length === 0) return Array(bands).fill(0);
+      const step = data.length / bands;
+      const result: number[] = [];
+      for (let i = 0; i < bands; i++) {
+        const start = Math.floor(i * step);
+        const end = Math.floor((i + 1) * step);
+        let sum = 0;
+        for (let j = start; j < end; j++) sum += data[j];
+        result.push(sum / (end - start) / 255);
+      }
+      return result;
+    },
+    []
+  );
+
   useEffect(() => {
     if (status !== "connected") return;
     const id = setInterval(() => {
       setInputVolume(getInputVolume());
       setOutputVolume(getOutputVolume());
+      setInputBands(downsample(getInputByteFrequencyData(), BAND_COUNT));
+      setOutputBands(downsample(getOutputByteFrequencyData(), BAND_COUNT));
     }, 100);
     return () => clearInterval(id);
-  }, [status, getInputVolume, getOutputVolume]);
+  }, [
+    status,
+    getInputVolume,
+    getOutputVolume,
+    getInputByteFrequencyData,
+    getOutputByteFrequencyData,
+    downsample,
+  ]);
 
   const handleSubmitText = () => {
     if (textInput.trim()) {
@@ -96,243 +134,266 @@ const ConversationScreen = () => {
     return s[0].toUpperCase() + s.slice(1);
   };
 
-  const canStart = (status === "disconnected" || status === "error") && !isStarting;
+  const canStart =
+    (status === "disconnected" || status === "error") && !isStarting;
   const canEnd = status === "connected";
 
   return (
     <View style={styles.container}>
-        <Text style={styles.title}>ElevenLabs React Native Example</Text>
-        <Text style={styles.subtitle}>
-          Remember to set the agentId in the code
-        </Text>
+      <Text style={styles.title}>ElevenLabs React Native Example</Text>
+      <Text style={styles.subtitle}>
+        Remember to set the agentId in the code
+      </Text>
 
-        <View style={styles.statusContainer}>
+      <View style={styles.statusContainer}>
+        <View
+          style={[
+            styles.statusDot,
+            { backgroundColor: getStatusColor(status) },
+          ]}
+        />
+        <Text style={styles.statusText}>{getStatusText(status)}</Text>
+      </View>
+
+      {/* Error Message */}
+      {status === "error" && statusMessage && (
+        <Text style={styles.errorText}>{statusMessage}</Text>
+      )}
+
+      {/* Conversation ID Display */}
+      {status === "connected" && (
+        <View style={styles.conversationIdContainer}>
+          <Text style={styles.conversationIdLabel}>Conversation ID:</Text>
+          <Text style={styles.conversationIdText}>{getId() || "N/A"}</Text>
+        </View>
+      )}
+
+      {/* Speaking Indicator */}
+      {status === "connected" && (
+        <View style={styles.speakingContainer}>
           <View
             style={[
-              styles.statusDot,
-              { backgroundColor: getStatusColor(status) },
+              styles.speakingDot,
+              {
+                backgroundColor: isSpeaking ? "#8B5CF6" : "#D1D5DB",
+              },
             ]}
           />
-          <Text style={styles.statusText}>{getStatusText(status)}</Text>
+          <Text
+            style={[
+              styles.speakingText,
+              { color: isSpeaking ? "#8B5CF6" : "#9CA3AF" },
+            ]}
+          >
+            {isSpeaking ? "AI Speaking" : "AI Listening"}
+          </Text>
         </View>
+      )}
 
-        {/* Error Message */}
-        {status === "error" && statusMessage && (
-          <Text style={styles.errorText}>{statusMessage}</Text>
-        )}
-
-        {/* Conversation ID Display */}
-        {status === "connected" && (
-          <View style={styles.conversationIdContainer}>
-            <Text style={styles.conversationIdLabel}>Conversation ID:</Text>
-            <Text style={styles.conversationIdText}>
-              {getId() || "N/A"}
-            </Text>
-          </View>
-        )}
-
-        {/* Speaking Indicator */}
-        {status === "connected" && (
-          <View style={styles.speakingContainer}>
+      {/* Volume & Frequency Indicators */}
+      {status === "connected" && (
+        <View style={styles.volumeContainer}>
+          <Text style={styles.volumeText}>
+            Input: {(inputVolume * 100).toFixed(0)}%
+          </Text>
+          <View style={styles.volumeBarBackground}>
             <View
               style={[
-                styles.speakingDot,
-                {
-                  backgroundColor: isSpeaking ? "#8B5CF6" : "#D1D5DB",
-                },
+                styles.volumeBarFill,
+                { width: `${inputVolume * 100}%`, backgroundColor: "#3B82F6" },
               ]}
             />
-            <Text
-              style={[
-                styles.speakingText,
-                { color: isSpeaking ? "#8B5CF6" : "#9CA3AF" },
-              ]}
-            >
-              {isSpeaking ? "AI Speaking" : "AI Listening"}
-            </Text>
           </View>
-        )}
-
-        {/* Volume Indicators */}
-        {status === "connected" && (
-          <View style={styles.volumeContainer}>
-            <Text style={styles.volumeText}>
-              Input: {(inputVolume * 100).toFixed(0)}%
-            </Text>
-            <View style={styles.volumeBarBackground}>
-              <View
-                style={[
-                  styles.volumeBarFill,
-                  { width: `${inputVolume * 100}%`, backgroundColor: "#3B82F6" },
-                ]}
-              />
-            </View>
-            <Text style={styles.volumeText}>
-              Output: {(outputVolume * 100).toFixed(0)}%
-            </Text>
-            <View style={styles.volumeBarBackground}>
-              <View
-                style={[
-                  styles.volumeBarFill,
-                  { width: `${outputVolume * 100}%`, backgroundColor: "#8B5CF6" },
-                ]}
-              />
-            </View>
+          <View style={styles.frequencyContainer}>
+            {inputBands.map((v, i) => (
+              <View key={i} style={styles.frequencyBarWrapper}>
+                <View
+                  style={[
+                    styles.frequencyBar,
+                    {
+                      height: `${Math.max(v * 100, 2)}%`,
+                      backgroundColor: "#3B82F6",
+                    },
+                  ]}
+                />
+              </View>
+            ))}
           </View>
-        )}
-
-        {/* Connection Type & Text Only Toggles */}
-        {status === "disconnected" && (
-          <View style={styles.toggleControlContainer}>
-            <TouchableOpacity
+          <Text style={styles.volumeText}>
+            Output: {(outputVolume * 100).toFixed(0)}%
+          </Text>
+          <View style={styles.volumeBarBackground}>
+            <View
               style={[
-                styles.button,
-                styles.toggleButton,
-                connectionType === "websocket"
-                  ? styles.toggleButtonActive
-                  : styles.toggleButtonPassive,
+                styles.volumeBarFill,
+                { width: `${outputVolume * 100}%`, backgroundColor: "#8B5CF6" },
               ]}
-              onPress={() =>
-                setConnectionType((v) =>
-                  v === "webrtc" ? "websocket" : "webrtc"
-                )
-              }
-            >
-              <Text style={styles.buttonText}>
-                {connectionType === "webrtc" ? "WebRTC" : "WebSocket"}
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                styles.toggleButton,
-                isTextOnly
-                  ? styles.toggleButtonActive
-                  : styles.toggleButtonPassive,
-              ]}
-              onPress={() => setIsTextOnly((v) => !v)}
-            >
-              <Text style={styles.buttonText}>
-                {isTextOnly ? "Text only" : "Enable text only"}
-              </Text>
-            </TouchableOpacity>
+            />
           </View>
-        )}
+          <View style={styles.frequencyContainer}>
+            {outputBands.map((v, i) => (
+              <View key={i} style={styles.frequencyBarWrapper}>
+                <View
+                  style={[
+                    styles.frequencyBar,
+                    {
+                      height: `${Math.max(v * 100, 2)}%`,
+                      backgroundColor: "#8B5CF6",
+                    },
+                  ]}
+                />
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
 
-        <View style={styles.buttonContainer}>
+      {/* Connection Type & Text Only Toggles */}
+      {status === "disconnected" && (
+        <View style={styles.toggleControlContainer}>
           <TouchableOpacity
             style={[
               styles.button,
-              styles.startButton,
-              !canStart && styles.disabledButton,
+              styles.toggleButton,
+              connectionType === "websocket"
+                ? styles.toggleButtonActive
+                : styles.toggleButtonPassive,
             ]}
-            onPress={startConversation}
-            disabled={!canStart}
+            onPress={() =>
+              setConnectionType(v => (v === "webrtc" ? "websocket" : "webrtc"))
+            }
           >
             <Text style={styles.buttonText}>
-              {isStarting ? "Starting..." : "Start Conversation"}
+              {connectionType === "webrtc" ? "WebRTC" : "WebSocket"}
             </Text>
           </TouchableOpacity>
-
           <TouchableOpacity
             style={[
               styles.button,
-              styles.endButton,
-              !canEnd && styles.disabledButton,
+              styles.toggleButton,
+              isTextOnly
+                ? styles.toggleButtonActive
+                : styles.toggleButtonPassive,
             ]}
-            onPress={endConversation}
-            disabled={!canEnd}
+            onPress={() => setIsTextOnly(v => !v)}
           >
-            <Text style={styles.buttonText}>End Conversation</Text>
+            <Text style={styles.buttonText}>
+              {isTextOnly ? "Text only" : "Enable text only"}
+            </Text>
           </TouchableOpacity>
         </View>
+      )}
 
-        {/* Microphone Controls */}
-        {status === "connected" && (
-          <View style={styles.toggleControlContainer}>
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity
+          style={[
+            styles.button,
+            styles.startButton,
+            !canStart && styles.disabledButton,
+          ]}
+          onPress={startConversation}
+          disabled={!canStart}
+        >
+          <Text style={styles.buttonText}>
+            {isStarting ? "Starting..." : "Start Conversation"}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.button,
+            styles.endButton,
+            !canEnd && styles.disabledButton,
+          ]}
+          onPress={endConversation}
+          disabled={!canEnd}
+        >
+          <Text style={styles.buttonText}>End Conversation</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Microphone Controls */}
+      {status === "connected" && (
+        <View style={styles.toggleControlContainer}>
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.toggleButton,
+              isMuted ? styles.toggleButtonActive : styles.toggleButtonPassive,
+            ]}
+            onPress={() => setMuted(!isMuted)}
+          >
+            <Text style={styles.buttonText}>{isMuted ? "Unmute" : "Mute"}</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Feedback Buttons */}
+      {status === "connected" && canSendFeedback && (
+        <View style={styles.feedbackContainer}>
+          <Text style={styles.feedbackLabel}>How was that response?</Text>
+          <View style={styles.feedbackButtons}>
             <TouchableOpacity
-              style={[
-                styles.button,
-                styles.toggleButton,
-                isMuted
-                  ? styles.toggleButtonActive
-                  : styles.toggleButtonPassive,
-              ]}
-              onPress={() => setMuted(!isMuted)}
+              style={[styles.button, styles.likeButton]}
+              onPress={() => sendFeedback(true)}
             >
-              <Text style={styles.buttonText}>
-                {isMuted ? "Unmute" : "Mute"}
-              </Text>
+              <Text style={styles.buttonText}>Like</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.button, styles.dislikeButton]}
+              onPress={() => sendFeedback(false)}
+            >
+              <Text style={styles.buttonText}>Dislike</Text>
             </TouchableOpacity>
           </View>
-        )}
+        </View>
+      )}
 
-        {/* Feedback Buttons */}
-        {status === "connected" && canSendFeedback && (
-          <View style={styles.feedbackContainer}>
-            <Text style={styles.feedbackLabel}>How was that response?</Text>
-            <View style={styles.feedbackButtons}>
-              <TouchableOpacity
-                style={[styles.button, styles.likeButton]}
-                onPress={() => sendFeedback(true)}
-              >
-                <Text style={styles.buttonText}>Like</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.button, styles.dislikeButton]}
-                onPress={() => sendFeedback(false)}
-              >
-                <Text style={styles.buttonText}>Dislike</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        )}
-
-        {/* Text Input and Messaging */}
-        {status === "connected" && (
-          <View style={styles.messagingContainer}>
-            <Text style={styles.messagingLabel}>Send Text Message</Text>
-            <TextInput
-              style={styles.textInput}
-              value={textInput}
-              onChangeText={(text) => {
-                setTextInput(text);
-                // Prevent agent from interrupting while user is typing
-                if (text.length > 0) {
-                  sendUserActivity();
+      {/* Text Input and Messaging */}
+      {status === "connected" && (
+        <View style={styles.messagingContainer}>
+          <Text style={styles.messagingLabel}>Send Text Message</Text>
+          <TextInput
+            style={styles.textInput}
+            value={textInput}
+            onChangeText={text => {
+              setTextInput(text);
+              // Prevent agent from interrupting while user is typing
+              if (text.length > 0) {
+                sendUserActivity();
+              }
+            }}
+            placeholder="Type your message or context... (Press Enter to send)"
+            multiline
+            onSubmitEditing={handleSubmitText}
+            returnKeyType="send"
+            blurOnSubmit={true}
+          />
+          <View style={styles.messageButtons}>
+            <TouchableOpacity
+              style={[styles.button, styles.messageButton]}
+              onPress={handleSubmitText}
+              disabled={!textInput.trim()}
+            >
+              <Text style={styles.buttonText}>Send Message</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.button, styles.contextButton]}
+              onPress={() => {
+                if (textInput.trim()) {
+                  sendContextualUpdate(textInput.trim());
+                  setTextInput("");
+                  Keyboard.dismiss();
                 }
               }}
-              placeholder="Type your message or context... (Press Enter to send)"
-              multiline
-              onSubmitEditing={handleSubmitText}
-              returnKeyType="send"
-              blurOnSubmit={true}
-            />
-            <View style={styles.messageButtons}>
-              <TouchableOpacity
-                style={[styles.button, styles.messageButton]}
-                onPress={handleSubmitText}
-                disabled={!textInput.trim()}
-              >
-                <Text style={styles.buttonText}>Send Message</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.button, styles.contextButton]}
-                onPress={() => {
-                  if (textInput.trim()) {
-                    sendContextualUpdate(textInput.trim());
-                    setTextInput("");
-                    Keyboard.dismiss();
-                  }
-                }}
-                disabled={!textInput.trim()}
-              >
-                <Text style={styles.buttonText}>Send Context</Text>
-              </TouchableOpacity>
-            </View>
+              disabled={!textInput.trim()}
+            >
+              <Text style={styles.buttonText}>Send Context</Text>
+            </TouchableOpacity>
           </View>
-        )}
-      </View>
+        </View>
+      )}
+    </View>
   );
 };
 
@@ -342,7 +403,7 @@ export default function App() {
       onConnect={({ conversationId }) => {
         console.log("Connected to conversation", conversationId);
       }}
-      onDisconnect={(details) => {
+      onDisconnect={details => {
         console.log("Disconnected from conversation", details);
       }}
       onError={(message, context) => {
@@ -364,35 +425,32 @@ export default function App() {
         // Commented out as it's quite noisy
         // console.log(`VAD Score: ${vadScore}`);
       }}
-      onInterruption={(event) => {
+      onInterruption={event => {
         console.log("Interruption detected:", event);
       }}
-      onMCPToolCall={(event) => {
+      onMCPToolCall={event => {
         console.log("MCP Tool Call:", event);
       }}
-      onMCPConnectionStatus={(event) => {
+      onMCPConnectionStatus={event => {
         console.log("MCP Connection Status:", event);
       }}
-      onAgentToolRequest={(event) => {
+      onAgentToolRequest={event => {
         console.log("Agent Tool Request:", event);
       }}
-      onAgentToolResponse={(event) => {
+      onAgentToolResponse={event => {
         console.log("Agent Tool Response:", event);
       }}
-      onAgentChatResponsePart={(part) => {
+      onAgentChatResponsePart={part => {
         console.log("Agent Response Part:", part);
       }}
-      onAudioAlignment={(alignment) => {
+      onAudioAlignment={alignment => {
         console.log("Audio Alignment:", {
           chars: alignment.chars.join(""),
           charCount: alignment.chars.length,
-          totalDuration: alignment.char_durations_ms.reduce(
-            (a, b) => a + b,
-            0
-          ),
+          totalDuration: alignment.char_durations_ms.reduce((a, b) => a + b, 0),
         });
       }}
-      onDebug={(data) => {
+      onDebug={data => {
         console.log("Debug:", data);
       }}
     >
@@ -578,6 +636,24 @@ const styles = StyleSheet.create({
   volumeBarFill: {
     height: "100%",
     borderRadius: 4,
+  },
+  frequencyContainer: {
+    flexDirection: "row",
+    height: 48,
+    gap: 2,
+    alignItems: "flex-end",
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  frequencyBarWrapper: {
+    flex: 1,
+    height: "100%",
+    justifyContent: "flex-end",
+  },
+  frequencyBar: {
+    width: "100%",
+    borderRadius: 2,
+    minHeight: 1,
   },
   toggleControlContainer: {
     flexDirection: "row",

--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   StyleSheet,
+  ScrollView,
   TouchableOpacity,
   Keyboard,
   TextInput,
@@ -91,7 +92,10 @@ const ConversationScreen = () => {
   const canEnd = status === "connected";
 
   return (
-    <View style={styles.container}>
+    <ScrollView
+      contentContainerStyle={styles.container}
+      keyboardShouldPersistTaps="handled"
+    >
       <Text style={styles.title}>ElevenLabs React Native Example</Text>
       <Text style={styles.subtitle}>
         Remember to set the agentId in the code
@@ -297,7 +301,7 @@ const ConversationScreen = () => {
           </View>
         </View>
       )}
-    </View>
+    </ScrollView>
   );
 };
 
@@ -365,11 +369,12 @@ export default function App() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     backgroundColor: "#F3F4F6",
     padding: 20,
+    paddingVertical: 60,
   },
   title: {
     fontSize: 24,

--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -33,8 +33,22 @@ const ConversationScreen = () => {
     sendContextualUpdate,
     sendUserActivity,
     getId,
+    getInputVolume,
+    getOutputVolume,
   } = useConversationControls();
   const isStarting = status === "connecting";
+
+  const [inputVolume, setInputVolume] = useState(0);
+  const [outputVolume, setOutputVolume] = useState(0);
+
+  useEffect(() => {
+    if (status !== "connected") return;
+    const id = setInterval(() => {
+      setInputVolume(getInputVolume());
+      setOutputVolume(getOutputVolume());
+    }, 100);
+    return () => clearInterval(id);
+  }, [status, getInputVolume, getOutputVolume]);
 
   const handleSubmitText = () => {
     if (textInput.trim()) {
@@ -136,6 +150,34 @@ const ConversationScreen = () => {
             >
               {isSpeaking ? "AI Speaking" : "AI Listening"}
             </Text>
+          </View>
+        )}
+
+        {/* Volume Indicators */}
+        {status === "connected" && (
+          <View style={styles.volumeContainer}>
+            <Text style={styles.volumeText}>
+              Input: {(inputVolume * 100).toFixed(0)}%
+            </Text>
+            <View style={styles.volumeBarBackground}>
+              <View
+                style={[
+                  styles.volumeBarFill,
+                  { width: `${inputVolume * 100}%`, backgroundColor: "#3B82F6" },
+                ]}
+              />
+            </View>
+            <Text style={styles.volumeText}>
+              Output: {(outputVolume * 100).toFixed(0)}%
+            </Text>
+            <View style={styles.volumeBarBackground}>
+              <View
+                style={[
+                  styles.volumeBarFill,
+                  { width: `${outputVolume * 100}%`, backgroundColor: "#8B5CF6" },
+                ]}
+              />
+            </View>
           </View>
         )}
 
@@ -516,6 +558,26 @@ const styles = StyleSheet.create({
   contextButton: {
     backgroundColor: "#4F46E5",
     flex: 1,
+  },
+  volumeContainer: {
+    width: "100%",
+    marginBottom: 16,
+    gap: 4,
+  },
+  volumeText: {
+    fontSize: 12,
+    fontWeight: "500",
+    color: "#6B7280",
+  },
+  volumeBarBackground: {
+    height: 8,
+    backgroundColor: "#E5E7EB",
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  volumeBarFill: {
+    height: "100%",
+    borderRadius: 4,
   },
   toggleControlContainer: {
     flexDirection: "row",

--- a/examples/react-native-expo/FrequencyBands.tsx
+++ b/examples/react-native-expo/FrequencyBands.tsx
@@ -1,0 +1,87 @@
+import React, { useState, useEffect, useRef } from "react";
+import { View, StyleSheet } from "react-native";
+import { useConversationControls } from "@elevenlabs/react-native";
+
+const BAND_COUNT = 32;
+const POLL_INTERVAL_MS = 100;
+
+function downsample(data: Uint8Array, bands: number): number[] {
+  if (data.length === 0) return Array(bands).fill(0);
+  const step = data.length / bands;
+  const result: number[] = [];
+  for (let i = 0; i < bands; i++) {
+    const start = Math.floor(i * step);
+    const end = Math.floor((i + 1) * step);
+    let sum = 0;
+    for (let j = start; j < end; j++) sum += data[j];
+    result.push(sum / (end - start) / 255);
+  }
+  return result;
+}
+
+type FrequencyBandsProps = {
+  color: string;
+  direction: "input" | "output";
+};
+
+export function FrequencyBands({ color, direction }: FrequencyBandsProps) {
+  const { getInputByteFrequencyData, getOutputByteFrequencyData } =
+    useConversationControls();
+  const getFreq =
+    direction === "input"
+      ? getInputByteFrequencyData
+      : getOutputByteFrequencyData;
+
+  const [bands, setBands] = useState<number[]>(() =>
+    Array(BAND_COUNT).fill(0)
+  );
+
+  const getFreqRef = useRef(getFreq);
+  getFreqRef.current = getFreq;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setBands(downsample(getFreqRef.current(), BAND_COUNT));
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {bands.map((v, i) => (
+        <View key={i} style={styles.barWrapper}>
+          <View
+            style={[
+              styles.bar,
+              {
+                height: `${Math.max(v * 100, 2)}%`,
+                backgroundColor: color,
+              },
+            ]}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    height: 48,
+    gap: 2,
+    alignItems: "flex-end",
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  barWrapper: {
+    flex: 1,
+    height: "100%",
+    justifyContent: "flex-end",
+  },
+  bar: {
+    width: "100%",
+    borderRadius: 2,
+    minHeight: 1,
+  },
+});

--- a/examples/react-native-expo/VolumeBar.tsx
+++ b/examples/react-native-expo/VolumeBar.tsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect, useRef } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useConversationControls } from "@elevenlabs/react-native";
+
+const POLL_INTERVAL_MS = 100;
+
+type VolumeBarProps = {
+  label: string;
+  color: string;
+  direction: "input" | "output";
+};
+
+export function VolumeBar({ label, color, direction }: VolumeBarProps) {
+  const { getInputVolume, getOutputVolume } = useConversationControls();
+  const getVolume = direction === "input" ? getInputVolume : getOutputVolume;
+
+  const [volume, setVolume] = useState(0);
+
+  const getVolumeRef = useRef(getVolume);
+  getVolumeRef.current = getVolume;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setVolume(getVolumeRef.current());
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <>
+      <Text style={styles.label}>
+        {label}: {(volume * 100).toFixed(0)}%
+      </Text>
+      <View style={styles.barBackground}>
+        <View
+          style={[
+            styles.barFill,
+            { width: `${volume * 100}%`, backgroundColor: color },
+          ]}
+        />
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 12,
+    fontWeight: "500",
+    color: "#6B7280",
+  },
+  barBackground: {
+    height: 8,
+    backgroundColor: "#E5E7EB",
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  barFill: {
+    height: "100%",
+    borderRadius: 4,
+  },
+});

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -500,7 +500,15 @@ export abstract class BaseConversation {
 
   public abstract setVolume(options: { volume: number }): void;
   public abstract setMicMuted(isMuted: boolean): void;
+  /**
+   * Returns byte frequency data (0-255) for the input audio, focused on the
+   * human voice range (100-8000 Hz).
+   */
   public abstract getInputByteFrequencyData(): Uint8Array;
+  /**
+   * Returns byte frequency data (0-255) for the output audio, focused on the
+   * human voice range (100-8000 Hz).
+   */
   public abstract getOutputByteFrequencyData(): Uint8Array;
   public abstract getInputVolume(): number;
   public abstract getOutputVolume(): number;

--- a/packages/client/src/InputController.ts
+++ b/packages/client/src/InputController.ts
@@ -16,6 +16,10 @@ export interface InputController {
 
   /** Returns current audio level as a scalar 0–1. */
   getVolume(): number;
-  /** Writes byte frequency data into the provided buffer. */
+  /**
+   * Writes byte frequency data (0-255) into the provided buffer, focused on
+   * the human voice range (100-8000 Hz). The buffer length determines the
+   * number of frequency bands returned.
+   */
   getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void;
 }

--- a/packages/client/src/InputController.ts
+++ b/packages/client/src/InputController.ts
@@ -11,7 +11,11 @@ export interface InputController {
   setMuted(isMuted: boolean): Promise<void>;
   isMuted(): boolean;
 
-  /** @deprecated Use getVolume() or getByteFrequencyData() instead. */
+  /**
+   * @deprecated AnalyserNode is a web-only API and will not work on all
+   * platforms. Use {@link getVolume} for a scalar audio level (0-1) or
+   * {@link getByteFrequencyData} for frequency band data instead.
+   */
   getAnalyser(): AnalyserNode | undefined;
 
   /** Returns current audio level as a scalar 0–1. */

--- a/packages/client/src/InputController.ts
+++ b/packages/client/src/InputController.ts
@@ -10,5 +10,12 @@ export interface InputController {
   setDevice(config?: Partial<FormatConfig> & InputDeviceConfig): Promise<void>;
   setMuted(isMuted: boolean): Promise<void>;
   isMuted(): boolean;
+
+  /** @deprecated Use getVolume() or getByteFrequencyData() instead. */
   getAnalyser(): AnalyserNode | undefined;
+
+  /** Returns current audio level as a scalar 0–1. */
+  getVolume(): number;
+  /** Writes byte frequency data into the provided buffer. */
+  getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void;
 }

--- a/packages/client/src/OutputController.ts
+++ b/packages/client/src/OutputController.ts
@@ -9,5 +9,12 @@ export interface OutputController {
   setDevice(config?: Partial<FormatConfig> & OutputDeviceConfig): Promise<void>;
   setVolume(volume: number): void;
   interrupt(resetDuration?: number): void;
+
+  /** @deprecated Use getVolume() or getByteFrequencyData() instead. */
   getAnalyser(): AnalyserNode | undefined;
+
+  /** Returns current audio level as a scalar 0–1. */
+  getVolume(): number;
+  /** Writes byte frequency data into the provided buffer. */
+  getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void;
 }

--- a/packages/client/src/OutputController.ts
+++ b/packages/client/src/OutputController.ts
@@ -10,7 +10,11 @@ export interface OutputController {
   setVolume(volume: number): void;
   interrupt(resetDuration?: number): void;
 
-  /** @deprecated Use getVolume() or getByteFrequencyData() instead. */
+  /**
+   * @deprecated AnalyserNode is a web-only API and will not work on all
+   * platforms. Use {@link getVolume} for a scalar audio level (0-1) or
+   * {@link getByteFrequencyData} for frequency band data instead.
+   */
   getAnalyser(): AnalyserNode | undefined;
 
   /** Returns current audio level as a scalar 0–1. */

--- a/packages/client/src/OutputController.ts
+++ b/packages/client/src/OutputController.ts
@@ -15,6 +15,10 @@ export interface OutputController {
 
   /** Returns current audio level as a scalar 0–1. */
   getVolume(): number;
-  /** Writes byte frequency data into the provided buffer. */
+  /**
+   * Writes byte frequency data (0-255) into the provided buffer, focused on
+   * the human voice range (100-8000 Hz). The buffer length determines the
+   * number of frequency bands returned.
+   */
   getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void;
 }

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -5,7 +5,6 @@ import type {
   PlaybackListener,
 } from "./utils/output.js";
 import type { BaseConnection, FormatConfig } from "./utils/BaseConnection.js";
-import { WebRTCConnection } from "./utils/WebRTCConnection.js";
 import type { AgentAudioEvent, InterruptionEvent } from "./utils/events.js";
 import { applyDelay } from "./utils/applyDelay.js";
 import {
@@ -16,8 +15,6 @@ import {
 import type { InputController } from "./InputController.js";
 import type { OutputController } from "./OutputController.js";
 import { setupStrategy } from "./platform/VoiceSessionSetup.js";
-
-const EMPTY_FREQUENCY_DATA = new Uint8Array(0) as Uint8Array<ArrayBuffer>;
 
 export class VoiceConversation extends BaseConversation {
   readonly type = "voice";
@@ -187,21 +184,7 @@ export class VoiceConversation extends BaseConversation {
     }
   }
 
-  private calculateVolume = (frequencyData: Uint8Array) => {
-    if (frequencyData.length === 0) {
-      return 0;
-    }
-
-    // TODO: Currently this averages all frequencies, but we should probably
-    // bias towards the frequencies that are more typical for human voice
-    let volume = 0;
-    for (let i = 0; i < frequencyData.length; i++) {
-      volume += frequencyData[i] / 255;
-    }
-    volume /= frequencyData.length;
-
-    return volume < 0 ? 0 : volume > 1 ? 1 : volume;
-  };
+  private static readonly FREQUENCY_BIN_COUNT = 1024;
 
   public setMicMuted(isMuted: boolean) {
     this.input.setMuted(isMuted).catch(error => {
@@ -210,46 +193,27 @@ export class VoiceConversation extends BaseConversation {
   }
 
   public getInputByteFrequencyData(): Uint8Array<ArrayBuffer> {
-    const analyser = this.input.getAnalyser();
-    if (!analyser) {
-      return EMPTY_FREQUENCY_DATA;
-    }
     this.inputFrequencyData ??= new Uint8Array(
-      analyser.frequencyBinCount
+      VoiceConversation.FREQUENCY_BIN_COUNT
     ) as Uint8Array<ArrayBuffer>;
-    analyser.getByteFrequencyData(this.inputFrequencyData);
+    this.input.getByteFrequencyData(this.inputFrequencyData);
     return this.inputFrequencyData;
   }
 
   public getOutputByteFrequencyData(): Uint8Array<ArrayBuffer> {
-    // Use WebRTC analyser if available
-    if (this.connection instanceof WebRTCConnection) {
-      const webrtcData = this.connection.getOutputByteFrequencyData();
-      if (webrtcData) {
-        return webrtcData as Uint8Array<ArrayBuffer>;
-      }
-      // Fallback to empty array if WebRTC analyser not ready
-      return new Uint8Array(1024) as Uint8Array<ArrayBuffer>;
-    }
-
-    const analyser = this.output.getAnalyser();
-    if (!analyser) {
-      return EMPTY_FREQUENCY_DATA;
-    }
-
     this.outputFrequencyData ??= new Uint8Array(
-      analyser.frequencyBinCount
+      VoiceConversation.FREQUENCY_BIN_COUNT
     ) as Uint8Array<ArrayBuffer>;
-    analyser.getByteFrequencyData(this.outputFrequencyData);
+    this.output.getByteFrequencyData(this.outputFrequencyData);
     return this.outputFrequencyData;
   }
 
-  public getInputVolume() {
-    return this.calculateVolume(this.getInputByteFrequencyData());
+  public getInputVolume(): number {
+    return this.input.getVolume();
   }
 
-  public getOutputVolume() {
-    return this.calculateVolume(this.getOutputByteFrequencyData());
+  public getOutputVolume(): number {
+    return this.output.getVolume();
   }
 
   public async changeInputDevice({

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -36,6 +36,7 @@ export type {
 export { createConnection } from "./utils/ConnectionFactory.js";
 export { WebSocketConnection } from "./utils/WebSocketConnection.js";
 export { WebRTCConnection } from "./utils/WebRTCConnection.js";
+export type { VolumeProvider } from "./utils/volumeProvider.js";
 export { postOverallFeedback } from "./utils/postOverallFeedback.js";
 export { SessionConnectionError } from "./utils/errors.js";
 export type { Location } from "./utils/location.js";

--- a/packages/client/src/internal.ts
+++ b/packages/client/src/internal.ts
@@ -15,3 +15,7 @@ export type {
   VoiceSessionSetupStrategy,
   VoiceSessionSetupResult,
 } from "./platform/VoiceSessionSetup.js";
+export {
+  MIN_VOICE_FREQUENCY,
+  MAX_VOICE_FREQUENCY,
+} from "./utils/volumeProvider.js";

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -196,6 +196,62 @@ describe("WebRTCConnection", () => {
     connection.close();
   });
 
+  it("sets isMuted and zeros volume even when track.mute() throws", async () => {
+    const mockRoom = new Room() as any;
+
+    const mockTrack = {
+      mediaStreamTrack: { id: "mic-track", kind: "audio" },
+      mute: vi.fn(() => Promise.resolve()),
+      unmute: vi.fn(() => Promise.resolve()),
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockReturnValue({ track: mockTrack });
+
+    // Set up room event mocks so create() resolves
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    // Simulate a native volume provider (like React Native)
+    connection.setInputVolumeProvider({
+      getVolume: () => 0.75,
+      getByteFrequencyData: (buf: Uint8Array) => buf.fill(200),
+    });
+    expect(connection.input.getVolume()).toBe(0.75);
+
+    // Now make both track.mute() and setMicrophoneEnabled throw
+    // (simulates RN environment where these operations may not be supported)
+    mockTrack.mute.mockRejectedValueOnce(new Error("mute unsupported"));
+    (
+      mockRoom.localParticipant.setMicrophoneEnabled as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("setMicrophoneEnabled unsupported"));
+
+    // Mute — even though track.mute() and setMicrophoneEnabled both throw,
+    // isMuted should already be set and volume should return 0
+    await connection.input.setMuted(true).catch(() => {});
+    expect(connection.input.isMuted()).toBe(true);
+    expect(connection.input.getVolume()).toBe(0);
+
+    connection.close();
+  });
+
   it.each([
     { textOnly: true, shouldEnableMic: false },
     { textOnly: false, shouldEnableMic: true },

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -19,6 +19,9 @@ vi.mock("livekit-client", () => {
     }),
     publishData: vi.fn(() => Promise.resolve()),
     audioTrackPublications: new Map(),
+    getTrackPublication: vi.fn(),
+    unpublishTrack: vi.fn(() => Promise.resolve()),
+    publishTrack: vi.fn(() => Promise.resolve()),
   };
 
   const mockRoom = {
@@ -56,7 +59,7 @@ vi.mock("livekit-client", () => {
 });
 
 import { WebRTCConnection } from "./WebRTCConnection.js";
-import { Room } from "livekit-client";
+import { Room, createLocalAudioTrack } from "livekit-client";
 
 describe("WebRTCConnection", () => {
   beforeEach(() => {
@@ -64,6 +67,65 @@ describe("WebRTCConnection", () => {
     (globalThis as Record<string, unknown>).__mockCalls__ = {
       setMicrophoneEnabled: [],
     };
+  });
+
+  it("replaces the input volume provider when switching input device", async () => {
+    const mockRoom = new Room() as any;
+
+    // Mock track returned by getTrackPublication (the "old" mic track)
+    const oldMockTrack = {
+      mediaStreamTrack: { id: "old-track", kind: "audio" },
+      stop: vi.fn(() => Promise.resolve()),
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockReturnValue({ track: oldMockTrack });
+
+    // Mock createLocalAudioTrack to return a "new" track after device switch
+    const newMockTrack = {
+      mediaStreamTrack: { id: "new-track", kind: "audio" },
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValue(
+      newMockTrack
+    );
+
+    // Set up room event mocks so create() resolves
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    // Simulate a working volume provider (as if set by the web analyser or RN layer)
+    connection.setInputVolumeProvider({
+      getVolume: () => 0.42,
+      getByteFrequencyData: () => {},
+    });
+    expect(connection.input.getVolume()).toBe(0.42);
+
+    // Switch input device
+    await connection.setAudioInputDevice("new-device-id");
+
+    // After fix: the stale volume provider should have been replaced.
+    // In the test env AudioContext setup fails with mock tracks, so
+    // NO_VOLUME (0) is used — either way, 0.42 must not persist.
+    expect(connection.input.getVolume()).not.toBe(0.42);
+
+    connection.close();
   });
 
   it.each([

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -69,7 +69,7 @@ describe("WebRTCConnection", () => {
     };
   });
 
-  it("replaces the input volume provider when switching input device", async () => {
+  it("preserves external volume provider when AudioContext is unavailable", async () => {
     const mockRoom = new Room() as any;
 
     // Mock track returned by getTrackPublication (the "old" mic track)
@@ -110,20 +110,18 @@ describe("WebRTCConnection", () => {
       connectionType: "webrtc",
     });
 
-    // Simulate a working volume provider (as if set by the web analyser or RN layer)
+    // Simulate an external volume provider (e.g. React Native's native layer)
     connection.setInputVolumeProvider({
       getVolume: () => 0.42,
       getByteFrequencyData: () => {},
     });
     expect(connection.input.getVolume()).toBe(0.42);
 
-    // Switch input device
+    // Switch input device — AudioContext will fail with mock tracks (as on RN),
+    // so the external provider should be preserved rather than clobbered.
     await connection.setAudioInputDevice("new-device-id");
 
-    // After fix: the stale volume provider should have been replaced.
-    // In the test env AudioContext setup fails with mock tracks, so
-    // NO_VOLUME (0) is used — either way, 0.42 must not persist.
-    expect(connection.input.getVolume()).not.toBe(0.42);
+    expect(connection.input.getVolume()).toBe(0.42);
 
     connection.close();
   });

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -64,6 +64,7 @@ import { Room, createLocalAudioTrack } from "livekit-client";
 describe("WebRTCConnection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
     (globalThis as Record<string, unknown>).__mockCalls__ = {
       setMicrophoneEnabled: [],
     };
@@ -122,6 +123,75 @@ describe("WebRTCConnection", () => {
     await connection.setAudioInputDevice("new-device-id");
 
     expect(connection.input.getVolume()).toBe(0.42);
+
+    connection.close();
+  });
+
+  it("reconnects input analyser after unmuting", async () => {
+    const mockRoom = new Room() as any;
+
+    const mockMediaStreamTrack = { id: "mic-track", kind: "audio" };
+    const mockTrack = {
+      mediaStreamTrack: mockMediaStreamTrack,
+      mute: vi.fn(() => Promise.resolve()),
+      unmute: vi.fn(() => Promise.resolve()),
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockReturnValue({ track: mockTrack });
+
+    // Set up room event mocks so create() resolves
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    // Mock AudioContext so setupInputAnalyser succeeds
+    const mockAnalyser = {
+      frequencyBinCount: 128,
+      getByteFrequencyData: vi.fn(),
+      getFloatTimeDomainData: vi.fn(),
+    };
+    const mockSource = { connect: vi.fn() };
+    const MockAudioContext = vi.fn(() => ({
+      createAnalyser: vi.fn(() => mockAnalyser),
+      createMediaStreamSource: vi.fn(() => mockSource),
+      close: vi.fn(() => Promise.resolve()),
+      sampleRate: 44100,
+    }));
+    vi.stubGlobal("AudioContext", MockAudioContext);
+    vi.stubGlobal(
+      "MediaStream",
+      vi.fn((tracks: unknown[]) => ({ getTracks: () => tracks }))
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    // Initial setup during create() may call AudioContext
+    const callsBeforeMute = MockAudioContext.mock.calls.length;
+
+    // Mute — should NOT reconnect analyser
+    await connection.input.setMuted(true);
+    expect(MockAudioContext.mock.calls.length).toBe(callsBeforeMute);
+    expect(connection.input.isMuted()).toBe(true);
+
+    // Unmute — should reconnect analyser with the current track
+    await connection.input.setMuted(false);
+    expect(MockAudioContext.mock.calls.length).toBe(callsBeforeMute + 1);
+    expect(connection.input.isMuted()).toBe(false);
 
     connection.close();
   });

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -117,6 +117,10 @@ export class WebRTCConnection extends BaseConnection {
         return;
       }
 
+      // Set immediately so volume/frequency indicators reflect the muted
+      // state even if the underlying track operation fails (e.g. on RN).
+      this._isMuted = isMuted;
+
       // Get the microphone track publication
       const micTrackPublication =
         this.room.localParticipant.getTrackPublication(Track.Source.Microphone);
@@ -137,8 +141,6 @@ export class WebRTCConnection extends BaseConnection {
         // No track found, use participant-level control directly
         await this.room.localParticipant.setMicrophoneEnabled(!isMuted);
       }
-
-      this._isMuted = isMuted;
 
       // After unmuting, reconnect the input analyser because LiveKit may
       // have replaced the underlying MediaStreamTrack during mute/unmute.

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -30,6 +30,11 @@ import type {
   OutputController,
   OutputDeviceConfig,
 } from "../OutputController.js";
+import {
+  type VolumeProvider,
+  NO_VOLUME,
+  createAnalyserVolumeProvider,
+} from "./volumeProvider.js";
 
 const DEFAULT_LIVEKIT_WS_URL = "wss://livekit.rtc.elevenlabs.io";
 const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
@@ -55,8 +60,12 @@ export class WebRTCConnection extends BaseConnection {
   private audioElements: HTMLAudioElement[] = [];
   private outputDeviceId: string | null = null;
 
+  private inputAnalyser: AnalyserNode | null = null;
+  private inputAudioContext: AudioContext | null = null;
+  private inputVolumeProvider: VolumeProvider = NO_VOLUME;
+
   private outputAnalyser: AnalyserNode | null = null;
-  private outputFrequencyData: Uint8Array<ArrayBuffer> | null = null;
+  private outputVolumeProvider: VolumeProvider = NO_VOLUME;
 
   // InputController state
   private _isMuted = false;
@@ -132,7 +141,11 @@ export class WebRTCConnection extends BaseConnection {
       this._isMuted = isMuted;
     },
     isMuted: () => this._isMuted,
-    getAnalyser: () => undefined, // WebRTC doesn't provide input analyser
+    getAnalyser: () => this.inputAnalyser ?? undefined,
+    getVolume: () => this.inputVolumeProvider.getVolume(),
+    getByteFrequencyData: (buffer: Uint8Array<ArrayBuffer>) => {
+      this.inputVolumeProvider.getByteFrequencyData(buffer);
+    },
   };
 
   // OutputController interface exposed as a property
@@ -166,6 +179,10 @@ export class WebRTCConnection extends BaseConnection {
       // Audio interruption is managed by the server/agent
     },
     getAnalyser: () => this.outputAnalyser ?? undefined,
+    getVolume: () => this.outputVolumeProvider.getVolume(),
+    getByteFrequencyData: (buffer: Uint8Array<ArrayBuffer>) => {
+      this.outputVolumeProvider.getByteFrequencyData(buffer);
+    },
   };
 
   private constructor(
@@ -285,6 +302,29 @@ export class WebRTCConnection extends BaseConnection {
 
       // Ensure the microphone was successfully enabled
       await micEnabled;
+
+      // Set up input analyser from the local mic track for volume metering
+      const micTrack = room.localParticipant.getTrackPublication(
+        Track.Source.Microphone
+      )?.track;
+      if (micTrack) {
+        try {
+          const ctx = new AudioContext();
+          const analyser = ctx.createAnalyser();
+          const source = ctx.createMediaStreamSource(
+            new MediaStream([micTrack.mediaStreamTrack])
+          );
+          source.connect(analyser);
+          connection.inputAnalyser = analyser;
+          connection.inputAudioContext = ctx;
+          connection.setInputVolumeProvider(
+            createAnalyserVolumeProvider(analyser)
+          );
+        } catch {
+          // AudioContext unavailable (React Native) — volume provider stays
+          // as NO_VOLUME until the platform layer sets its own provider
+        }
+      }
 
       if (room.name) {
         connection.conversationId =
@@ -444,6 +484,15 @@ export class WebRTCConnection extends BaseConnection {
         console.warn("Error stopping local tracks:", error);
       }
 
+      // Clean up input audio context (non-blocking)
+      if (this.inputAudioContext) {
+        this.inputAudioContext.close().catch(error => {
+          console.warn("Error closing input audio context:", error);
+        });
+        this.inputAudioContext = null;
+        this.inputAnalyser = null;
+      }
+
       // Clean up audio capture context (non-blocking)
       if (this.audioCaptureContext) {
         this.audioCaptureContext.close().catch(error => {
@@ -500,6 +549,14 @@ export class WebRTCConnection extends BaseConnection {
     return this.room;
   }
 
+  public setInputVolumeProvider(provider: VolumeProvider) {
+    this.inputVolumeProvider = provider;
+  }
+
+  public setOutputVolumeProvider(provider: VolumeProvider) {
+    this.outputVolumeProvider = provider;
+  }
+
   private async setupAudioCapture(track: RemoteAudioTrack) {
     try {
       // Create audio context for processing
@@ -519,6 +576,9 @@ export class WebRTCConnection extends BaseConnection {
 
       // Connect source to analyser
       source.connect(this.outputAnalyser);
+      this.setOutputVolumeProvider(
+        createAnalyserVolumeProvider(this.outputAnalyser)
+      );
 
       await loadRawAudioProcessor(audioContext.audioWorklet);
       const worklet = new AudioWorkletNode(audioContext, "rawAudioProcessor");
@@ -644,15 +704,5 @@ export class WebRTCConnection extends BaseConnection {
 
       throw error;
     }
-  }
-
-  public getOutputByteFrequencyData(): Uint8Array<ArrayBuffer> | null {
-    if (!this.outputAnalyser) return null;
-
-    this.outputFrequencyData ??= new Uint8Array(
-      this.outputAnalyser.frequencyBinCount
-    ) as Uint8Array<ArrayBuffer>;
-    this.outputAnalyser.getByteFrequencyData(this.outputFrequencyData);
-    return this.outputFrequencyData;
   }
 }

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -544,10 +544,9 @@ export class WebRTCConnection extends BaseConnection {
     // Clean up existing input audio context
     if (this.inputAudioContext) {
       this.inputAudioContext.close().catch(() => {});
+      this.inputAudioContext = null;
+      this.inputAnalyser = null;
     }
-    this.inputAudioContext = null;
-    this.inputAnalyser = null;
-    this.inputVolumeProvider = NO_VOLUME;
 
     try {
       const ctx = new AudioContext();
@@ -560,6 +559,8 @@ export class WebRTCConnection extends BaseConnection {
       this.inputAudioContext = ctx;
       this.inputVolumeProvider = createAnalyserVolumeProvider(analyser);
     } catch (error) {
+      // Don't reset inputVolumeProvider here — an external provider (e.g.
+      // React Native's native volume layer) may still be valid.
       console.warn(
         "[ConversationalAI] Failed to set up input volume analyser:",
         error

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -142,8 +142,15 @@ export class WebRTCConnection extends BaseConnection {
     },
     isMuted: () => this._isMuted,
     getAnalyser: () => this.inputAnalyser ?? undefined,
-    getVolume: () => this.inputVolumeProvider.getVolume(),
+    getVolume: () => {
+      if (this._isMuted) return 0;
+      return this.inputVolumeProvider.getVolume();
+    },
     getByteFrequencyData: (buffer: Uint8Array<ArrayBuffer>) => {
+      if (this._isMuted) {
+        buffer.fill(0);
+        return;
+      }
       this.inputVolumeProvider.getByteFrequencyData(buffer);
     },
   };

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -557,7 +557,10 @@ export class WebRTCConnection extends BaseConnection {
       source.connect(analyser);
       this.inputAnalyser = analyser;
       this.inputAudioContext = ctx;
-      this.inputVolumeProvider = createAnalyserVolumeProvider(analyser);
+      this.inputVolumeProvider = createAnalyserVolumeProvider(
+        analyser,
+        ctx.sampleRate
+      );
     } catch (error) {
       // Don't reset inputVolumeProvider here — an external provider (e.g.
       // React Native's native volume layer) may still be valid.
@@ -596,7 +599,10 @@ export class WebRTCConnection extends BaseConnection {
       // Connect source to analyser
       source.connect(this.outputAnalyser);
       this.setOutputVolumeProvider(
-        createAnalyserVolumeProvider(this.outputAnalyser)
+        createAnalyserVolumeProvider(
+          this.outputAnalyser,
+          audioContext.sampleRate
+        )
       );
 
       await loadRawAudioProcessor(audioContext.audioWorklet);

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -308,22 +308,7 @@ export class WebRTCConnection extends BaseConnection {
         Track.Source.Microphone
       )?.track;
       if (micTrack) {
-        try {
-          const ctx = new AudioContext();
-          const analyser = ctx.createAnalyser();
-          const source = ctx.createMediaStreamSource(
-            new MediaStream([micTrack.mediaStreamTrack])
-          );
-          source.connect(analyser);
-          connection.inputAnalyser = analyser;
-          connection.inputAudioContext = ctx;
-          connection.setInputVolumeProvider(
-            createAnalyserVolumeProvider(analyser)
-          );
-        } catch {
-          // AudioContext unavailable (React Native) — volume provider stays
-          // as NO_VOLUME until the platform layer sets its own provider
-        }
+        connection.setupInputAnalyser(micTrack.mediaStreamTrack);
       }
 
       if (room.name) {
@@ -549,6 +534,39 @@ export class WebRTCConnection extends BaseConnection {
     return this.room;
   }
 
+  /**
+   * (Re-)creates an AudioContext + AnalyserNode from the given track and
+   * installs the corresponding VolumeProvider. Called once during create()
+   * and again after an input device switch so the analyser follows the
+   * active mic track.
+   */
+  private setupInputAnalyser(mediaStreamTrack: MediaStreamTrack): void {
+    // Clean up existing input audio context
+    if (this.inputAudioContext) {
+      this.inputAudioContext.close().catch(() => {});
+    }
+    this.inputAudioContext = null;
+    this.inputAnalyser = null;
+    this.inputVolumeProvider = NO_VOLUME;
+
+    try {
+      const ctx = new AudioContext();
+      const analyser = ctx.createAnalyser();
+      const source = ctx.createMediaStreamSource(
+        new MediaStream([mediaStreamTrack])
+      );
+      source.connect(analyser);
+      this.inputAnalyser = analyser;
+      this.inputAudioContext = ctx;
+      this.inputVolumeProvider = createAnalyserVolumeProvider(analyser);
+    } catch (error) {
+      console.warn(
+        "[ConversationalAI] Failed to set up input volume analyser:",
+        error
+      );
+    }
+  }
+
   public setInputVolumeProvider(provider: VolumeProvider) {
     this.inputVolumeProvider = provider;
   }
@@ -689,6 +707,9 @@ export class WebRTCConnection extends BaseConnection {
         name: "microphone",
         source: Track.Source.Microphone,
       });
+
+      // Reconnect the input analyser to the new track
+      this.setupInputAnalyser(audioTrack.mediaStreamTrack);
     } catch (error) {
       console.error("Failed to change input device:", error);
 

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -139,6 +139,17 @@ export class WebRTCConnection extends BaseConnection {
       }
 
       this._isMuted = isMuted;
+
+      // After unmuting, reconnect the input analyser because LiveKit may
+      // have replaced the underlying MediaStreamTrack during mute/unmute.
+      if (!isMuted) {
+        const track = this.room.localParticipant.getTrackPublication(
+          Track.Source.Microphone
+        )?.track;
+        if (track) {
+          this.setupInputAnalyser(track.mediaStreamTrack);
+        }
+      }
     },
     isMuted: () => this._isMuted,
     getAnalyser: () => this.inputAnalyser ?? undefined,

--- a/packages/client/src/utils/calculateVolume.ts
+++ b/packages/client/src/utils/calculateVolume.ts
@@ -10,8 +10,6 @@ export function calculateVolume(
     return 0;
   }
 
-  // TODO: Currently this averages all frequencies, but we should probably
-  // bias towards the frequencies that are more typical for human voice
   let volume = 0;
   for (let i = 0; i < frequencyData.length; i++) {
     volume += frequencyData[i] / 255;

--- a/packages/client/src/utils/calculateVolume.ts
+++ b/packages/client/src/utils/calculateVolume.ts
@@ -1,0 +1,20 @@
+/**
+ * Calculate a scalar volume level (0–1) from byte frequency data.
+ *
+ * The value is the mean of all frequency bins normalised to [0, 1].
+ */
+export function calculateVolume(frequencyData: Uint8Array): number {
+  if (frequencyData.length === 0) {
+    return 0;
+  }
+
+  // TODO: Currently this averages all frequencies, but we should probably
+  // bias towards the frequencies that are more typical for human voice
+  let volume = 0;
+  for (let i = 0; i < frequencyData.length; i++) {
+    volume += frequencyData[i] / 255;
+  }
+  volume /= frequencyData.length;
+
+  return volume < 0 ? 0 : volume > 1 ? 1 : volume;
+}

--- a/packages/client/src/utils/calculateVolume.ts
+++ b/packages/client/src/utils/calculateVolume.ts
@@ -3,7 +3,9 @@
  *
  * The value is the mean of all frequency bins normalised to [0, 1].
  */
-export function calculateVolume(frequencyData: Uint8Array): number {
+export function calculateVolume(
+  frequencyData: Uint8Array<ArrayBuffer>
+): number {
   if (frequencyData.length === 0) {
     return 0;
   }

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -163,10 +163,15 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
   }
 
   public getVolume(): number {
+    if (this.muted) return 0;
     return this.volumeProvider.getVolume();
   }
 
   public getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
+    if (this.muted) {
+      buffer.fill(0);
+      return;
+    }
     this.volumeProvider.getByteFrequencyData(buffer);
   }
 

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -5,6 +5,7 @@ import type { AudioWorkletConfig } from "../BaseConversation.js";
 import { addLibsamplerateModule } from "./addLibsamplerateModule.js";
 import type { InputController, InputDeviceConfig } from "../InputController.js";
 import { calculateVolume } from "./calculateVolume.js";
+import { resampleVoiceRange } from "./volumeProvider.js";
 
 export type InputConfig = InputDeviceConfig & {
   onError?(message: string, context?: unknown): void;
@@ -165,7 +166,11 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
   }
 
   public getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
-    this.analyser.getByteFrequencyData(buffer);
+    this.volumeData ??= new Uint8Array(
+      this.analyser.frequencyBinCount
+    ) as Uint8Array<ArrayBuffer>;
+    this.analyser.getByteFrequencyData(this.volumeData);
+    resampleVoiceRange(this.volumeData, buffer, this.context.sampleRate);
   }
 
   public isMuted(): boolean {

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -4,6 +4,7 @@ import { isIosDevice } from "./compatibility.js";
 import type { AudioWorkletConfig } from "../BaseConversation.js";
 import { addLibsamplerateModule } from "./addLibsamplerateModule.js";
 import type { InputController, InputDeviceConfig } from "../InputController.js";
+import { calculateVolume } from "./calculateVolume.js";
 
 export type InputConfig = InputDeviceConfig & {
   onError?(message: string, context?: unknown): void;
@@ -151,6 +152,20 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
 
   public getAnalyser(): AnalyserNode {
     return this.analyser;
+  }
+
+  private volumeData?: Uint8Array<ArrayBuffer>;
+
+  public getVolume(): number {
+    this.volumeData ??= new Uint8Array(
+      this.analyser.frequencyBinCount
+    ) as Uint8Array<ArrayBuffer>;
+    this.analyser.getByteFrequencyData(this.volumeData);
+    return calculateVolume(this.volumeData);
+  }
+
+  public getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
+    this.analyser.getByteFrequencyData(buffer);
   }
 
   public isMuted(): boolean {

--- a/packages/client/src/utils/input.ts
+++ b/packages/client/src/utils/input.ts
@@ -4,8 +4,10 @@ import { isIosDevice } from "./compatibility.js";
 import type { AudioWorkletConfig } from "../BaseConversation.js";
 import { addLibsamplerateModule } from "./addLibsamplerateModule.js";
 import type { InputController, InputDeviceConfig } from "../InputController.js";
-import { calculateVolume } from "./calculateVolume.js";
-import { resampleVoiceRange } from "./volumeProvider.js";
+import {
+  createAnalyserVolumeProvider,
+  type VolumeProvider,
+} from "./volumeProvider.js";
 
 export type InputConfig = InputDeviceConfig & {
   onError?(message: string, context?: unknown): void;
@@ -132,6 +134,7 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
   }
 
   private muted = false;
+  private readonly volumeProvider: VolumeProvider;
 
   private constructor(
     private readonly context: AudioContext,
@@ -149,28 +152,22 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
     // Start the MessagePort to enable addEventListener to work
     // (required when using addEventListener instead of onmessage)
     this.worklet.port.start();
+    this.volumeProvider = createAnalyserVolumeProvider(
+      analyser,
+      context.sampleRate
+    );
   }
 
   public getAnalyser(): AnalyserNode {
     return this.analyser;
   }
 
-  private volumeData?: Uint8Array<ArrayBuffer>;
-
   public getVolume(): number {
-    this.volumeData ??= new Uint8Array(
-      this.analyser.frequencyBinCount
-    ) as Uint8Array<ArrayBuffer>;
-    this.analyser.getByteFrequencyData(this.volumeData);
-    return calculateVolume(this.volumeData);
+    return this.volumeProvider.getVolume();
   }
 
   public getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
-    this.volumeData ??= new Uint8Array(
-      this.analyser.frequencyBinCount
-    ) as Uint8Array<ArrayBuffer>;
-    this.analyser.getByteFrequencyData(this.volumeData);
-    resampleVoiceRange(this.volumeData, buffer, this.context.sampleRate);
+    this.volumeProvider.getByteFrequencyData(buffer);
   }
 
   public isMuted(): boolean {

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -6,6 +6,7 @@ import type {
   OutputController,
   OutputDeviceConfig,
 } from "../OutputController.js";
+import { calculateVolume } from "./calculateVolume.js";
 
 export type OutputConfig = OutputDeviceConfig;
 
@@ -136,6 +137,20 @@ export class MediaDeviceOutput
 
   public getAnalyser(): AnalyserNode {
     return this.analyser;
+  }
+
+  private volumeData?: Uint8Array<ArrayBuffer>;
+
+  public getVolume(): number {
+    this.volumeData ??= new Uint8Array(
+      this.analyser.frequencyBinCount
+    ) as Uint8Array<ArrayBuffer>;
+    this.analyser.getByteFrequencyData(this.volumeData);
+    return calculateVolume(this.volumeData);
+  }
+
+  public getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
+    this.analyser.getByteFrequencyData(buffer);
   }
 
   public addListener(listener: PlaybackListener): void {

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -6,8 +6,10 @@ import type {
   OutputController,
   OutputDeviceConfig,
 } from "../OutputController.js";
-import { calculateVolume } from "./calculateVolume.js";
-import { resampleVoiceRange } from "./volumeProvider.js";
+import {
+  createAnalyserVolumeProvider,
+  type VolumeProvider,
+} from "./volumeProvider.js";
 
 export type OutputConfig = OutputDeviceConfig;
 
@@ -123,6 +125,7 @@ export class MediaDeviceOutput
   private volume = 1;
   private interrupted = false;
   private interruptTimeout: ReturnType<typeof setTimeout> | null = null;
+  private readonly volumeProvider: VolumeProvider;
 
   private constructor(
     private readonly context: AudioContext,
@@ -134,28 +137,22 @@ export class MediaDeviceOutput
     // Start the MessagePort to enable addEventListener to work
     // (required when using addEventListener instead of onmessage)
     this.worklet.port.start();
+    this.volumeProvider = createAnalyserVolumeProvider(
+      analyser,
+      context.sampleRate
+    );
   }
 
   public getAnalyser(): AnalyserNode {
     return this.analyser;
   }
 
-  private volumeData?: Uint8Array<ArrayBuffer>;
-
   public getVolume(): number {
-    this.volumeData ??= new Uint8Array(
-      this.analyser.frequencyBinCount
-    ) as Uint8Array<ArrayBuffer>;
-    this.analyser.getByteFrequencyData(this.volumeData);
-    return calculateVolume(this.volumeData);
+    return this.volumeProvider.getVolume();
   }
 
   public getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
-    this.volumeData ??= new Uint8Array(
-      this.analyser.frequencyBinCount
-    ) as Uint8Array<ArrayBuffer>;
-    this.analyser.getByteFrequencyData(this.volumeData);
-    resampleVoiceRange(this.volumeData, buffer, this.context.sampleRate);
+    this.volumeProvider.getByteFrequencyData(buffer);
   }
 
   public addListener(listener: PlaybackListener): void {

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -7,6 +7,7 @@ import type {
   OutputDeviceConfig,
 } from "../OutputController.js";
 import { calculateVolume } from "./calculateVolume.js";
+import { resampleVoiceRange } from "./volumeProvider.js";
 
 export type OutputConfig = OutputDeviceConfig;
 
@@ -150,7 +151,11 @@ export class MediaDeviceOutput
   }
 
   public getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
-    this.analyser.getByteFrequencyData(buffer);
+    this.volumeData ??= new Uint8Array(
+      this.analyser.frequencyBinCount
+    ) as Uint8Array<ArrayBuffer>;
+    this.analyser.getByteFrequencyData(this.volumeData);
+    resampleVoiceRange(this.volumeData, buffer, this.context.sampleRate);
   }
 
   public addListener(listener: PlaybackListener): void {

--- a/packages/client/src/utils/volumeProvider.ts
+++ b/packages/client/src/utils/volumeProvider.ts
@@ -1,0 +1,29 @@
+import { calculateVolume } from "./calculateVolume.js";
+
+export interface VolumeProvider {
+  getVolume(): number;
+  getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void;
+}
+
+export const NO_VOLUME: VolumeProvider = {
+  getVolume: () => 0,
+  getByteFrequencyData: () => {},
+};
+
+export function createAnalyserVolumeProvider(
+  analyser: AnalyserNode
+): VolumeProvider {
+  let data: Uint8Array<ArrayBuffer> | undefined;
+  return {
+    getVolume() {
+      data ??= new Uint8Array(
+        analyser.frequencyBinCount
+      ) as Uint8Array<ArrayBuffer>;
+      analyser.getByteFrequencyData(data);
+      return calculateVolume(data);
+    },
+    getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>) {
+      analyser.getByteFrequencyData(buffer);
+    },
+  };
+}

--- a/packages/client/src/utils/volumeProvider.ts
+++ b/packages/client/src/utils/volumeProvider.ts
@@ -10,20 +10,53 @@ export const NO_VOLUME: VolumeProvider = {
   getByteFrequencyData: () => {},
 };
 
+// Voice-relevant frequency range, matching the React Native multiband
+// processor config so both platforms return comparable data.
+export const MIN_VOICE_FREQUENCY = 100;
+export const MAX_VOICE_FREQUENCY = 8000;
+
+/**
+ * Resamples the voice-relevant portion of raw frequency data into an output
+ * buffer using linear interpolation. This ensures both web and React Native
+ * return comparable frequency data focused on the human voice range.
+ */
+export function resampleVoiceRange(
+  raw: Uint8Array<ArrayBuffer>,
+  buffer: Uint8Array<ArrayBuffer>,
+  sampleRate: number
+): void {
+  const binCount = raw.length;
+  const hzPerBin = sampleRate / 2 / binCount;
+  const minBin = Math.floor(MIN_VOICE_FREQUENCY / hzPerBin);
+  const maxBin = Math.min(Math.ceil(MAX_VOICE_FREQUENCY / hzPerBin), binCount);
+  const voiceBinCount = maxBin - minBin;
+  const outLen = buffer.length;
+  for (let i = 0; i < outLen; i++) {
+    const pos = (i / outLen) * voiceBinCount;
+    const lo = minBin + Math.floor(pos);
+    const hi = Math.min(lo + 1, maxBin - 1);
+    const t = pos - Math.floor(pos);
+    buffer[i] = Math.round(raw[lo] * (1 - t) + raw[hi] * t);
+  }
+}
+
 export function createAnalyserVolumeProvider(
-  analyser: AnalyserNode
+  analyser: AnalyserNode,
+  sampleRate: number
 ): VolumeProvider {
-  let data: Uint8Array<ArrayBuffer> | undefined;
+  const binCount = analyser.frequencyBinCount;
+  let rawData: Uint8Array<ArrayBuffer> | undefined;
+
   return {
     getVolume() {
-      data ??= new Uint8Array(
-        analyser.frequencyBinCount
-      ) as Uint8Array<ArrayBuffer>;
-      analyser.getByteFrequencyData(data);
-      return calculateVolume(data);
+      rawData ??= new Uint8Array(binCount) as Uint8Array<ArrayBuffer>;
+      analyser.getByteFrequencyData(rawData);
+      return calculateVolume(rawData);
     },
     getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>) {
-      analyser.getByteFrequencyData(buffer);
+      rawData ??= new Uint8Array(binCount) as Uint8Array<ArrayBuffer>;
+      analyser.getByteFrequencyData(rawData);
+      resampleVoiceRange(rawData, buffer, sampleRate);
     },
   };
 }

--- a/packages/client/src/utils/volumeProvider.ts
+++ b/packages/client/src/utils/volumeProvider.ts
@@ -52,12 +52,17 @@ export function createAnalyserVolumeProvider(
 ): VolumeProvider {
   const binCount = analyser.frequencyBinCount;
   let rawData: Uint8Array<ArrayBuffer> | undefined;
+  // Resampled buffer used by getVolume() so the scalar is computed from the
+  // voice-frequency range only, matching RN's RMS processor behaviour.
+  let voiceData: Uint8Array<ArrayBuffer> | undefined;
 
   return {
     getVolume() {
       rawData ??= new Uint8Array(binCount) as Uint8Array<ArrayBuffer>;
+      voiceData ??= new Uint8Array(binCount) as Uint8Array<ArrayBuffer>;
       analyser.getByteFrequencyData(rawData);
-      return calculateVolume(rawData);
+      resampleVoiceRange(rawData, voiceData, sampleRate);
+      return calculateVolume(voiceData);
     },
     getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>) {
       rawData ??= new Uint8Array(binCount) as Uint8Array<ArrayBuffer>;

--- a/packages/client/src/utils/volumeProvider.ts
+++ b/packages/client/src/utils/volumeProvider.ts
@@ -1,7 +1,13 @@
 import { calculateVolume } from "./calculateVolume.js";
 
 export interface VolumeProvider {
+  /** Returns current audio level as a scalar 0-1. */
   getVolume(): number;
+  /**
+   * Writes byte frequency data (0-255) into the provided buffer, focused on
+   * the human voice range (100-8000 Hz). The buffer length determines the
+   * number of frequency bands returned.
+   */
   getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void;
 }
 

--- a/packages/react-native/src/index.react-native.ts
+++ b/packages/react-native/src/index.react-native.ts
@@ -9,6 +9,7 @@ import {
   webSessionSetup,
   type VoiceSessionSetupResult,
 } from "@elevenlabs/client/internal";
+import { attachNativeVolume } from "./nativeVolume.js";
 
 // Polyfill WebRTC globals needed by livekit-client in React Native
 registerGlobals();
@@ -18,7 +19,8 @@ registerGlobals();
  *
  * 1. Configures and starts the native AudioSession
  * 2. Delegates connection + input/output setup to the web strategy
- * 3. Wraps detach to stop the native AudioSession on cleanup
+ * 3. Wraps input/output controllers with native volume processors
+ * 4. Wraps detach to stop the native AudioSession on cleanup
  */
 async function reactNativeSessionSetup(
   options: Options
@@ -34,7 +36,7 @@ async function reactNativeSessionSetup(
   });
   await AudioSession.startAudioSession();
 
-  const result = await webSessionSetup(options);
+  const result = attachNativeVolume(await webSessionSetup(options));
 
   const originalDetach = result.detach;
   return {

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -111,7 +111,7 @@ class NativeVolumeProvider implements VolumeProvider {
 
   getVolume(): number {
     this.ensureVolumeProcessor();
-    return this.volume;
+    return this.volume < 0 ? 0 : this.volume > 1 ? 1 : this.volume;
   }
 
   getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
@@ -119,11 +119,13 @@ class NativeVolumeProvider implements VolumeProvider {
     if (this.magnitudes.length === 0) {
       // No multiband data yet; fall back to uniform fill from RMS volume
       this.ensureVolumeProcessor();
-      buffer.fill(Math.round(this.volume * 255));
+      const clamped = this.volume < 0 ? 0 : this.volume > 1 ? 1 : this.volume;
+      buffer.fill(Math.round(clamped * 255));
       return;
     }
     for (let i = 0; i < buffer.length; i++) {
-      buffer[i] = Math.round((this.magnitudes[i] ?? 0) * 255);
+      const m = this.magnitudes[i] ?? 0;
+      buffer[i] = Math.round((m < 0 ? 0 : m > 1 ? 1 : m) * 255);
     }
   }
 

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -15,32 +15,133 @@ interface VolumeEvent {
   volume: number;
 }
 
-function createNativeVolumeProvider(): {
-  provider: VolumeProvider;
-  setVolume: (v: number) => void;
-} {
-  let volume = 0;
-  return {
-    provider: {
-      getVolume: () => volume,
-      getByteFrequencyData: (buffer: Uint8Array<ArrayBuffer>) =>
-        buffer.fill(Math.round(volume * 255)),
-    },
-    setVolume: v => {
-      volume = v;
-    },
-  };
+interface MultibandEvent {
+  id: string;
+  magnitudes: number[];
+}
+
+const MULTIBAND_FREQUENCY_OPTIONS = {
+  minFrequency: 100,
+  maxFrequency: 8000,
+};
+
+/**
+ * A VolumeProvider backed by native LiveKit audio processors.
+ *
+ * Both processors are created lazily: the RMS volume processor on the first
+ * `getVolume()` call, and the FFT multiband processor on the first
+ * `getByteFrequencyData()` call (with its band count matching the buffer
+ * length). If the buffer size changes, the multiband processor is recreated.
+ */
+class NativeVolumeProvider implements VolumeProvider {
+  private volume = 0;
+  private magnitudes: number[] = [];
+
+  // Volume processor state (lazy)
+  private volumeTag: string | null = null;
+  private volumeSub: { remove: () => void } | null = null;
+
+  // Multiband processor state (lazy)
+  private multibandTag: string | null = null;
+  private multibandSub: { remove: () => void } | null = null;
+  private currentBands = 0;
+
+  constructor(
+    private readonly pcId: number,
+    private readonly trackId: string
+  ) {}
+
+  private ensureVolumeProcessor() {
+    if (this.volumeTag) return;
+    this.volumeTag = LiveKitModule.createVolumeProcessor(
+      this.pcId,
+      this.trackId
+    );
+    this.volumeSub = getEmitter().addListener(
+      "LK_VOLUME_PROCESSED",
+      (event: VolumeEvent) => {
+        if (event.id === this.volumeTag) {
+          this.volume = event.volume;
+        }
+      }
+    );
+  }
+
+  private ensureMultibandProcessor(bands: number) {
+    if (bands === this.currentBands) return;
+
+    // Cleanup previous processor
+    if (this.multibandTag) {
+      LiveKitModule.deleteMultibandVolumeProcessor(
+        this.multibandTag,
+        this.pcId,
+        this.trackId
+      );
+      this.multibandSub?.remove();
+    }
+
+    this.currentBands = bands;
+    this.magnitudes = [];
+    this.multibandTag = LiveKitModule.createMultibandVolumeProcessor(
+      { ...MULTIBAND_FREQUENCY_OPTIONS, bands },
+      this.pcId,
+      this.trackId
+    );
+    this.multibandSub = getEmitter().addListener(
+      "LK_MULTIBAND_PROCESSED",
+      (event: MultibandEvent) => {
+        if (event.id === this.multibandTag) {
+          this.magnitudes = event.magnitudes;
+        }
+      }
+    );
+  }
+
+  getVolume(): number {
+    this.ensureVolumeProcessor();
+    return this.volume;
+  }
+
+  getByteFrequencyData(buffer: Uint8Array<ArrayBuffer>): void {
+    this.ensureMultibandProcessor(buffer.length);
+    if (this.magnitudes.length === 0) {
+      // No multiband data yet; fall back to uniform fill from RMS volume
+      buffer.fill(Math.round(this.volume * 255));
+      return;
+    }
+    for (let i = 0; i < buffer.length; i++) {
+      buffer[i] = Math.round((this.magnitudes[i] ?? 0) * 255);
+    }
+  }
+
+  cleanup() {
+    if (this.volumeTag) {
+      LiveKitModule.deleteVolumeProcessor(
+        this.volumeTag,
+        this.pcId,
+        this.trackId
+      );
+      this.volumeSub?.remove();
+    }
+    if (this.multibandTag) {
+      LiveKitModule.deleteMultibandVolumeProcessor(
+        this.multibandTag,
+        this.pcId,
+        this.trackId
+      );
+      this.multibandSub?.remove();
+    }
+  }
 }
 
 /**
- * Sets up native volume processors for the WebRTC connection and installs
- * VolumeProvider instances that feed their values through to the controllers.
- * Returns a cleanup function.
+ * Sets up lazy native volume providers for the WebRTC connection. No native
+ * processors are created until `getVolume()` or `getByteFrequencyData()` is
+ * actually called. Returns a cleanup function.
  */
 function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
   const room = connection.getRoom();
-  const subscriptions: Array<{ remove: () => void }> = [];
-  const reactTags: Array<{ tag: string; track: any }> = [];
+  const providers: NativeVolumeProvider[] = [];
 
   // --- Input (local mic track) ---
   const micPub = room.localParticipant.audioTrackPublications.values().next();
@@ -48,19 +149,10 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
   if (micTrack) {
     const mst = micTrack.mediaStreamTrack as any;
     const pcId: number = mst._peerConnectionId ?? -1;
-    const tag: string = LiveKitModule.createVolumeProcessor(pcId, mst.id);
-    reactTags.push({ tag, track: micTrack });
 
-    const input = createNativeVolumeProvider();
-    connection.setInputVolumeProvider(input.provider);
-
-    subscriptions.push(
-      getEmitter().addListener("LK_VOLUME_PROCESSED", (event: VolumeEvent) => {
-        if (event.id === tag) {
-          input.setVolume(event.volume);
-        }
-      })
-    );
+    const input = new NativeVolumeProvider(pcId, mst.id);
+    providers.push(input);
+    connection.setInputVolumeProvider(input);
   }
 
   // --- Output (remote agent track) ---
@@ -71,19 +163,10 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
     outputSetUp = true;
     const mst = track.mediaStreamTrack as any;
     const pcId: number = mst._peerConnectionId ?? -1;
-    const tag: string = LiveKitModule.createVolumeProcessor(pcId, mst.id);
-    reactTags.push({ tag, track });
 
-    const output = createNativeVolumeProvider();
-    connection.setOutputVolumeProvider(output.provider);
-
-    subscriptions.push(
-      getEmitter().addListener("LK_VOLUME_PROCESSED", (event: VolumeEvent) => {
-        if (event.id === tag) {
-          output.setVolume(event.volume);
-        }
-      })
-    );
+    const output = new NativeVolumeProvider(pcId, mst.id);
+    providers.push(output);
+    connection.setOutputVolumeProvider(output);
   }
 
   // Check for an existing remote audio track from the agent
@@ -108,16 +191,8 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
 
   return () => {
     room.off("trackSubscribed", trackHandler);
-    for (const { tag, track } of reactTags) {
-      const mst = track.mediaStreamTrack as any;
-      LiveKitModule.deleteVolumeProcessor(
-        tag,
-        mst._peerConnectionId ?? -1,
-        mst.id
-      );
-    }
-    for (const sub of subscriptions) {
-      sub.remove();
+    for (const provider of providers) {
+      provider.cleanup();
     }
   };
 }

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -195,17 +195,18 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
   room.on("localTrackPublished", localTrackHandler);
 
   // --- Output (remote agent track) ---
-  let outputSetUp = false;
+  let outputProvider: NativeVolumeProvider | null = null;
 
   function setupOutputTrack(track: any) {
-    if (outputSetUp) return;
-    outputSetUp = true;
     const mst = track.mediaStreamTrack as any;
     const pcId: number = mst._peerConnectionId ?? -1;
-
-    const output = new NativeVolumeProvider(pcId, mst.id);
-    providers.push(output);
-    connection.setOutputVolumeProvider(output);
+    if (outputProvider) {
+      outputProvider.updateTrack(pcId, mst.id);
+    } else {
+      outputProvider = new NativeVolumeProvider(pcId, mst.id);
+      providers.push(outputProvider);
+      connection.setOutputVolumeProvider(outputProvider);
+    }
   }
 
   // Check for an existing remote audio track from the agent

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -1,0 +1,149 @@
+import { NativeModules, NativeEventEmitter } from "react-native";
+import { WebRTCConnection, type VolumeProvider } from "@elevenlabs/client";
+import type { VoiceSessionSetupResult } from "@elevenlabs/client/internal";
+
+const LiveKitModule = NativeModules.LivekitReactNativeModule;
+
+let emitter: NativeEventEmitter | null = null;
+function getEmitter(): NativeEventEmitter {
+  emitter ??= new NativeEventEmitter(LiveKitModule);
+  return emitter;
+}
+
+interface VolumeEvent {
+  name: string;
+  data: { id: string; volume: number };
+}
+
+function createNativeVolumeProvider(): {
+  provider: VolumeProvider;
+  setVolume: (v: number) => void;
+} {
+  let volume = 0;
+  return {
+    provider: {
+      getVolume: () => volume,
+      getByteFrequencyData: (buffer: Uint8Array<ArrayBuffer>) =>
+        buffer.fill(Math.round(volume * 255)),
+    },
+    setVolume: v => {
+      volume = v;
+    },
+  };
+}
+
+/**
+ * Sets up native volume processors for the WebRTC connection and installs
+ * VolumeProvider instances that feed their values through to the controllers.
+ * Returns a cleanup function.
+ */
+function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
+  const room = connection.getRoom();
+  const subscriptions: Array<{ remove: () => void }> = [];
+  const reactTags: Array<{ tag: string; track: any }> = [];
+
+  // --- Input (local mic track) ---
+  const micPub = room.localParticipant.audioTrackPublications.values().next();
+  const micTrack = micPub.done ? undefined : micPub.value?.track;
+  if (micTrack) {
+    const mst = micTrack.mediaStreamTrack as any;
+    const pcId: number = mst._peerConnectionId ?? -1;
+    const tag: string = LiveKitModule.createVolumeProcessor(pcId, mst.id);
+    reactTags.push({ tag, track: micTrack });
+
+    const input = createNativeVolumeProvider();
+    connection.setInputVolumeProvider(input.provider);
+
+    subscriptions.push(
+      getEmitter().addListener("event", (event: VolumeEvent) => {
+        if (event.name === "LK_VOLUME_PROCESSED" && event.data.id === tag) {
+          input.setVolume(event.data.volume);
+        }
+      })
+    );
+  }
+
+  // --- Output (remote agent track) ---
+  let outputSetUp = false;
+
+  function setupOutputTrack(track: any) {
+    if (outputSetUp) return;
+    outputSetUp = true;
+    const mst = track.mediaStreamTrack as any;
+    const pcId: number = mst._peerConnectionId ?? -1;
+    const tag: string = LiveKitModule.createVolumeProcessor(pcId, mst.id);
+    reactTags.push({ tag, track });
+
+    const output = createNativeVolumeProvider();
+    connection.setOutputVolumeProvider(output.provider);
+
+    subscriptions.push(
+      getEmitter().addListener("event", (event: VolumeEvent) => {
+        if (event.name === "LK_VOLUME_PROCESSED" && event.data.id === tag) {
+          output.setVolume(event.data.volume);
+        }
+      })
+    );
+  }
+
+  // Check for an existing remote audio track from the agent
+  for (const participant of room.remoteParticipants.values()) {
+    if (participant.identity?.includes("agent")) {
+      for (const pub of participant.audioTrackPublications.values()) {
+        if (pub.track) {
+          setupOutputTrack(pub.track);
+          break;
+        }
+      }
+    }
+  }
+
+  // Listen for future track subscriptions
+  const trackHandler = (track: any) => {
+    if (track.kind === "audio") {
+      setupOutputTrack(track);
+    }
+  };
+  room.on("trackSubscribed", trackHandler);
+
+  return () => {
+    room.off("trackSubscribed", trackHandler);
+    for (const { tag, track } of reactTags) {
+      const mst = track.mediaStreamTrack as any;
+      LiveKitModule.deleteVolumeProcessor(
+        tag,
+        mst._peerConnectionId ?? -1,
+        mst.id
+      );
+    }
+    for (const sub of subscriptions) {
+      sub.remove();
+    }
+  };
+}
+
+/**
+ * Attaches native volume processors to the WebRTC connection so that
+ * `getInputVolume()` / `getOutputVolume()` return real values on
+ * React Native. Falls through unchanged for non-WebRTC connections;
+ * WebSocket volume on React Native is a known gap (MediaDeviceInput/
+ * MediaDeviceOutput depend on AudioContext which is unavailable in RN).
+ */
+export function attachNativeVolume(
+  result: VoiceSessionSetupResult
+): VoiceSessionSetupResult {
+  if (!(result.connection instanceof WebRTCConnection)) {
+    return result;
+  }
+
+  const cleanup = setupNativeVolumeProcessors(result.connection);
+
+  const originalDetach = result.detach;
+  return {
+    ...result,
+    detach: () => {
+      cleanup();
+      originalDetach();
+    },
+  };
+}

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -1,6 +1,10 @@
 import { NativeModules, NativeEventEmitter } from "react-native";
 import { WebRTCConnection, type VolumeProvider } from "@elevenlabs/client";
-import type { VoiceSessionSetupResult } from "@elevenlabs/client/internal";
+import {
+  MIN_VOICE_FREQUENCY,
+  MAX_VOICE_FREQUENCY,
+  type VoiceSessionSetupResult,
+} from "@elevenlabs/client/internal";
 
 const LiveKitModule = NativeModules.LivekitReactNativeModule;
 
@@ -21,8 +25,8 @@ interface MultibandEvent {
 }
 
 const MULTIBAND_FREQUENCY_OPTIONS = {
-  minFrequency: 100,
-  maxFrequency: 8000,
+  minFrequency: MIN_VOICE_FREQUENCY,
+  maxFrequency: MAX_VOICE_FREQUENCY,
   updateInterval: 40,
 };
 

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -99,8 +99,8 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
   }
 
   // Listen for future track subscriptions
-  const trackHandler = (track: any) => {
-    if (track.kind === "audio") {
+  const trackHandler = (track: any, _publication: any, participant: any) => {
+    if (track.kind === "audio" && participant?.identity?.includes("agent")) {
       setupOutputTrack(track);
     }
   };

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -23,6 +23,7 @@ interface MultibandEvent {
 const MULTIBAND_FREQUENCY_OPTIONS = {
   minFrequency: 100,
   maxFrequency: 8000,
+  updateInterval: 40,
 };
 
 /**

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -47,9 +47,21 @@ class NativeVolumeProvider implements VolumeProvider {
   private currentBands = 0;
 
   constructor(
-    private readonly pcId: number,
-    private readonly trackId: string
+    private pcId: number,
+    private trackId: string
   ) {}
+
+  /**
+   * Rebinds this provider to a new track, cleaning up any existing native
+   * processors so they are lazily recreated against the new track.
+   */
+  updateTrack(pcId: number, trackId: string) {
+    this.cleanupProcessors();
+    this.pcId = pcId;
+    this.trackId = trackId;
+    this.volume = 0;
+    this.magnitudes = [];
+  }
 
   private ensureVolumeProcessor() {
     if (this.volumeTag) return;
@@ -114,7 +126,7 @@ class NativeVolumeProvider implements VolumeProvider {
     }
   }
 
-  cleanup() {
+  private cleanupProcessors() {
     if (this.volumeTag) {
       LiveKitModule.deleteVolumeProcessor(
         this.volumeTag,
@@ -122,6 +134,8 @@ class NativeVolumeProvider implements VolumeProvider {
         this.trackId
       );
       this.volumeSub?.remove();
+      this.volumeTag = null;
+      this.volumeSub = null;
     }
     if (this.multibandTag) {
       LiveKitModule.deleteMultibandVolumeProcessor(
@@ -130,7 +144,14 @@ class NativeVolumeProvider implements VolumeProvider {
         this.trackId
       );
       this.multibandSub?.remove();
+      this.multibandTag = null;
+      this.multibandSub = null;
+      this.currentBands = 0;
     }
+  }
+
+  cleanup() {
+    this.cleanupProcessors();
   }
 }
 
@@ -144,16 +165,34 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
   const providers: NativeVolumeProvider[] = [];
 
   // --- Input (local mic track) ---
+  let inputProvider: NativeVolumeProvider | null = null;
+
+  function setupInputTrack(track: any) {
+    const mst = track.mediaStreamTrack as any;
+    const pcId: number = mst._peerConnectionId ?? -1;
+    if (inputProvider) {
+      inputProvider.updateTrack(pcId, mst.id);
+    } else {
+      inputProvider = new NativeVolumeProvider(pcId, mst.id);
+      providers.push(inputProvider);
+      connection.setInputVolumeProvider(inputProvider);
+    }
+  }
+
   const micPub = room.localParticipant.audioTrackPublications.values().next();
   const micTrack = micPub.done ? undefined : micPub.value?.track;
   if (micTrack) {
-    const mst = micTrack.mediaStreamTrack as any;
-    const pcId: number = mst._peerConnectionId ?? -1;
-
-    const input = new NativeVolumeProvider(pcId, mst.id);
-    providers.push(input);
-    connection.setInputVolumeProvider(input);
+    setupInputTrack(micTrack);
   }
+
+  // Re-bind the input provider when the local mic track is republished
+  // (e.g. after setAudioInputDevice)
+  const localTrackHandler = (publication: any) => {
+    if (publication.track?.kind === "audio") {
+      setupInputTrack(publication.track);
+    }
+  };
+  room.on("localTrackPublished", localTrackHandler);
 
   // --- Output (remote agent track) ---
   let outputSetUp = false;
@@ -190,6 +229,7 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
   room.on("trackSubscribed", trackHandler);
 
   return () => {
+    room.off("localTrackPublished", localTrackHandler);
     room.off("trackSubscribed", trackHandler);
     for (const provider of providers) {
       provider.cleanup();

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -11,8 +11,8 @@ function getEmitter(): NativeEventEmitter {
 }
 
 interface VolumeEvent {
-  name: string;
-  data: { id: string; volume: number };
+  id: string;
+  volume: number;
 }
 
 function createNativeVolumeProvider(): {
@@ -55,9 +55,9 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
     connection.setInputVolumeProvider(input.provider);
 
     subscriptions.push(
-      getEmitter().addListener("event", (event: VolumeEvent) => {
-        if (event.name === "LK_VOLUME_PROCESSED" && event.data.id === tag) {
-          input.setVolume(event.data.volume);
+      getEmitter().addListener("LK_VOLUME_PROCESSED", (event: VolumeEvent) => {
+        if (event.id === tag) {
+          input.setVolume(event.volume);
         }
       })
     );
@@ -78,9 +78,9 @@ function setupNativeVolumeProcessors(connection: WebRTCConnection): () => void {
     connection.setOutputVolumeProvider(output.provider);
 
     subscriptions.push(
-      getEmitter().addListener("event", (event: VolumeEvent) => {
-        if (event.name === "LK_VOLUME_PROCESSED" && event.data.id === tag) {
-          output.setVolume(event.data.volume);
+      getEmitter().addListener("LK_VOLUME_PROCESSED", (event: VolumeEvent) => {
+        if (event.id === tag) {
+          output.setVolume(event.volume);
         }
       })
     );

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -118,6 +118,7 @@ class NativeVolumeProvider implements VolumeProvider {
     this.ensureMultibandProcessor(buffer.length);
     if (this.magnitudes.length === 0) {
       // No multiband data yet; fall back to uniform fill from RMS volume
+      this.ensureVolumeProcessor();
       buffer.fill(Math.round(this.volume * 255));
       return;
     }

--- a/packages/react/src/conversation/ConversationControls.tsx
+++ b/packages/react/src/conversation/ConversationControls.tsx
@@ -29,7 +29,9 @@ export type ConversationControlsValue = {
   changeOutputDevice: (
     config: Partial<FormatConfig> & OutputConfig
   ) => Promise<void>;
+  /** Returns byte frequency data (0-255) for the input, focused on 100-8000 Hz. */
   getInputByteFrequencyData: () => Uint8Array;
+  /** Returns byte frequency data (0-255) for the output, focused on 100-8000 Hz. */
   getOutputByteFrequencyData: () => Uint8Array;
   getInputVolume: () => number;
   getOutputVolume: () => number;


### PR DESCRIPTION
## Summary
Fixes #655

- Adds a `VolumeProvider` abstraction and moves `getVolume()`/`getByteFrequencyData()` onto `InputController`/`OutputController`, so `VoiceConversation` no longer needs to know about platform-specific volume wiring.
- On React Native, uses `@livekit/react-native`'s native processors via `NativeEventEmitter`:
  - RMS volume processor for `getVolume()` (time-domain)
  - FFT multiband processor for `getByteFrequencyData()` (frequency-domain), with band count matching the caller's buffer size
  - Both processors are created lazily on first use, so no native resources are allocated unless the app actually reads volume or frequency data.
- On web, `WebRTCConnection` creates its own `AudioContext` + `AnalyserNode` for the local mic track (and re-creates it on input device switch to avoid stale readings).
- Fixes a bug where switching input devices on React Native would permanently lose the native volume provider (setupInputAnalyser now preserves external providers when AudioContext is unavailable).
- Extracts `calculateVolume()` into a shared utility used by both web and RN paths.
- Normalizes `getByteFrequencyData()` to the voice frequency range (100-8000 Hz) on all platforms. Web `AnalyserNode` returns full-spectrum bins (0 to sampleRate/2), while RN's multiband processor is configured for the voice range. The SDK now resamples the voice-relevant portion on web so both platforms return comparable frequency data.
- Clamps native volume values to [0, 1] to prevent `Uint8Array` wrapping (a magnitude slightly above 1.0 would wrap to 0 due to modulo-256 semantics).
- Fixes native multiband processor crash on Android by passing the required `updateInterval` option (iOS silently defaults to 40ms, Android throws without it).
- Extracts volume bar and frequency band visualizations in the example app into self-contained `VolumeBar` and `FrequencyBands` components.

> [!NOTE]
> **Notable change in `getByteFrequencyData()`** -- Previously on web, `getByteFrequencyData()` returned raw `AnalyserNode` data spanning the full spectrum (0 to sampleRate/2, typically 0-22kHz). It now returns data focused on the human voice range (100-8000 Hz), this is matching the React Native behavior which is also being introduced here. Consumers relying on full-spectrum frequency data from this method will see different output. The `getAnalyser()` method (deprecated) still provides direct access to the raw `AnalyserNode` if needed.

## Test plan
- [x] Unit tests pass (`npm run test` -- 164 tests, all green)
- [x] New test verifies external volume provider is preserved after `setAudioInputDevice()` when AudioContext is unavailable (RN scenario)
- [x] Verified on iOS Simulator: input and output volume indicators show non-zero values during a conversation
- [x] Verified frequency visualization is comparable between web and React Native
- [x] Manually verified volume and frequency visualization using the Expo example app on iOS and web
- [x] Verified on physical Android device: both input and output volume/frequency indicators work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core audio metering paths (WebRTC + React Native) and changes `get*ByteFrequencyData()` semantics to a voice-only range, which may affect downstream visualizers/analytics despite being well-contained and covered by new tests.
> 
> **Overview**
> Fixes React Native `getInputVolume()`/`getOutputVolume()` returning `0` by introducing a `VolumeProvider` abstraction and moving `getVolume()`/`getByteFrequencyData()` onto `InputController`/`OutputController`, with `VoiceConversation` delegating to those providers.
> 
> Adds platform-specific volume wiring: web `WebRTCConnection` now sets up/reconnects an input analyser for the mic and exposes pluggable input/output volume providers; React Native wraps the WebRTC session with lazy native LiveKit RMS/FFT processors (`nativeVolume.ts`) to supply real volume + multiband frequency data and cleans them up on detach.
> 
> Normalizes frequency data across platforms to the human voice range (100–8000 Hz) via new `utils/volumeProvider.ts` (plus shared `calculateVolume()`), expands WebRTC unit tests around provider preservation/device switching/mute, and updates the Expo example UI to display live volume + frequency visualizations (`VolumeBar`, `FrequencyBands`) and improve scrolling/layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e053a0eaf1238c6c5937b1cbdf5d6a900c08c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->