### PR TITLE
Type-check tests as part of build, remove redundant check-types

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,12 +15,11 @@
   "scripts": {
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
     "generate-worklets": "node scripts/generateWorklets.js",
-    "build:esm": "tsc --build tsconfig.build.json",
+    "build:esm": "tsc --build",
     "build:iife": "rolldown src/index.ts -f iife --name ElevenLabsClient -o dist/lib.iife.js --sourcemap --external react --external react-dom",
     "build": "node --run build:esm && node --run build:iife",
-    "dev": "tsc --build tsconfig.build.json --watch",
-    "clean": "tsc --build tsconfig.build.json --clean && rm -rf ./dist",
-    "check-types": "tsc --noEmit --project tsconfig.build.json && tsc --noEmit --project tsconfig.test.json",
+    "dev": "tsc --build --watch",
+    "clean": "tsc --build --clean && rm -rf ./dist",
     "lint:es": "pnpm exec eslint .",
     "lint:prettier": "prettier 'src/**/*.ts' --check",
     "test": "vitest"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,12 +17,11 @@
   "scripts": {
     "generate-version": "printf \"// This file is auto-generated during build\\nexport const PACKAGE_VERSION = \\\"%s\\\";\\n\" \"$npm_package_version\" > src/version.ts",
     "prebuild": "npm run generate-version",
-    "build:esm": "tsc --build tsconfig.build.json",
+    "build:esm": "tsc --build",
     "build:iife": "rolldown src/index.ts -f iife --name ElevenLabsReact -o dist/lib.iife.js --sourcemap --external react --external react-dom --external @elevenlabs/client --external @elevenlabs/client/internal",
     "build": "node --run build:esm && node --run build:iife",
-    "clean": "tsc --build tsconfig.build.json --clean && rm -rf ./dist",
-    "dev": "tsc --build tsconfig.build.json --watch",
-    "check-types": "tsc --noEmit --project tsconfig.build.json && tsc --noEmit --project tsconfig.test.json",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "dev": "tsc --build --watch",
     "lint:es": "pnpm exec eslint .",
     "lint:prettier": "prettier 'src/**/*.ts' --check",
     "test": "vitest"

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
         "tsconfig.json",
         "tsconfig.build.json"
       ],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "generated/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "generated/**", "*.tsbuildinfo"]
     },
     "test": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -9,10 +9,9 @@
         "$TURBO_DEFAULT$",
         ".env*",
         "src/**",
-        "!src/**/*.test.*",
-        "!src/**/*.spec.*",
         "tsconfig.json",
-        "tsconfig.build.json"
+        "tsconfig.build.json",
+        "tsconfig.test.json"
       ],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "generated/**", "*.tsbuildinfo"]
     },


### PR DESCRIPTION
## Summary
- In `client` and `react` packages, `tsc --build` now uses the root tsconfig (which references both build and test configs via project references), so test files are type-checked during build. This makes the separate `check-types` scripts redundant and removes them.
- Include `*.tsbuildinfo` in turbo build outputs so they are cached alongside `dist/`, preventing stale incremental state after cache restores.

## Test plan
- [x] Full `turbo lint --force` passes (29/29 tasks, 0 cached)
- [x] `turbo test` passes for client (162 tests) and react
- [x] Verified from fully clean state (deleted all dist/, .turbo/, *.tsbuildinfo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build pipeline changes can affect CI caching and TypeScript incremental state; risk is limited to tooling/config and should surface quickly via build/test failures.
> 
> **Overview**
> **TypeScript build now runs via root/project references** in `@elevenlabs/client` and `@elevenlabs/react` by switching `tsc --build tsconfig.build.json` to `tsc --build`, and removing the redundant `check-types` scripts.
> 
> **Turborepo build caching is adjusted** by including `tsconfig.test.json` in `build` inputs and adding `*.tsbuildinfo` to `build` outputs so incremental compilation state is cached/restored alongside `dist/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cbd482181ed061952c870fa53c2c212b2d91f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->