### PR TITLE
Add missing changeset for #659

### DIFF
--- a/.changeset/fix-startsession-error-swallowed.md
+++ b/.changeset/fix-startsession-error-swallowed.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/react": patch
+---
+
+Fix `startSession` errors being swallowed instead of surfaced via `onError` in `ConversationProvider`. Previously, when `Conversation.startSession()` rejected (e.g. "agent not found"), the UI would get stuck in "connecting" with no error feedback.


### PR DESCRIPTION
## Summary
- Adds the missing changeset (`patch` for `@elevenlabs/react`) for #659 which surfaced `startSession` errors via `onError` instead of swallowing them.

## Test plan
- [x] Changeset file is valid and references the correct package and bump level

🤖 Generated with [Claude Code](https://claude.com/claude-code)