### PR TITLE
[Widget] Use server side message ordering for consistency

### DIFF
--- a/.changeset/fix-voice-transcript-ordering.md
+++ b/.changeset/fix-voice-transcript-ordering.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix transcript message ordering in voice mode where agent responses could appear before user messages.

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -316,6 +316,20 @@ describe("buildDisplayTranscript", () => {
       expect(result[1]).toMatchObject({ role: "agent", message: "Hello!" });
     });
 
+    it("sorts correctly when non-message entries sit between misordered messages", () => {
+      const input: TranscriptEntry[] = [
+        msg("agent", "Hello!", { eventId: 2, isText: false }),
+        { type: "mode_toggle", mode: "text", conversationIndex: 0 },
+        msg("user", "Hi", { eventId: 1, isText: false }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(3);
+      // Messages with eventId are reordered; mode_toggle stays in place
+      expect(result[0]).toMatchObject({ role: "user", message: "Hi" });
+      expect(result[1]).toMatchObject({ type: "mode_toggle" });
+      expect(result[2]).toMatchObject({ role: "agent", message: "Hello!" });
+    });
+
     it("keeps entries without eventId in their original position", () => {
       const input = [
         msg("user", "typed", { isText: true }),

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -293,6 +293,41 @@ describe("buildDisplayTranscript", () => {
     });
   });
 
+  describe("eventId sorting", () => {
+    it("reorders agent before user when agent_response arrives first in voice mode", () => {
+      const input = [
+        msg("agent", "Hello!", { eventId: 2, isText: false }),
+        msg("user", "Hi", { eventId: 1, isText: false }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ role: "user", message: "Hi" });
+      expect(result[1]).toMatchObject({ role: "agent", message: "Hello!" });
+    });
+
+    it("preserves order when eventIds are already sequential", () => {
+      const input = [
+        msg("user", "Hi", { eventId: 1, isText: false }),
+        msg("agent", "Hello!", { eventId: 2, isText: false }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ role: "user", message: "Hi" });
+      expect(result[1]).toMatchObject({ role: "agent", message: "Hello!" });
+    });
+
+    it("keeps entries without eventId in their original position", () => {
+      const input = [
+        msg("user", "typed", { isText: true }),
+        msg("agent", "response", { eventId: 5, isText: true }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ role: "user", message: "typed" });
+      expect(result[1]).toMatchObject({ role: "agent", message: "response" });
+    });
+  });
+
   describe("real HAR flows", () => {
     it.each<{
       description: string;

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -132,19 +132,34 @@ export function buildDisplayTranscript(
     result.push(entry);
   }
 
-  // Sort by eventId to fix ordering when server sends agent_response
-  // before user_transcript in voice mode.
-  result.sort((a, b) => {
-    const aId = a.type === "message" ? a.eventId : undefined;
-    const bId = b.type === "message" ? b.eventId : undefined;
-    if (aId != null && bId != null) return aId - bId;
-    return 0;
+  // Sort message entries by eventId to fix ordering when server sends
+  // agent_response before user_transcript in voice mode.
+  // Only reorder entries that have an eventId; leave others in place.
+  const sortableIndices: number[] = [];
+  const sortableEntries: DisplayTranscriptEntry[] = [];
+  for (let i = 0; i < result.length; i++) {
+    const entry = result[i];
+    if (entry.type === "message" && entry.eventId != null) {
+      sortableIndices.push(i);
+      sortableEntries.push(entry);
+    }
+  }
+  sortableEntries.sort((a, b) => {
+    const aId = (a as Extract<DisplayTranscriptEntry, { type: "message" }>)
+      .eventId!;
+    const bId = (b as Extract<DisplayTranscriptEntry, { type: "message" }>)
+      .eventId!;
+    return aId - bId;
   });
+  const sorted = [...result];
+  for (let i = 0; i < sortableIndices.length; i++) {
+    sorted[sortableIndices[i]] = sortableEntries[i];
+  }
 
   // Attach tool status to agent messages
   if (config.showAgentStatus) {
-    for (let i = 0; i < result.length; i++) {
-      const entry = result[i];
+    for (let i = 0; i < sorted.length; i++) {
+      const entry = sorted[i];
       if (
         entry.type !== "message" ||
         entry.role !== "agent" ||
@@ -160,9 +175,9 @@ export function buildDisplayTranscript(
           : status.error > 0
             ? ToolCallStatus.ERROR
             : ToolCallStatus.SUCCESS;
-      result[i] = { ...entry, toolStatus };
+      sorted[i] = { ...entry, toolStatus };
     }
   }
 
-  return result;
+  return sorted;
 }

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -132,6 +132,15 @@ export function buildDisplayTranscript(
     result.push(entry);
   }
 
+  // Sort by eventId to fix ordering when server sends agent_response
+  // before user_transcript in voice mode.
+  result.sort((a, b) => {
+    const aId = a.type === "message" ? a.eventId : undefined;
+    const bId = b.type === "message" ? b.eventId : undefined;
+    if (aId != null && bId != null) return aId - bId;
+    return 0;
+  });
+
   // Attach tool status to agent messages
   if (config.showAgentStatus) {
     for (let i = 0; i < result.length; i++) {


### PR DESCRIPTION
## Summary
- In voice mode, the server can send `agent_response` before `user_transcript` (agent starts generating while speech is still being transcribed)
- The widget appended messages in arrival order, causing agent responses to appear before the user's message
- Fix: sort display transcript entries by server-assigned `eventId` to ensure correct conversational ordering

Closes AP-1747

## Test plan
- [x] Added unit tests for eventId sorting in `buildDisplayTranscript`
- [x] Existing tests pass (24/24)
- [ ] Manual test: voice conversation should show user message before agent response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transcript ordering logic, which could affect how mixed message/non-message entries render and how tool statuses attach if eventIds are missing or duplicated. Scope is limited and covered by new unit tests for multiple ordering scenarios.
> 
> **Overview**
> Fixes voice-mode transcript ordering by **re-sorting message entries with an `eventId`** in `buildDisplayTranscript`, ensuring user transcripts appear before agent responses when events arrive out of order, while leaving non-`eventId` entries in place.
> 
> Adds targeted unit tests for `eventId` sorting behavior (including mixed non-message entries) and ships a patch changeset for `@elevenlabs/convai-widget-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5883c8099a70ded7caa3220432ceca0839730d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->