### PR TITLE
fix(react): fire onConnect after conversationRef is set

### DIFF
--- a/.changeset/fix-conversation-ready-lifecycle.md
+++ b/.changeset/fix-conversation-ready-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react": patch
+---
+
+Fix conversation startup readiness so `onConnect` runs after the session is marked connected and React has synchronized `conversationRef`. Also expose and forward `onConversationCreated` for consumers that need the created `Conversation` instance before `onConnect`.

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -5,6 +5,7 @@ import type {
   SessionConfig,
   FormatConfig,
 } from "./utils/BaseConnection.js";
+import type { Conversation } from "./index.js";
 import type {
   AgentAudioEvent,
   AgentChatResponsePartEvent,
@@ -39,8 +40,15 @@ export type AudioWorkletConfig = {
   libsampleratePath?: string;
 };
 
+export type ConversationCreatedCallback = (conversation: Conversation) => void;
+
+export type ConversationLifecycleOptions = {
+  onConversationCreated?: ConversationCreatedCallback;
+};
+
 export type Options = SessionConfig &
   Callbacks &
+  ConversationLifecycleOptions &
   ClientToolsConfig &
   InputConfig &
   OutputConfig &
@@ -48,6 +56,7 @@ export type Options = SessionConfig &
 
 export type PartialOptions = SessionConfig &
   Partial<Callbacks> &
+  ConversationLifecycleOptions &
   Partial<ClientToolsConfig> &
   Partial<InputConfig> &
   Partial<OutputConfig> &
@@ -127,12 +136,12 @@ export abstract class BaseConversation {
     protected readonly options: Options,
     protected readonly connection: BaseConnection
   ) {
-    if (this.options.onConnect) {
-      this.options.onConnect({ conversationId: connection.conversationId });
-    }
     this.connection.onMessage(this.onMessage);
     this.connection.onDisconnect(this.endSessionWithDetails);
     this.connection.onModeChange(mode => this.updateMode(mode));
+  }
+
+  protected markConnected() {
     this.updateStatus("connected");
   }
 

--- a/packages/client/src/TextConversation.ts
+++ b/packages/client/src/TextConversation.ts
@@ -51,15 +51,22 @@ export class TextConversation extends BaseConversation {
     }
 
     let connection: BaseConnection | null = null;
+    let conversation: TextConversation | null = null;
     try {
       await applyDelay(fullOptions.connectionDelay);
       connection = await createConnection(fullOptions);
-      return new TextConversation(fullOptions, connection);
+      conversation = new TextConversation(fullOptions, connection);
+      fullOptions.onConversationCreated?.(conversation);
+      conversation.markConnected();
+      fullOptions.onConnect?.({ conversationId: connection.conversationId });
+      return conversation;
     } catch (error) {
-      if (fullOptions.onStatusChange) {
-        fullOptions.onStatusChange({ status: "disconnected" });
+      if (conversation) {
+        await conversation.endSession().catch(() => {});
+      } else {
+        fullOptions.onStatusChange?.({ status: "disconnected" });
+        connection?.close();
       }
-      connection?.close();
       throw error;
     }
   }

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -44,6 +44,7 @@ export class VoiceConversation extends BaseConversation {
     }
 
     let preliminaryInputStream: MediaStream | null = null;
+    let conversation: VoiceConversation | null = null;
 
     const useWakeLock = options.useWakeLock ?? true;
     let wakeLock: WakeLockSentinel | null = null;
@@ -72,7 +73,7 @@ export class VoiceConversation extends BaseConversation {
       });
       preliminaryInputStream = null;
 
