### PR TITLE
Add changeset for volume fix

### DIFF
--- a/.changeset/fix-volume-react-native.md
+++ b/.changeset/fix-volume-react-native.md
@@ -1,6 +1,9 @@
 ---
-"@elevenlabs/client": patch
-"@elevenlabs/react-native": patch
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/react-native": minor
 ---
 
-Fix getInputVolume/getOutputVolume returning 0 in React Native by adding native volume providers using LiveKit's RMS and multiband FFT processors. On web, getVolume() now computes from the voice frequency range (100-8000 Hz) instead of the full spectrum, and getByteFrequencyData() is normalized to the same range on both platforms.
+Fix getInputVolume/getOutputVolume returning 0 in React Native by adding native volume providers using LiveKit's RMS and multiband FFT processors.
+
+**Breaking:** `getByteFrequencyData()` now returns data focused on the human voice range (100-8000 Hz) instead of the full spectrum (0 to sampleRate/2). On web, `getVolume()` is also computed from this range. The deprecated `getAnalyser()` method still provides direct access to the raw `AnalyserNode` for consumers needing full-spectrum data.

--- a/.changeset/fix-volume-react-native.md
+++ b/.changeset/fix-volume-react-native.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react-native": patch
+---
+
+Fix getInputVolume/getOutputVolume returning 0 in React Native by adding native volume providers using LiveKit's RMS and multiband FFT processors. On web, getVolume() now computes from the voice frequency range (100-8000 Hz) instead of the full spectrum, and getByteFrequencyData() is normalized to the same range on both platforms.


### PR DESCRIPTION
## Summary
- Adds missing changeset for PR #657 (Fix getInputVolume/getOutputVolume returning 0 in React Native)
- Patches `@elevenlabs/client` and `@elevenlabs/react-native`

## Test plan
- [x] No code changes, changeset only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changeset-only PR that updates release metadata and communicates a breaking behavior change for `getByteFrequencyData()`; no runtime code changes.
> 
> **Overview**
> Adds a new changeset to publish *minor* bumps for `@elevenlabs/client`, `@elevenlabs/react`, and `@elevenlabs/react-native` for the React Native volume fix.
> 
> Documents a **breaking** behavioral change: `getByteFrequencyData()` (and web `getVolume()`) now uses the 100–8000 Hz voice band, with `getAnalyser()` remaining as the escape hatch for full-spectrum access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40aa3df8e447124a81863dd15b7cf449b2fc3ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->