-      return new VoiceConversation(
+      conversation = new VoiceConversation(
         fullOptions,
         sessionSetup.connection,
         sessionSetup.input,
@@ -81,13 +82,21 @@ export class VoiceConversation extends BaseConversation {
         sessionSetup.detach,
         wakeLock
       );
+      fullOptions.onConversationCreated?.(conversation);
+      conversation.markConnected();
+      fullOptions.onConnect?.({
+        conversationId: sessionSetup.connection.conversationId,
+      });
+      return conversation;
     } catch (error) {
-      if (fullOptions.onStatusChange) {
-        fullOptions.onStatusChange({ status: "disconnected" });
-      }
       preliminaryInputStream?.getTracks().forEach(track => {
         track.stop();
       });
+      if (conversation) {
+        await conversation.endSession().catch(() => {});
+      } else {
+        fullOptions.onStatusChange?.({ status: "disconnected" });
+      }
       try {
         await wakeLock?.release();
         wakeLock = null;

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -355,6 +355,94 @@ describe("Conversation", () => {
       );
     }
   );
+
+  it.each(ConversationTypes)(
+    "marks the session connected before onConnect (%s)",
+    async conversationType => {
+      const server = new Server(
+        `wss://api.elevenlabs.io/${conversationType}/connected-before-onconnect`
+      );
+      const clientPromise = new Promise<Client>((resolve, reject) => {
+        server.on("connection", socket => {
+          resolve(socket);
+        });
+        server.on("error", reject);
+        setTimeout(() => reject(new Error("timeout")), 5000);
+      });
+
+      let status: Status | null = null;
+      let statusAtOnConnect: Status | null = null;
+
+      const conversationPromise = Conversation.startSession({
+        signedUrl: `wss://api.elevenlabs.io/${conversationType}/connected-before-onconnect`,
+        onConnect: () => {
+          statusAtOnConnect = status;
+        },
+        onStatusChange: value => {
+          status = value.status;
+        },
+        connectionDelay: { default: 0 },
+        textOnly: conversationType === "text",
+      });
+
+      const client = await clientPromise;
+      client.send(
+        JSON.stringify({
+          type: "conversation_initiation_metadata",
+          conversation_initiation_metadata_event: {
+            conversation_id: CONVERSATION_ID,
+            agent_output_audio_format: OUTPUT_AUDIO_FORMAT,
+          },
+        })
+      );
+
+      const conversation = await conversationPromise;
+      expect(statusAtOnConnect).toBe("connected");
+      expect(conversation.isOpen()).toBe(true);
+
+      await conversation.endSession();
+      server.close();
+    }
+  );
+
+  it("preserves the original startup error when cleanup throws", async () => {
+    const server = new Server("wss://api.elevenlabs.io/text/startup-error");
+    const clientPromise = new Promise<Client>((resolve, reject) => {
+      server.on("connection", socket => {
+        resolve(socket);
+      });
+      server.on("error", reject);
+      setTimeout(() => reject(new Error("timeout")), 5000);
+    });
+
+    const originalError = new Error("onConnect failed");
+    const startSessionPromise = Conversation.startSession({
+      signedUrl: "wss://api.elevenlabs.io/text/startup-error",
+      connectionDelay: { default: 0 },
+      textOnly: true,
+      onConnect: () => {
+        throw originalError;
+      },
+      onDisconnect: () => {
+        throw new Error("cleanup failed");
+      },
+    });
+
+    const client = await clientPromise;
+    client.send(
+      JSON.stringify({
+        type: "conversation_initiation_metadata",
+        conversation_initiation_metadata_event: {
+          conversation_id: CONVERSATION_ID,
+          agent_output_audio_format: OUTPUT_AUDIO_FORMAT,
+        },
+      })
+    );
+
+    await expect(startSessionPromise).rejects.toBe(originalError);
+
+    server.close();
+  });
 });
 
 describe("Connection Types", () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,6 +12,8 @@ export type {
   Status,
   AudioWorkletConfig,
   MultimodalMessageInput,
+  ConversationCreatedCallback,
+  ConversationLifecycleOptions,
 } from "./BaseConversation.js";
 export type { InputController, InputDeviceConfig } from "./InputController.js";
 export type {

--- a/packages/client/src/internal.ts
+++ b/packages/client/src/internal.ts
@@ -19,3 +19,7 @@ export {
   MIN_VOICE_FREQUENCY,
   MAX_VOICE_FREQUENCY,
 } from "./utils/volumeProvider.js";
+export type {
+  ConversationCreatedCallback,
+  ConversationLifecycleOptions,
+} from "./BaseConversation.js";

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -706,6 +706,64 @@ describe("ConversationProvider", () => {
       mockConversation
     );
   });
+
+  it("ignores stale startSession resolution after restarting inside onConnect", async () => {
+    const firstConversation = createMockConversation("first-id");
+    const secondConversation = createMockConversation("second-id");
+    const { promise: firstPromise, resolve: resolveFirst } =
+      Promise.withResolvers<Conversation>();
+    const { promise: secondPromise, resolve: resolveSecond } =
+      Promise.withResolvers<Conversation>();
+    let firstOptions: MockStartSessionOptions | null = null;
+    let secondOptions: MockStartSessionOptions | null = null;
+
+    vi.mocked(Conversation.startSession).mockImplementation(options => {
+      if (!firstOptions) {
+        firstOptions = options as MockStartSessionOptions;
+        return firstPromise;
+      }
+      secondOptions = options as MockStartSessionOptions;
+      return secondPromise;
+    });
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.startSession({
+        onConnect: () => {
+          result.current.endSession();
+          result.current.startSession();
+        },
+      });
+    });
+
+    act(() => {
+      driveConnectedSessionLifecycle(firstOptions!, firstConversation);
+    });
+
+    expect(Conversation.startSession).toHaveBeenCalledTimes(2);
+    expect(result.current.conversation).toBeNull();
+
+    act(() => {
+      driveConnectedSessionLifecycle(secondOptions!, secondConversation);
+    });
+
+    expect(result.current.conversation).toBe(secondConversation);
+
+    await act(async () => {
+      resolveFirst(firstConversation);
+    });
+
+    expect(result.current.conversation).toBe(secondConversation);
+
+    await act(async () => {
+      resolveSecond(secondConversation);
+    });
+
+    expect(result.current.conversation).toBe(secondConversation);
+  });
 });
 
 describe("CALLBACK_KEYS", () => {

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -764,6 +764,59 @@ describe("ConversationProvider", () => {
 
     expect(result.current.conversation).toBe(secondConversation);
   });
+
+  it("ignores stale startSession rejection after restarting inside onConnect", async () => {
+    const onError = vi.fn();
+    const firstConversation = createMockConversation("first-id");
+    const secondConversation = createMockConversation("second-id");
+    const firstError = new Error("first failed");
+    const { promise: firstPromise, reject: rejectFirst } =
+      Promise.withResolvers<Conversation>();
+    const { promise: secondPromise, resolve: resolveSecond } =
+      Promise.withResolvers<Conversation>();
+    let firstOptions: MockStartSessionOptions | null = null;
+    let secondOptions: MockStartSessionOptions | null = null;
+
+    vi.mocked(Conversation.startSession).mockImplementation(options => {
+      if (!firstOptions) {
+        firstOptions = options as MockStartSessionOptions;
+        return firstPromise;
+      }
+      secondOptions = options as MockStartSessionOptions;
+      return secondPromise;
+    });
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper({ onError }),
+    });
+
+    act(() => {
+      result.current.startSession({
+        onConnect: () => {
+          result.current.endSession();
+          result.current.startSession();
+        },
+      });
+    });
+
+    act(() => {
+      driveConnectedSessionLifecycle(firstOptions!, firstConversation);
+      driveConnectedSessionLifecycle(secondOptions!, secondConversation);
+    });
+
+    expect(result.current.conversation).toBe(secondConversation);
+
+    await act(async () => {
+      rejectFirst(firstError);
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(result.current.conversation).toBe(secondConversation);
+
+    await act(async () => {
+      resolveSecond(secondConversation);
+    });
+  });
 });
 
 describe("CALLBACK_KEYS", () => {

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -672,6 +672,40 @@ describe("ConversationProvider", () => {
     expect(onError).toHaveBeenCalledWith("boom", expect.any(Error));
     expect(result.current.conversation).toBeNull();
   });
+
+  it("forwards user onConversationCreated after provider sets conversationRef", async () => {
+    const mockConversation = createMockConversation();
+    const userOnConversationCreated = vi.fn();
+
+    vi.mocked(Conversation.startSession).mockImplementation(async opts => {
+      driveConnectedSessionLifecycle(
+        opts as MockStartSessionOptions,
+        mockConversation
+      );
+      return mockConversation;
+    });
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession({
+        onConversationCreated(conv) {
+          userOnConversationCreated(
+            conv,
+            result.current.conversationRef.current
+          );
+        },
+      });
+    });
+
+    expect(userOnConversationCreated).toHaveBeenCalledTimes(1);
+    expect(userOnConversationCreated).toHaveBeenCalledWith(
+      mockConversation,
+      mockConversation
+    );
+  });
 });
 
 describe("CALLBACK_KEYS", () => {

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -32,6 +32,7 @@ const createMockConversation = (id = "test-id") =>
     endSession: vi.fn().mockResolvedValue(undefined),
     setMicMuted: vi.fn(),
     setVolume: vi.fn(),
+    sendUserMessage: vi.fn(),
   }) as unknown as Conversation;
 
 function createWrapper(props: Record<string, unknown> = {}) {
@@ -241,10 +242,7 @@ describe("ConversationProvider", () => {
       });
     });
 
-    // Invoke the composed onConnect that was passed to startSession
-    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
-    opts.onConnect!({ conversationId: "test-id" });
-
+    // onConnect is fired by the provider after startSession resolves
     expect(propCalls).toEqual(["prop"]);
     expect(sessionCalls).toEqual(["session"]);
   });
@@ -265,9 +263,6 @@ describe("ConversationProvider", () => {
       result.current.startSession();
     });
 
-    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
-    opts.onConnect!({ conversationId: "test-id" });
-
     expect(propCalls).toEqual(["prop"]);
   });
 
@@ -286,9 +281,6 @@ describe("ConversationProvider", () => {
         onConnect: () => sessionCalls.push("session"),
       });
     });
-
-    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
-    opts.onConnect!({ conversationId: "test-id" });
 
     expect(sessionCalls).toEqual(["session"]);
   });
@@ -562,8 +554,6 @@ describe("ConversationProvider", () => {
       </ConversationProvider>
     );
 
-    // We test the stable callback pattern by checking that
-    // Conversation.startSession is called with callbacks
     const mockConversation = createMockConversation();
     vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
 
@@ -575,14 +565,58 @@ describe("ConversationProvider", () => {
       result.current.startSession();
     });
 
-    // Verify Conversation.startSession was called with the provided callback
     const startSessionCall = vi.mocked(Conversation.startSession).mock
       .calls[0][0];
-    expect(typeof startSessionCall.onConnect).toBe("function");
+    // onConnect is stripped from options and fired by the provider after
+    // startSession resolves, so it should NOT be on the options object
+    expect(startSessionCall.onConnect).toBeUndefined();
     // onDisconnect is registered internally by the provider
     expect(typeof startSessionCall.onDisconnect).toBe("function");
     // Unprovided callbacks are omitted so client feature guards work
     expect(startSessionCall.onUnhandledClientToolCall).toBeUndefined();
+    // onConnect should still have been called
+    expect(onConnect).toHaveBeenCalledWith({ conversationId: "test-id" });
+  });
+
+  it("can send a message from onConnect without throwing", async () => {
+    const mockConversation = createMockConversation();
+
+    // Simulate real behavior: onConnect fires during startSession (inside
+    // the BaseConversation constructor) before the promise resolves.
+    vi.mocked(Conversation.startSession).mockImplementation(async opts => {
+      opts.onConnect?.({ conversationId: "test-id" });
+      return mockConversation;
+    });
+
+    const onConnectError = vi.fn();
+
+    function useTestHarness() {
+      const ctx = useContext(ConversationContext)!;
+      return {
+        startSession: () =>
+          ctx.startSession({
+            onConnect: () => {
+              try {
+                const conv = ctx.conversationRef.current;
+                conv!.sendUserMessage("hello");
+              } catch (e) {
+                onConnectError(e);
+              }
+            },
+          }),
+      };
+    }
+
+    const { result } = renderHook(() => useTestHarness(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    expect(onConnectError).not.toHaveBeenCalled();
+    expect(mockConversation.sendUserMessage).toHaveBeenCalledWith("hello");
   });
 });
 

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import React, { useContext } from "react";
 import { renderHook, act } from "@testing-library/react";
-import { Conversation, type Callbacks } from "@elevenlabs/client";
+import {
+  Conversation,
+  type Callbacks,
+  type ConversationLifecycleOptions,
+} from "@elevenlabs/client";
 import { CALLBACK_KEYS } from "@elevenlabs/client/internal";
 import { ConversationProvider } from "./ConversationProvider.js";
 import {
@@ -43,6 +47,29 @@ function createWrapper(props: Record<string, unknown> = {}) {
       </ConversationProvider>
     );
   };
+}
+
+type MockStartSessionOptions = Partial<Callbacks & ConversationLifecycleOptions> &
+  Record<string, unknown>;
+
+function driveConnectedSessionLifecycle(
+  options: MockStartSessionOptions,
+  conversation: Conversation
+) {
+  options.onConversationCreated?.(conversation);
+  options.onStatusChange?.({ status: "connected" });
+  options.onConnect?.({ conversationId: conversation.getId() });
+}
+
+function mockStartSessionWithLifecycle(conversation = createMockConversation()) {
+  vi.mocked(Conversation.startSession).mockImplementation(async options => {
+    driveConnectedSessionLifecycle(
+      options as MockStartSessionOptions,
+      conversation
+    );
+    return conversation;
+  });
+  return conversation;
 }
 
 describe("ConversationProvider", () => {
@@ -227,8 +254,7 @@ describe("ConversationProvider", () => {
     const propCalls: string[] = [];
     const sessionCalls: string[] = [];
 
-    const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+    mockStartSessionWithLifecycle();
 
     const { result } = renderHook(() => useTestContext(), {
       wrapper: createWrapper({
@@ -242,7 +268,7 @@ describe("ConversationProvider", () => {
       });
     });
 
-    // onConnect is fired by the provider after startSession resolves
+    // onConnect is forwarded through the provider-owned wrapper.
     expect(propCalls).toEqual(["prop"]);
     expect(sessionCalls).toEqual(["session"]);
   });
@@ -250,8 +276,7 @@ describe("ConversationProvider", () => {
   it("calls only the prop callback when startSession provides none", async () => {
     const propCalls: string[] = [];
 
-    const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+    mockStartSessionWithLifecycle();
 
     const { result } = renderHook(() => useTestContext(), {
       wrapper: createWrapper({
@@ -269,8 +294,7 @@ describe("ConversationProvider", () => {
   it("calls only the startSession callback when no prop callback is set", async () => {
     const sessionCalls: string[] = [];
 
-    const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+    mockStartSessionWithLifecycle();
 
     const { result } = renderHook(() => useTestContext(), {
       wrapper: createWrapper(),
@@ -554,8 +578,7 @@ describe("ConversationProvider", () => {
       </ConversationProvider>
     );
 
-    const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+    mockStartSessionWithLifecycle();
 
     const { result } = renderHook(() => useTestContext(), {
       wrapper,
@@ -567,9 +590,11 @@ describe("ConversationProvider", () => {
 
     const startSessionCall = vi.mocked(Conversation.startSession).mock
       .calls[0][0];
-    // onConnect is stripped from options and fired by the provider after
-    // startSession resolves, so it should NOT be on the options object
-    expect(startSessionCall.onConnect).toBeUndefined();
+    // onConnect is wrapped by the provider and forwarded through the SDK.
+    expect(typeof startSessionCall.onConnect).toBe("function");
+    expect(
+      typeof (startSessionCall as MockStartSessionOptions).onConversationCreated
+    ).toBe("function");
     // onDisconnect is registered internally by the provider
     expect(typeof startSessionCall.onDisconnect).toBe("function");
     // Unprovided callbacks are omitted so client feature guards work
@@ -581,10 +606,11 @@ describe("ConversationProvider", () => {
   it("can send a message from onConnect without throwing", async () => {
     const mockConversation = createMockConversation();
 
-    // Simulate real behavior: onConnect fires during startSession (inside
-    // the BaseConversation constructor) before the promise resolves.
     vi.mocked(Conversation.startSession).mockImplementation(async opts => {
-      opts.onConnect?.({ conversationId: "test-id" });
+      driveConnectedSessionLifecycle(
+        opts as MockStartSessionOptions,
+        mockConversation
+      );
       return mockConversation;
     });
 
@@ -617,6 +643,34 @@ describe("ConversationProvider", () => {
 
     expect(onConnectError).not.toHaveBeenCalled();
     expect(mockConversation.sendUserMessage).toHaveBeenCalledWith("hello");
+  });
+
+  it("clears the active conversation when onConnect throws", async () => {
+    const mockConversation = createMockConversation();
+    const onError = vi.fn();
+
+    vi.mocked(Conversation.startSession).mockImplementation(async opts => {
+      driveConnectedSessionLifecycle(
+        opts as MockStartSessionOptions,
+        mockConversation
+      );
+      return mockConversation;
+    });
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper({ onError }),
+    });
+
+    await act(async () => {
+      result.current.startSession({
+        onConnect: () => {
+          throw new Error("boom");
+        },
+      });
+    });
+
+    expect(onError).toHaveBeenCalledWith("boom", expect.any(Error));
+    expect(result.current.conversation).toBeNull();
   });
 });
 

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -6,7 +6,12 @@ import {
   useRef,
   useState,
 } from "react";
-import { Conversation, type Options, type Callbacks } from "@elevenlabs/client";
+import {
+  Conversation,
+  type Options,
+  type Callbacks,
+  type ConversationLifecycleOptions,
+} from "@elevenlabs/client";
 import {
   CALLBACK_KEYS,
   mergeOptions,
@@ -145,9 +150,34 @@ export function ConversationProvider({
       clientToolsRef.current = clientTools;
       sessionOptions.clientTools = clientTools;
 
-      const { onConnect, ...sessionOptionsWithoutOnConnect } = sessionOptions;
+      const handleConversationCreated = (conv: Conversation) => {
+        if (shouldEndRef.current) {
+          return;
+        }
+        conversationRef.current = conv;
+        setConversation(conv);
+      };
 
-      lockRef.current = Conversation.startSession(sessionOptionsWithoutOnConnect);
+      const handleConnect: NonNullable<Callbacks["onConnect"]> = props => {
+        if (shouldEndRef.current) {
+          return;
+        }
+        lockRef.current = null;
+        sessionOptions.onConnect?.(props);
+      };
+
+      const providerLifecycleOptions: ConversationLifecycleOptions &
+        Pick<Callbacks, "onConnect"> = {
+        onConversationCreated: handleConversationCreated,
+        onConnect: handleConnect,
+      };
+
+      const startSessionOptions: Options = {
+        ...sessionOptions,
+        ...providerLifecycleOptions,
+      };
+
+      lockRef.current = Conversation.startSession(startSessionOptions);
 
       lockRef.current.then(
         conv => {
@@ -156,12 +186,15 @@ export function ConversationProvider({
             lockRef.current = null;
             return;
           }
-          conversationRef.current = conv;
-          setConversation(conv);
+          if (conversationRef.current !== conv) {
+            conversationRef.current = conv;
+            setConversation(conv);
+          }
           lockRef.current = null;
-          onConnect?.({ conversationId: conv.getId() });
         },
         (error: unknown) => {
+          conversationRef.current = null;
+          setConversation(null);
           lockRef.current = null;
           if (shouldEndRef.current) {
             return;

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -150,12 +150,15 @@ export function ConversationProvider({
       clientToolsRef.current = clientTools;
       sessionOptions.clientTools = clientTools;
 
+      const userOnConversationCreated = sessionOptions.onConversationCreated;
+
       const handleConversationCreated = (conv: Conversation) => {
         if (shouldEndRef.current) {
           return;
         }
         conversationRef.current = conv;
         setConversation(conv);
+        userOnConversationCreated?.(conv);
       };
 
       const handleConnect: NonNullable<Callbacks["onConnect"]> = props => {

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -145,7 +145,9 @@ export function ConversationProvider({
       clientToolsRef.current = clientTools;
       sessionOptions.clientTools = clientTools;
 
-      lockRef.current = Conversation.startSession(sessionOptions);
+      const { onConnect, ...sessionOptionsWithoutOnConnect } = sessionOptions;
+
+      lockRef.current = Conversation.startSession(sessionOptionsWithoutOnConnect);
 
       lockRef.current.then(
         conv => {
@@ -157,6 +159,7 @@ export function ConversationProvider({
           conversationRef.current = conv;
           setConversation(conv);
           lockRef.current = null;
+          onConnect?.({ conversationId: conv.getId() });
         },
         (error: unknown) => {
           lockRef.current = null;

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -67,6 +67,8 @@ export function ConversationProvider({
   const conversationRef = useRef<Conversation | null>(null);
   /** In-flight startSession promise, used to prevent duplicate connections. */
   const lockRef = useRef<Promise<Conversation> | null>(null);
+  /** Monotonic id used to ignore stale async handlers from older starts. */
+  const startSessionIdRef = useRef(0);
   /** Signals that endSession was called while a connection was still pending. */
   const shouldEndRef = useRef(false);
   /** Registry of hook-registered client tools. Survives across sessions. */
@@ -117,6 +119,7 @@ export function ConversationProvider({
       }
 
       shouldEndRef.current = false;
+      const startSessionId = ++startSessionIdRef.current;
 
       const defaults = defaultOptionsRef.current;
       const resolvedServerLocation = parseLocation(
@@ -151,9 +154,11 @@ export function ConversationProvider({
       sessionOptions.clientTools = clientTools;
 
       const userOnConversationCreated = sessionOptions.onConversationCreated;
+      const isStaleStartSession = () =>
+        startSessionId !== startSessionIdRef.current;
 
       const handleConversationCreated = (conv: Conversation) => {
-        if (shouldEndRef.current) {
+        if (shouldEndRef.current || isStaleStartSession()) {
           return;
         }
         conversationRef.current = conv;
@@ -162,7 +167,7 @@ export function ConversationProvider({
       };
 
       const handleConnect: NonNullable<Callbacks["onConnect"]> = props => {
-        if (shouldEndRef.current) {
+        if (shouldEndRef.current || isStaleStartSession()) {
           return;
         }
         lockRef.current = null;
@@ -184,6 +189,9 @@ export function ConversationProvider({
 
       lockRef.current.then(
         conv => {
+          if (isStaleStartSession()) {
+            return;
+          }
           if (shouldEndRef.current) {
             conv.endSession();
             lockRef.current = null;
@@ -196,6 +204,9 @@ export function ConversationProvider({
           lockRef.current = null;
         },
         (error: unknown) => {
+          if (isStaleStartSession()) {
+            return;
+          }
           conversationRef.current = null;
           setConversation(null);
           lockRef.current = null;

--- a/packages/react/src/conversation/ConversationStatus.test.tsx
+++ b/packages/react/src/conversation/ConversationStatus.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import React, { useContext } from "react";
 import { renderHook, act } from "@testing-library/react";
-import { Conversation } from "@elevenlabs/client";
+import {
+  Conversation,
+  type Callbacks,
+  type ConversationLifecycleOptions,
+} from "@elevenlabs/client";
 import { ConversationProvider } from "./ConversationProvider.js";
 import {
   ConversationContext,
@@ -37,6 +41,18 @@ function createWrapper(props: Record<string, unknown> = {}) {
       </ConversationProvider>
     );
   };
+}
+
+type MockStartSessionOptions = Partial<Callbacks & ConversationLifecycleOptions> &
+  Record<string, unknown>;
+
+function driveConnectedSessionLifecycle(
+  options: MockStartSessionOptions,
+  conversation: Conversation
+) {
+  options.onConversationCreated?.(conversation);
+  options.onStatusChange?.({ status: "connected" });
+  options.onConnect?.({ conversationId: conversation.getId() });
 }
 
 describe("ConversationStatus", () => {
@@ -153,6 +169,32 @@ describe("ConversationStatus", () => {
 
     expect(result.current.status.status).toBe("error");
     expect(result.current.status.message).toBe("agent not found");
+  });
+
+  it("transitions to error status when onConnect throws", async () => {
+    const mockConversation = createMockConversation();
+    vi.mocked(Conversation.startSession).mockImplementation(async options => {
+      driveConnectedSessionLifecycle(
+        options as MockStartSessionOptions,
+        mockConversation
+      );
+      return mockConversation;
+    });
+
+    const { result } = renderHook(() => useTestHook(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession({
+        onConnect: () => {
+          throw new Error("boom");
+        },
+      });
+    });
+
+    expect(result.current.status.status).toBe("error");
+    expect(result.current.status.message).toBe("boom");
   });
 
   it("ignores disconnecting status (transient)", async () => {

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -6,6 +6,7 @@ import type {
   OutputConfig,
   FormatConfig,
   Callbacks,
+  ConversationLifecycleOptions,
   Location,
 } from "@elevenlabs/client";
 
@@ -46,6 +47,7 @@ export type HookCallbacks = Pick<
 export type HookOptions = Partial<
   SessionConfig &
     HookCallbacks &
+    ConversationLifecycleOptions &
     ClientToolsConfig &
     InputConfig &
     OutputConfig &

--- a/packages/react/src/conversation/useConversation.test.tsx
+++ b/packages/react/src/conversation/useConversation.test.tsx
@@ -176,12 +176,12 @@ describe("useConversation", () => {
       result.current.startSession({ signedUrl: "wss://test.example.com" });
     });
 
-    // Invoke the callbacks that were passed to Conversation.startSession
-    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
-    opts.onConnect!({ conversationId: "test-id" });
-    opts.onError!("something went wrong", { type: "unknown" });
-
+    // onConnect is fired by the provider after startSession resolves
     expect(onConnect).toHaveBeenCalledWith({ conversationId: "test-id" });
+
+    // onError is still passed through to the SDK — invoke it manually
+    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
+    opts.onError!("something went wrong", { type: "unknown" });
     expect(onError).toHaveBeenCalledWith("something went wrong", { type: "unknown" });
   });
 
@@ -200,9 +200,7 @@ describe("useConversation", () => {
       result.current.startSession({ signedUrl: "wss://test.example.com" });
     });
 
-    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
-    opts.onConnect!({ conversationId: "test-id" });
-
+    // onConnect is fired by the provider after startSession resolves
     expect(providerOnConnect).toHaveBeenCalledWith({ conversationId: "test-id" });
     expect(hookOnConnect).toHaveBeenCalledWith({ conversationId: "test-id" });
   });
@@ -224,9 +222,7 @@ describe("useConversation", () => {
       });
     });
 
-    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
-    opts.onConnect!({ conversationId: "test-id" });
-
+    // onConnect is fired by the provider after startSession resolves
     expect(calls).toContain("provider");
     expect(calls).toContain("hook");
     expect(calls).toContain("startSession");
@@ -235,7 +231,11 @@ describe("useConversation", () => {
   it("always invokes the latest hook callback (no stale closures)", async () => {
     const calls: string[] = [];
     const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+
+    // Use a deferred promise so we can rerender before resolving
+    const { promise, resolve: resolveStartSession } =
+      Promise.withResolvers<typeof mockConversation>();
+    vi.mocked(Conversation.startSession).mockReturnValue(promise);
 
     const { result, rerender } = renderHook(
       ({ cb }: { cb: () => void }) => useConversation({ onConnect: cb }),
@@ -245,16 +245,18 @@ describe("useConversation", () => {
       },
     );
 
-    await act(async () => {
+    act(() => {
       result.current.startSession({ signedUrl: "wss://test.example.com" });
     });
 
-    // Update the callback after the session has started
+    // Update the callback before the session resolves
     rerender({ cb: () => calls.push("second") });
 
-    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
-    opts.onConnect!({ conversationId: "test-id" });
+    await act(async () => {
+      resolveStartSession(mockConversation);
+    });
 
+    // Should invoke the latest callback, not the stale one
     expect(calls).toEqual(["second"]);
   });
 

--- a/packages/react/src/conversation/useConversation.test.tsx
+++ b/packages/react/src/conversation/useConversation.test.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { it, expect, describe, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { Conversation } from "@elevenlabs/client";
+import {
+  Conversation,
+  type Callbacks,
+  type ConversationLifecycleOptions,
+} from "@elevenlabs/client";
 import { useConversation } from "./useConversation.js";
 import { ConversationProvider } from "./ConversationProvider.js";
 
@@ -34,6 +38,29 @@ function createWrapper(props: Record<string, unknown> = {}) {
       <ConversationProvider {...props}>{children}</ConversationProvider>
     );
   };
+}
+
+type MockStartSessionOptions = Partial<Callbacks & ConversationLifecycleOptions> &
+  Record<string, unknown>;
+
+function driveConnectedSessionLifecycle(
+  options: MockStartSessionOptions,
+  conversation: Conversation
+) {
+  options.onConversationCreated?.(conversation);
+  options.onStatusChange?.({ status: "connected" });
+  options.onConnect?.({ conversationId: conversation.getId() });
+}
+
+function mockStartSessionWithLifecycle(conversation = createMockConversation()) {
+  vi.mocked(Conversation.startSession).mockImplementation(async options => {
+    driveConnectedSessionLifecycle(
+      options as MockStartSessionOptions,
+      conversation
+    );
+    return conversation;
+  });
+  return conversation;
 }
 
 describe("useConversation", () => {
@@ -164,8 +191,7 @@ describe("useConversation", () => {
   it("registers hook callbacks so they are invoked during a session", async () => {
     const onConnect = vi.fn();
     const onError = vi.fn();
-    const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+    mockStartSessionWithLifecycle();
 
     const { result } = renderHook(
       () => useConversation({ onConnect, onError }),
@@ -176,7 +202,7 @@ describe("useConversation", () => {
       result.current.startSession({ signedUrl: "wss://test.example.com" });
     });
 
-    // onConnect is fired by the provider after startSession resolves
+    // onConnect is forwarded through the provider-owned wrapper.
     expect(onConnect).toHaveBeenCalledWith({ conversationId: "test-id" });
 
     // onError is still passed through to the SDK — invoke it manually
@@ -188,8 +214,7 @@ describe("useConversation", () => {
   it("composes hook callbacks with provider callbacks", async () => {
     const providerOnConnect = vi.fn();
     const hookOnConnect = vi.fn();
-    const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+    mockStartSessionWithLifecycle();
 
     const { result } = renderHook(
       () => useConversation({ onConnect: hookOnConnect }),
@@ -200,15 +225,14 @@ describe("useConversation", () => {
       result.current.startSession({ signedUrl: "wss://test.example.com" });
     });
 
-    // onConnect is fired by the provider after startSession resolves
+    // onConnect is forwarded through the provider-owned wrapper.
     expect(providerOnConnect).toHaveBeenCalledWith({ conversationId: "test-id" });
     expect(hookOnConnect).toHaveBeenCalledWith({ conversationId: "test-id" });
   });
 
   it("composes hook, provider, and startSession callbacks together", async () => {
     const calls: string[] = [];
-    const mockConversation = createMockConversation();
-    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+    mockStartSessionWithLifecycle();
 
     const { result } = renderHook(
       () => useConversation({ onConnect: () => calls.push("hook") }),
@@ -222,7 +246,7 @@ describe("useConversation", () => {
       });
     });
 
-    // onConnect is fired by the provider after startSession resolves
+    // onConnect is forwarded through the provider-owned wrapper.
     expect(calls).toContain("provider");
     expect(calls).toContain("hook");
     expect(calls).toContain("startSession");
@@ -251,6 +275,14 @@ describe("useConversation", () => {
 
     // Update the callback before the session resolves
     rerender({ cb: () => calls.push("second") });
+
+    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
+    act(() => {
+      driveConnectedSessionLifecycle(
+        opts as MockStartSessionOptions,
+        mockConversation
+      );
+    });
 
     await act(async () => {
       resolveStartSession(mockConversation);
@@ -308,9 +340,14 @@ describe("useConversation", () => {
       result.current.startSession();
     });
 
-    // agentId should be forwarded, but onConnect should not appear
-    // as a raw prop — it's registered via useRegisterCallbacks instead
+    // agentId should be forwarded, and the provider should wrap onConnect while
+    // still registering the hook callback via useRegisterCallbacks.
     const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
     expect(opts.agentId).toBe("hook-agent-id");
+    expect(typeof opts.onConnect).toBe("function");
+    expect(opts.onConnect).not.toBe(onConnect);
+    expect(
+      typeof (opts as MockStartSessionOptions).onConversationCreated
+    ).toBe("function");
   });
 });


### PR DESCRIPTION
# Why

`onConnect` and `connected` currently describe two different readiness points.

On `main`, the client fires `onConnect` before the session is marked `connected`, and React only assigns `conversationRef` after `Conversation.startSession()` resolves. That means React consumers can hit `No active conversation` if they call controls from `onConnect`, while direct client readiness checks like `isOpen()` still lag behind message-sending behavior.

This change aligns the lifecycle so `connected` means ready, and makes the React provider participate in the same lifecycle instead of replaying `onConnect` later.

```mermaid
sequenceDiagram
    participant ReactUser as "ReactUser onConnect"
    participant Provider as "ConversationProvider"
    participant Client as "Conversation.startSession"
    participant Session as "Conversation"

    rect rgb(0,0,0)
        Note over ReactUser,Session: main
        ReactUser->>Provider: startSession(options)
        Provider->>Client: startSession(sessionOptionsWithUserOnConnect)
        Client->>Session: construct conversation
        Session->>ReactUser: onConnect({ conversationId })
        Note over Provider: conversationRef still null
        Note over Session: status still connecting
        Session-->>Session: set status connected
        Client-->>Provider: resolve(conversation)
        Provider->>Provider: conversationRef = conversation
    end

    rect rgb(0,0,0)
        Note over ReactUser,Session: final
        ReactUser->>Provider: startSession(options)
        Provider->>Client: startSession(wrappedOnConnect + onConversationCreated)
        Client->>Session: construct conversation
        Session->>Provider: onConversationCreated(conversation)
        Provider->>Provider: conversationRef = conversation
        Session-->>Session: set status connected
        Session->>ReactUser: onConnect({ conversationId })
    end
```

# What

- Refactor client session startup so concrete `startSession()` flows own the `connected` and `onConnect` ordering instead of `BaseConversation` constructors.
- Mark the session `connected` before user `onConnect`, so `isOpen()` and callback-time readiness agree.
- Let the React provider synchronize `conversationRef` through the same lifecycle rather than stripping and replaying `onConnect` after promise resolution.
- Add regressions covering:
  - calling controls from React `onConnect`
  - thrown `onConnect` flowing through the normal error path
  - the new client ordering of `connected` before `onConnect`
  - startup cleanup preserving the original error when teardown also throws


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversation session startup ordering and React provider lifecycle handling, which can affect when consumer code runs and how errors/cleanup propagate. Risk is mitigated by added regression tests covering ordering, error paths, and stale-session handling.
> 
> **Overview**
> **Fixes conversation readiness semantics** by moving `onConnect` out of `BaseConversation` construction and ensuring `TextConversation`/`VoiceConversation` call `markConnected()` *before* invoking user `onConnect`, with improved cleanup when startup fails.
> 
> **Adds a new lifecycle callback** `onConversationCreated(conversation)` to the client options/types and exports it (including internal exports), then updates the React `ConversationProvider` to set `conversationRef`/state via `onConversationCreated`, wrap `onConnect`, and ignore stale async resolutions via a monotonic `startSessionId`.
> 
> **Expands test coverage** in both packages to verify `connected` precedes `onConnect`, React consumers can safely call controls in `onConnect`, thrown `onConnect` transitions to error/clears conversation, stale start/restart scenarios are ignored, and original startup errors are preserved even if cleanup throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891e6316f1e2cb911c75d04bce35d0311ca614ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->