### PR TITLE
[convai] Add file upload functionality to embedded agent widget

### DIFF
--- a/.changeset/beige-worlds-fry.md
+++ b/.changeset/beige-worlds-fry.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": minor
+---
+
+Add file upload support to the embedded ConvAI widget

--- a/packages/convai-widget-core/src/components/Icon.tsx
+++ b/packages/convai-widget-core/src/components/Icon.tsx
@@ -4,6 +4,7 @@ import { JSX } from "preact";
 const ICON_MAP = {
   phone: PhoneIcon,
   "phone-off": PhoneSlashIcon,
+  paperclip: PaperclipIcon,
   chat: ChatIcon,
   mic: MicIcon,
   "mic-off": MicOffIcon,
@@ -18,8 +19,8 @@ const ICON_MAP = {
   wrap: WrapTextIcon,
   maximize: MaximizeIcon,
   minimize: MinimizeIcon,
-  "loader": LoaderIcon,
-  "x": XIcon,
+  loader: LoaderIcon,
+  x: XIcon,
 };
 
 const SIZE_CLASSES = {
@@ -77,6 +78,26 @@ function PhoneSlashIcon(props: JSX.HTMLAttributes<SVGSVGElement>) {
     >
       <path d="M16.0303 3.53033C16.3232 3.23744 16.3232 2.76256 16.0303 2.46967C15.7374 2.17678 15.2626 2.17678 14.9697 2.46967L8.6271 8.81224C8.25925 8.3778 7.93185 7.90804 7.65074 7.40881L8.21246 6.84709C8.60266 6.45689 8.74711 5.88396 8.58854 5.35541L7.97761 3.31898C7.78727 2.6845 7.20329 2.25 6.54087 2.25H4.2489C3.43286 2.25 2.71942 2.92142 2.77338 3.7963C2.95462 6.73468 4.13069 9.40357 5.96899 11.4703L2.96967 14.4697C2.67678 14.7626 2.67678 15.2374 2.96967 15.5303C3.26256 15.8232 3.73744 15.8232 4.03033 15.5303L16.0303 3.53033Z" />
       <path d="M14.7026 15.7255C12.2994 15.5773 10.0765 14.7636 8.21584 13.4665L10.9278 10.7545C10.9815 10.7863 11.0356 10.8175 11.0901 10.8482L11.6518 10.2864C12.042 9.89623 12.6149 9.75179 13.1435 9.91035L15.1799 10.5213C15.8144 10.7116 16.2489 11.2956 16.2489 11.958V14.25C16.2489 15.066 15.5775 15.7795 14.7026 15.7255Z" />
+    </svg>
+  );
+}
+
+function PaperclipIcon(props: JSX.HTMLAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="1em"
+      width="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      {...props}
+    >
+      <path d="M13.234 20.252 21 12.3"></path>
+      <path d="m16 6-8.414 8.586a2 2 0 0 0 0 2.828 2 2 0 0 0 2.828 0l8.414-8.586a4 4 0 0 0 0-5.656 4 4 0 0 0-5.656 0l-8.415 8.585a6 6 0 1 0 8.486 8.486"></path>
     </svg>
   );
 }
@@ -461,11 +482,39 @@ function MinimizeIcon(props: JSX.HTMLAttributes<SVGSVGElement>) {
 
 function LoaderIcon(props: JSX.HTMLAttributes<SVGSVGElement>) {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" {...props}><path d="M21 12a9 9 0 1 1-6.219-8.56" /></svg>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      {...props}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
   );
 }
 
 function XIcon(props: JSX.HTMLAttributes<SVGSVGElement>) {
   return (
-<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" {...props}><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg> );
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      {...props}
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
 }

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -1,7 +1,6 @@
 import {
   Conversation,
   Mode,
-  MultimodalMessageInput,
   Role,
   SessionConfig,
   Status,
@@ -428,13 +427,16 @@ function useConversationSetup() {
           },
         ];
       },
-      sendMultimodalMessage: (
-        options: MultimodalMessageInput,
-        fileInput: TranscriptFileInput
-      ) => {
-        const trimmed = options.text?.trim() ?? "";
-        if (!trimmed && !options.fileId) return;
-        conversationRef.current?.sendMultimodalMessage(options);
+      sendMultimodalMessage: (input: {
+        text?: string;
+        file: TranscriptFileInput & { fileId: string };
+      }) => {
+        const trimmed = input.text?.trim() ?? "";
+        const { fileId, ...fileInput } = input.file;
+        conversationRef.current?.sendMultimodalMessage({
+          text: trimmed || undefined,
+          fileId,
+        });
         transcript.value = [
           ...transcript.value,
           {

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -1,6 +1,7 @@
 import {
   Conversation,
   Mode,
+  MultimodalMessageInput,
   Role,
   SessionConfig,
   Status,
@@ -28,6 +29,13 @@ interface ConversationProviderProps {
   children: ComponentChildren;
 }
 
+/** File metadata stored alongside a user message in the local transcript. */
+export type TranscriptFileInput = {
+  fileName: string;
+  mimeType: string;
+  previewUrl: string | null;
+};
+
 export type TranscriptEntry =
   | {
       type: "message";
@@ -36,6 +44,7 @@ export type TranscriptEntry =
       isText: boolean;
       conversationIndex: number;
       eventId?: number;
+      fileInput?: TranscriptFileInput | null;
     }
   | {
       type: "agent_tool_request";
@@ -416,6 +425,25 @@ function useConversationSetup() {
             message: text,
             isText: true,
             conversationIndex: conversationIndex.peek(),
+          },
+        ];
+      },
+      sendMultimodalMessage: (
+        options: MultimodalMessageInput,
+        fileInput: TranscriptFileInput
+      ) => {
+        const trimmed = options.text?.trim() ?? "";
+        if (!trimmed && !options.fileId) return;
+        conversationRef.current?.sendMultimodalMessage(options);
+        transcript.value = [
+          ...transcript.value,
+          {
+            type: "message",
+            role: "user",
+            message: trimmed,
+            isText: true,
+            conversationIndex: conversationIndex.peek(),
+            fileInput,
           },
         ];
       },

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -225,13 +225,13 @@ export function useTextInputEnabled() {
 
 export function useFileInputEnabled() {
   const config = useWidgetConfig();
-  return useComputed(() => config.value.file_input_enabled ?? false);
+  return useComputed(() => config.value.file_input_config?.enabled ?? false);
 }
 
 export function useFileInputMaxFiles() {
   const config = useWidgetConfig();
   return useComputed(
-    () => config.value.file_input_max_files_per_conversation ?? null
+    () => config.value.file_input_config?.max_files_per_conversation ?? null
   );
 }
 

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -223,6 +223,18 @@ export function useTextInputEnabled() {
   return useComputed(() => config.value.text_input_enabled ?? false);
 }
 
+export function useFileInputEnabled() {
+  const config = useWidgetConfig();
+  return useComputed(() => config.value.file_input_enabled ?? false);
+}
+
+export function useFileInputMaxFiles() {
+  const config = useWidgetConfig();
+  return useComputed(
+    () => config.value.file_input_max_files_per_conversation ?? null
+  );
+}
+
 export function useLocalizedTerms() {
   const config = useWidgetConfig();
   const { language } = useLanguageConfig();

--- a/packages/convai-widget-core/src/markdown.dev.tsx
+++ b/packages/convai-widget-core/src/markdown.dev.tsx
@@ -142,6 +142,7 @@ function MockConversationProvider({
       setMicMuted: () => {},
       sendFeedback: () => {},
       sendUserMessage: () => {},
+      sendMultimodalMessage: () => {},
       sendUserActivity: () => {},
       sendContextualUpdate: () => {},
       addModeToggleEntry: () => {},
@@ -171,72 +172,74 @@ function WidgetSandbox({
         value={{
           "agent-id": import.meta.env.VITE_AGENT_ID,
           "override-config": JSON.stringify({
-          variant: "full",
-          placement: "bottom-right",
-          avatar: {
-            type: "orb",
-            color_1: "#2E2E2E",
-            color_2: "#B8B8B8",
-          },
-          feedback_mode: "none",
-          language: "en",
-          supported_language_overrides: ["en"],
-          mic_muting_enabled: false,
-          transcript_enabled: true,
-          text_input_enabled: true,
-          default_expanded: true,
-          always_expanded: false,
-          text_contents: {},
-          language_presets: {},
-          disable_banner: true,
-          text_only: true,
-          supports_text_only: true,
-          styles: theme === "light" ? LIGHT_THEME_STYLES : DARK_THEME_STYLES,
-          syntax_highlight_theme: theme === "light" ? "light" : "dark",
-          markdown_link_allowed_hosts: allowedDomains.map(d => ({ hostname: d })),
-        }),
-      }}
-    >
-      <ServerLocationProvider>
-        <WidgetConfigProvider>
-          <WidgetSizeProvider>
-            <LanguageConfigProvider>
-              <TermsProvider>
-                <SessionConfigProvider>
-                  <MockConversationProvider
-                    displayTextSignal={displayTextSignal}
-                  >
-                    <ConversationModeProvider>
-                      <AudioConfigProvider>
-                        <TextContentsProvider>
-                          <AvatarConfigProvider>
-                            <SheetContentProvider>
-                              <FeedbackProvider>
-                                <div className="dev-host">
-                                  <Style />
-                                  <Wrapper />
-                                  {theme === "dark" && (
-                                    <style>{`
+            variant: "full",
+            placement: "bottom-right",
+            avatar: {
+              type: "orb",
+              color_1: "#2E2E2E",
+              color_2: "#B8B8B8",
+            },
+            feedback_mode: "none",
+            language: "en",
+            supported_language_overrides: ["en"],
+            mic_muting_enabled: false,
+            transcript_enabled: true,
+            text_input_enabled: true,
+            default_expanded: true,
+            always_expanded: false,
+            text_contents: {},
+            language_presets: {},
+            disable_banner: true,
+            text_only: true,
+            supports_text_only: true,
+            styles: theme === "light" ? LIGHT_THEME_STYLES : DARK_THEME_STYLES,
+            syntax_highlight_theme: theme === "light" ? "light" : "dark",
+            markdown_link_allowed_hosts: allowedDomains.map(d => ({
+              hostname: d,
+            })),
+          }),
+        }}
+      >
+        <ServerLocationProvider>
+          <WidgetConfigProvider>
+            <WidgetSizeProvider>
+              <LanguageConfigProvider>
+                <TermsProvider>
+                  <SessionConfigProvider>
+                    <MockConversationProvider
+                      displayTextSignal={displayTextSignal}
+                    >
+                      <ConversationModeProvider>
+                        <AudioConfigProvider>
+                          <TextContentsProvider>
+                            <AvatarConfigProvider>
+                              <SheetContentProvider>
+                                <FeedbackProvider>
+                                  <div className="dev-host">
+                                    <Style />
+                                    <Wrapper />
+                                    {theme === "dark" && (
+                                      <style>{`
                                 .dev-host {
                                   scrollbar-color: #4b5563 transparent !important;
                                 }
                               `}</style>
-                                  )}
-                                </div>
-                              </FeedbackProvider>
-                            </SheetContentProvider>
-                          </AvatarConfigProvider>
-                        </TextContentsProvider>
-                      </AudioConfigProvider>
-                    </ConversationModeProvider>
-                  </MockConversationProvider>
-                </SessionConfigProvider>
-              </TermsProvider>
-            </LanguageConfigProvider>
-          </WidgetSizeProvider>
-        </WidgetConfigProvider>
-      </ServerLocationProvider>
-    </AttributesProvider>
+                                    )}
+                                  </div>
+                                </FeedbackProvider>
+                              </SheetContentProvider>
+                            </AvatarConfigProvider>
+                          </TextContentsProvider>
+                        </AudioConfigProvider>
+                      </ConversationModeProvider>
+                    </MockConversationProvider>
+                  </SessionConfigProvider>
+                </TermsProvider>
+              </LanguageConfigProvider>
+            </WidgetSizeProvider>
+          </WidgetConfigProvider>
+        </ServerLocationProvider>
+      </AttributesProvider>
     </ShadowHostProvider>
   );
 }
@@ -259,7 +262,10 @@ function MarkdownPlayground() {
   const allowedDomains = useMemo(() => {
     const trimmed = allowedDomainsInput.trim();
     if (!trimmed) return [];
-    return trimmed.split(",").map(d => d.trim()).filter(Boolean);
+    return trimmed
+      .split(",")
+      .map(d => d.trim())
+      .filter(Boolean);
   }, [allowedDomainsInput]);
 
   useEffect(() => {
@@ -357,7 +363,11 @@ function MarkdownPlayground() {
           </div>
         </div>
       </div>
-      <WidgetSandbox theme={theme} displayTextSignal={displayTextSignal} allowedDomains={allowedDomains} />
+      <WidgetSandbox
+        theme={theme}
+        displayTextSignal={displayTextSignal}
+        allowedDomains={allowedDomains}
+      />
     </>
   );
 }

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -169,8 +169,10 @@ const codeBlock = true;
     text_only: true,
     transcript_enabled: true,
     text_input_enabled: true,
-    file_input_enabled: true,
-    file_input_max_files_per_conversation: 2,
+    file_input_config: {
+      enabled: true,
+      max_files_per_conversation: 2,
+    },
     terms_html: undefined,
     default_expanded: true,
     first_message: "",
@@ -180,7 +182,9 @@ const codeBlock = true;
     text_only: true,
     transcript_enabled: true,
     text_input_enabled: true,
-    file_input_enabled: false,
+    file_input_config: {
+      enabled: false,
+    },
     terms_html: undefined,
     default_expanded: true,
     first_message: "",

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -164,6 +164,27 @@ const codeBlock = true;
     strip_audio_tags: false,
     first_message: "[happy] Hello there! [excited] How can I help you today?",
   },
+  file_upload: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    file_input_enabled: true,
+    file_input_max_files_per_conversation: 2,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
+  no_file_upload: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    file_input_enabled: false,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
 } as const satisfies Record<string, WidgetConfig>;
 
 function isValidAgentId(agentId: string): agentId is keyof typeof AGENTS {
@@ -183,6 +204,21 @@ export const Worker = setupWorker(
 
       return HttpResponse.error();
     }
+  ),
+  http.post(
+    `${import.meta.env.VITE_SERVER_URL_US}/v1/convai/conversations/:conversationId/files`,
+    async ({ request }) => {
+      const form = await request.formData();
+      const file = form.get("file");
+      if (!(file instanceof File)) {
+        return HttpResponse.json({ detail: "no file" }, { status: 400 });
+      }
+      return HttpResponse.json({ file_id: `file_${file.name}` });
+    }
+  ),
+  http.delete(
+    `${import.meta.env.VITE_SERVER_URL_US}/v1/convai/conversations/:conversationId/files/:fileId`,
+    () => new HttpResponse(null, { status: 204 })
   ),
   ws
     .link(`${import.meta.env.VITE_WEBSOCKET_URL_US}/v1/convai/conversation`)
@@ -215,7 +251,9 @@ export const Worker = setupWorker(
       if (
         config.text_only &&
         agentId !== "end_call_test" &&
-        agentId !== "tool_call"
+        agentId !== "tool_call" &&
+        agentId !== "file_upload" &&
+        agentId !== "no_file_upload"
       ) {
         client.send(
           JSON.stringify({

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -151,8 +151,7 @@ export const DefaultTextContents = {
   attach_file: "Attach file",
   remove_file: "Remove file",
   file_upload_error: "Failed to upload file.",
-  file_type_unsupported:
-    "Unsupported file type. Accepted types: PNG, JPEG, GIF, WEBP, PDF.",
+  file_type_unsupported: "Unsupported file type. Accepted types:",
   file_too_large: "File size exceeds the maximum limit.",
   file_limit_reached: "Maximum number of files for this conversation reached.",
 };

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -148,7 +148,7 @@ export const DefaultTextContents = {
   agent_error: "Error occurred",
   attach_file: "Attach file",
   remove_file: "Remove file",
-  file_upload_error: "Failed to upload file. Please try again.",
+  file_upload_error: "Failed to upload file.",
   file_type_unsupported:
     "Unsupported file type. Accepted types: PNG, JPEG, GIF, WEBP, PDF.",
   file_too_large: "File size exceeds the maximum limit.",

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -79,8 +79,10 @@ export interface WidgetConfig {
   conversation_mode_toggle_enabled?: boolean;
   show_agent_status?: boolean;
   show_conversation_id?: boolean;
-  file_input_enabled?: boolean;
-  file_input_max_files_per_conversation?: number;
+  file_input_config?: {
+    enabled?: boolean;
+    max_files_per_conversation?: number;
+  };
 }
 
 export type AvatarConfig =

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -79,6 +79,8 @@ export interface WidgetConfig {
   conversation_mode_toggle_enabled?: boolean;
   show_agent_status?: boolean;
   show_conversation_id?: boolean;
+  file_input_enabled?: boolean;
+  file_input_max_files_per_conversation?: number;
 }
 
 export type AvatarConfig =
@@ -144,6 +146,13 @@ export const DefaultTextContents = {
   agent_working: "Working...",
   agent_done: "Completed",
   agent_error: "Error occurred",
+  attach_file: "Attach file",
+  remove_file: "Remove file",
+  file_upload_error: "Failed to upload file. Please try again.",
+  file_type_unsupported:
+    "Unsupported file type. Accepted types: PNG, JPEG, GIF, WEBP, PDF.",
+  file_too_large: "File size exceeds the maximum limit.",
+  file_limit_reached: "Maximum number of files for this conversation reached.",
 };
 
 export const TextKeys = Object.keys(

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -1,5 +1,8 @@
 import type { Role } from "@elevenlabs/client";
-import type { TranscriptEntry } from "../contexts/conversation";
+import type {
+  TranscriptEntry,
+  TranscriptFileInput,
+} from "../contexts/conversation";
 import type { ConversationMode } from "../contexts/conversation-mode";
 
 export const ToolCallStatus = {
@@ -20,6 +23,7 @@ export type DisplayTranscriptEntry =
       conversationIndex: number;
       eventId?: number;
       toolStatus?: ToolCallStatusType;
+      fileInput?: TranscriptFileInput | null;
     }
   | {
       type: "disconnection";

--- a/packages/convai-widget-core/src/widget/PendingFilePreview.tsx
+++ b/packages/convai-widget-core/src/widget/PendingFilePreview.tsx
@@ -1,7 +1,7 @@
 import { cn } from "../utils/cn";
 import { Icon } from "../components/Icon";
 import { useTextContents } from "../contexts/text-contents";
-import type { PendingFile } from "./useFileUpload";
+import { isImageMimeType, type PendingFile } from "./useFileUpload";
 
 interface PendingFilePreviewProps {
   pendingFile: PendingFile;
@@ -13,7 +13,7 @@ export function PendingFilePreview({
   onRemove,
 }: PendingFilePreviewProps) {
   const text = useTextContents();
-  const isImage = pendingFile.file.type.startsWith("image/");
+  const isImage = isImageMimeType(pendingFile.file.type);
   const isUploading = pendingFile.status === "uploading";
   const hasError = pendingFile.status === "error";
 

--- a/packages/convai-widget-core/src/widget/PendingFilePreview.tsx
+++ b/packages/convai-widget-core/src/widget/PendingFilePreview.tsx
@@ -1,0 +1,95 @@
+import { cn } from "../utils/cn";
+import { Icon } from "../components/Icon";
+import { useTextContents } from "../contexts/text-contents";
+import type { PendingFile } from "./useFileUpload";
+
+interface PendingFilePreviewProps {
+  pendingFile: PendingFile;
+  onRemove: () => void;
+}
+
+export function PendingFilePreview({
+  pendingFile,
+  onRemove,
+}: PendingFilePreviewProps) {
+  const text = useTextContents();
+  const isImage = pendingFile.file.type.startsWith("image/");
+  const isUploading = pendingFile.status === "uploading";
+  const hasError = pendingFile.status === "error";
+
+  return (
+    <div
+      className={cn(
+        "relative inline-flex items-center gap-2 rounded-input border py-1.5 pl-1.5 pr-7 overflow-hidden",
+        hasError
+          ? "border-base-error/30 bg-base-error/5"
+          : "border-base-border/60 bg-base-active/40"
+      )}
+    >
+      {isImage && pendingFile.previewUrl ? (
+        <img
+          src={pendingFile.previewUrl}
+          alt={pendingFile.file.name}
+          className="h-11 w-11 rounded-input object-cover shrink-0 bg-base-active"
+        />
+      ) : (
+        <div className="flex h-11 w-11 items-center justify-center rounded-input bg-base-active shrink-0">
+          <FileTextIcon />
+        </div>
+      )}
+
+      <span className="text-sm text-base-primary truncate max-w-[160px]">
+        {pendingFile.file.name}
+      </span>
+
+      {hasError && (
+        <span
+          className="text-xs text-base-error truncate max-w-[120px]"
+          title={pendingFile.error}
+        >
+          {pendingFile.error}
+        </span>
+      )}
+
+      {isUploading && (
+        <Icon
+          name="loader"
+          size="sm"
+          className="animate-spin text-base-subtle shrink-0"
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={text.remove_file.value}
+        className="absolute right-1.5 top-1/2 -translate-y-1/2 !mt-0 text-base-subtle hover:text-base-primary transition-colors"
+      >
+        <Icon name="x" size="sm" />
+      </button>
+    </div>
+  );
+}
+
+function FileTextIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className="text-base-subtle"
+    >
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+      <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+      <path d="M10 9H8" />
+      <path d="M16 13H8" />
+      <path d="M16 17H8" />
+    </svg>
+  );
+}

--- a/packages/convai-widget-core/src/widget/PendingFilePreview.tsx
+++ b/packages/convai-widget-core/src/widget/PendingFilePreview.tsx
@@ -38,18 +38,16 @@ export function PendingFilePreview({
         </div>
       )}
 
-      <span className="text-sm text-base-primary truncate max-w-[160px]">
-        {pendingFile.file.name}
-      </span>
-
-      {hasError && (
-        <span
-          className="text-xs text-base-error truncate max-w-[120px]"
-          title={pendingFile.error}
-        >
-          {pendingFile.error}
+      <div className="flex flex-col min-w-0 max-w-[220px]">
+        <span className="text-sm text-base-primary truncate">
+          {pendingFile.file.name}
         </span>
-      )}
+        {hasError && (
+          <span className="text-xs text-base-error break-words">
+            {pendingFile.error || text.file_upload_error.value}
+          </span>
+        )}
+      </div>
 
       {isUploading && (
         <Icon

--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -26,7 +26,7 @@ import { TriggerMuteButton } from "./TriggerMuteButton";
 import { useConversationMode } from "../contexts/conversation-mode";
 import { UploadFileButton } from "./UploadFileButton";
 import { PendingFilePreview } from "./PendingFilePreview";
-import { useFileUpload } from "./useFileUpload";
+import { ACCEPTED_FILE_EXTENSIONS, useFileUpload } from "./useFileUpload";
 
 export function SheetActions({
   showTranscript,
@@ -91,8 +91,12 @@ export function SheetActions({
     (file: File) => {
       const error = addFile(file);
       if (!error) return;
+      if (error === "unsupported_type") {
+        fileError.value =
+          `${text.file_type_unsupported.peek()} ${ACCEPTED_FILE_EXTENSIONS.join(", ")}.`;
+        return;
+      }
       const messageByCode = {
-        unsupported_type: text.file_type_unsupported,
         too_large: text.file_too_large,
         limit_reached: text.file_limit_reached,
       };

--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -26,7 +26,7 @@ import { TriggerMuteButton } from "./TriggerMuteButton";
 import { useConversationMode } from "../contexts/conversation-mode";
 import { UploadFileButton } from "./UploadFileButton";
 import { PendingFilePreview } from "./PendingFilePreview";
-import { useFileUpload, type PendingFile } from "./useFileUpload";
+import { useFileUpload } from "./useFileUpload";
 
 export function SheetActions({
   showTranscript,
@@ -74,41 +74,62 @@ export function SheetActions({
     markFileAsSent,
   } = useFileUpload({ conversationId, maxFiles: maxFiles.value });
 
+  // File upload is only exposed alongside the text input — without a
+  // textarea there's nowhere to preview the attachment or send it.
+  const showUploadButton = useComputed(
+    () =>
+      fileInputEnabled.value && textInputEnabled.value && !isDisconnected.value
+  );
+  const uploadEnabled = useComputed(
+    () =>
+      !pendingFile.value &&
+      !hasReachedLimit.value &&
+      status.value === "connected"
+  );
+
   const handleFileSelect = useCallback(
     (file: File) => {
       const error = addFile(file);
-      if (error === "unsupported_type") {
-        fileError.value = text.file_type_unsupported.peek();
-      } else if (error === "too_large") {
-        fileError.value = text.file_too_large.peek();
-      } else if (error === "limit_reached") {
-        fileError.value = text.file_limit_reached.peek();
-      } else if (error) {
-        fileError.value = error;
-      }
+      if (!error) return;
+      const messageByCode = {
+        unsupported_type: text.file_type_unsupported,
+        too_large: text.file_too_large,
+        limit_reached: text.file_limit_reached,
+      };
+      fileError.value = messageByCode[error].peek();
     },
     [addFile, text, fileError]
   );
 
+  const canSend = useComputed(() => {
+    const hasText = !!userMessage.value.trim();
+    const hasReadyFile = pendingFile.value?.status === "ready";
+    return (hasText || hasReadyFile) && !isUploading.value;
+  });
+
   const handleSendMessage = useCallback(
     async (e: TargetedEvent<HTMLElement>) => {
       e.preventDefault();
+      // Runtime guard — the send button's `disabled` prop and the keydown
+      // canSend check both reflect render-time state, so a click/keypress
+      // racing with an upload starting could otherwise fall through to the
+      // text-only path and silently drop the in-flight file.
+      if (!canSend.peek()) return;
+
       const message = userMessage.value.trim();
       const pending = pendingFile.value;
 
       if (pending?.status === "ready" && !isDisconnected.value) {
         scrollPinned.value = true;
-        sendMultimodalMessage(
-          {
-            text: message || undefined,
+        sendMultimodalMessage({
+          text: message || undefined,
+          file: {
             fileId: pending.fileId,
-          },
-          {
             fileName: pending.file.name,
             mimeType: pending.file.type,
             previewUrl: pending.previewUrl,
-          }
-        );
+          },
+        });
         markFileAsSent();
         userMessage.value = "";
         return;
@@ -133,14 +154,9 @@ export function SheetActions({
       sendMultimodalMessage,
       pendingFile,
       markFileAsSent,
+      canSend,
     ]
   );
-
-  const canSend = useComputed(() => {
-    const hasText = !!userMessage.value.trim();
-    const hasReadyFile = pendingFile.value?.status === "ready";
-    return (hasText || hasReadyFile) && !isUploading.value;
-  });
 
   return (
     <div className="sticky bottom-0 pointer-events-none z-10 max-h-[50%] flex flex-col">
@@ -175,13 +191,11 @@ export function SheetActions({
             <div className="absolute bottom-0 left-0 right-0 flex gap-1.5 items-center justify-end px-3 pb-3 pt-2 pointer-events-none">
               <div className="pointer-events-auto flex gap-1.5 items-center">
                 <SheetButtons
-                  userMessage={userMessage}
                   canSend={canSend}
                   onSendMessage={handleSendMessage}
                   showTranscript={showTranscript}
-                  fileInputEnabled={fileInputEnabled}
-                  pendingFile={pendingFile}
-                  hasReachedLimit={hasReachedLimit}
+                  showUploadButton={showUploadButton}
+                  uploadEnabled={uploadEnabled}
                   onFileSelect={handleFileSelect}
                 />
               </div>
@@ -191,13 +205,11 @@ export function SheetActions({
         {!textInputEnabled.value && (
           <div className="w-full flex gap-1.5 items-center justify-end">
             <SheetButtons
-              userMessage={userMessage}
               canSend={canSend}
               onSendMessage={handleSendMessage}
               showTranscript={showTranscript}
-              fileInputEnabled={fileInputEnabled}
-              pendingFile={pendingFile}
-              hasReachedLimit={hasReachedLimit}
+              showUploadButton={showUploadButton}
+              uploadEnabled={uploadEnabled}
               onFileSelect={handleFileSelect}
             />
           </div>
@@ -272,22 +284,18 @@ function SheetTextarea({
 }
 
 function SheetButtons({
-  userMessage,
   canSend,
   onSendMessage,
   showTranscript = false,
-  fileInputEnabled,
-  pendingFile,
-  hasReachedLimit,
+  showUploadButton,
+  uploadEnabled,
   onFileSelect,
 }: {
-  userMessage: Signal<string>;
   canSend: ReadonlySignal<boolean>;
   onSendMessage: (e: TargetedEvent<HTMLElement>) => Promise<void>;
   showTranscript?: boolean;
-  fileInputEnabled: ReadonlySignal<boolean>;
-  pendingFile: ReadonlySignal<PendingFile | null>;
-  hasReachedLimit: ReadonlySignal<boolean>;
+  showUploadButton: ReadonlySignal<boolean>;
+  uploadEnabled: ReadonlySignal<boolean>;
   onFileSelect: (file: File) => void;
 }) {
   const text = useTextContents();
@@ -296,21 +304,11 @@ function SheetButtons({
   const { isDisconnected, status } = useConversation();
   const { isTextMode } = useConversationMode();
 
-  const showSendButtonControl = useComputed(() => {
-    return textInputEnabled.value;
-  });
   const showCallButton = useComputed(() => {
     return !isDisconnected.value || (!textOnly.value && showTranscript);
   });
   const showMuteButton = useComputed(() => {
     return !textOnly.value && !isDisconnected.value && !isTextMode.value;
-  });
-  const showUploadButton = useComputed(() => {
-    // File upload is only exposed alongside the text input — without a textarea
-    // there's nowhere to preview the attachment or send it.
-    return (
-      fileInputEnabled.value && textInputEnabled.value && !isDisconnected.value
-    );
   });
 
   return (
@@ -321,11 +319,7 @@ function SheetButtons({
       <SizeTransition visible={showUploadButton.value}>
         <UploadFileButton
           iconOnly
-          disabled={
-            !!pendingFile.value ||
-            hasReachedLimit.value ||
-            status.value !== "connected"
-          }
+          disabled={!uploadEnabled.value}
           onFileSelect={onFileSelect}
           className="bg-base text-base-primary hover:bg-base-hover active:bg-base-active"
         />
@@ -340,7 +334,7 @@ function SheetButtons({
           className="bg-base text-base-primary hover:bg-base-hover active:bg-base-active"
         />
       </SizeTransition>
-      {showSendButtonControl.value && (
+      {textInputEnabled.value && (
         <Button
           icon="send"
           onClick={onSendMessage}

--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -3,12 +3,12 @@ import {
   Signal,
   useComputed,
   useSignal,
+  useSignalEffect,
 } from "@preact/signals";
 import {
   KeyboardEventHandler,
   TargetedEvent,
   useCallback,
-  useRef,
 } from "preact/compat";
 import { Button } from "../components/Button";
 import { SizeTransition } from "../components/SizeTransition";
@@ -51,9 +51,20 @@ export function SheetActions({
   } = useConversation();
 
   const fileError = useSignal<string | null>(null);
-  const fileErrorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Auto-dismiss the validation toast 4s after it's set; a new message resets
+  // the timer because useSignalEffect re-runs (and cleans up) on change.
+  useSignalEffect(() => {
+    if (!fileError.value) return;
+    const id = setTimeout(() => {
+      fileError.value = null;
+    }, 4000);
+    return () => clearTimeout(id);
+  });
 
-  const conversationId = isDisconnected.value ? null : lastId.value;
+  // Only expose the conversation id while fully connected — during the
+  // "connecting" phase of a reconnect, `lastId` still holds the previous
+  // conversation's id, which would cause uploads to target the wrong endpoint.
+  const conversationId = status.value === "connected" ? lastId.value : null;
   const {
     pendingFile,
     isUploading,
@@ -63,31 +74,20 @@ export function SheetActions({
     markFileAsSent,
   } = useFileUpload({ conversationId, maxFiles: maxFiles.value });
 
-  const showFileError = useCallback(
-    (message: string) => {
-      if (fileErrorTimer.current) clearTimeout(fileErrorTimer.current);
-      fileError.value = message;
-      fileErrorTimer.current = setTimeout(() => {
-        fileError.value = null;
-      }, 4000);
-    },
-    [fileError]
-  );
-
   const handleFileSelect = useCallback(
     (file: File) => {
       const error = addFile(file);
       if (error === "unsupported_type") {
-        showFileError(text.file_type_unsupported.peek());
+        fileError.value = text.file_type_unsupported.peek();
       } else if (error === "too_large") {
-        showFileError(text.file_too_large.peek());
+        fileError.value = text.file_too_large.peek();
       } else if (error === "limit_reached") {
-        showFileError(text.file_limit_reached.peek());
+        fileError.value = text.file_limit_reached.peek();
       } else if (error) {
-        showFileError(error);
+        fileError.value = error;
       }
     },
-    [addFile, text, showFileError]
+    [addFile, text, fileError]
   );
 
   const handleSendMessage = useCallback(
@@ -169,6 +169,7 @@ export function SheetActions({
             <SheetTextarea
               userMessage={userMessage}
               isFocused={isFocused}
+              canSend={canSend}
               onSendMessage={handleSendMessage}
             />
             <div className="absolute bottom-0 left-0 right-0 flex gap-1.5 items-center justify-end px-3 pb-3 pt-2 pointer-events-none">
@@ -178,7 +179,7 @@ export function SheetActions({
                   canSend={canSend}
                   onSendMessage={handleSendMessage}
                   showTranscript={showTranscript}
-                  fileInputEnabled={fileInputEnabled.value}
+                  fileInputEnabled={fileInputEnabled}
                   pendingFile={pendingFile}
                   hasReachedLimit={hasReachedLimit}
                   onFileSelect={handleFileSelect}
@@ -194,7 +195,7 @@ export function SheetActions({
               canSend={canSend}
               onSendMessage={handleSendMessage}
               showTranscript={showTranscript}
-              fileInputEnabled={fileInputEnabled.value}
+              fileInputEnabled={fileInputEnabled}
               pendingFile={pendingFile}
               hasReachedLimit={hasReachedLimit}
               onFileSelect={handleFileSelect}
@@ -209,10 +210,12 @@ export function SheetActions({
 function SheetTextarea({
   userMessage,
   isFocused,
+  canSend,
   onSendMessage,
 }: {
   userMessage: Signal<string>;
   isFocused: Signal<boolean>;
+  canSend: ReadonlySignal<boolean>;
   onSendMessage: (e: TargetedEvent<HTMLElement>) => Promise<void>;
 }) {
   const text = useTextContents();
@@ -230,10 +233,13 @@ function SheetTextarea({
   const handleKeyDown = useCallback<KeyboardEventHandler<HTMLTextAreaElement>>(
     async e => {
       if (e.key === "Enter" && !e.shiftKey) {
-        await onSendMessage(e);
+        e.preventDefault();
+        if (canSend.peek()) {
+          await onSendMessage(e);
+        }
       }
     },
-    [onSendMessage]
+    [onSendMessage, canSend]
   );
 
   const handleFocus = useCallback(() => {
@@ -279,7 +285,7 @@ function SheetButtons({
   canSend: ReadonlySignal<boolean>;
   onSendMessage: (e: TargetedEvent<HTMLElement>) => Promise<void>;
   showTranscript?: boolean;
-  fileInputEnabled: boolean;
+  fileInputEnabled: ReadonlySignal<boolean>;
   pendingFile: ReadonlySignal<PendingFile | null>;
   hasReachedLimit: ReadonlySignal<boolean>;
   onFileSelect: (file: File) => void;
@@ -300,7 +306,11 @@ function SheetButtons({
     return !textOnly.value && !isDisconnected.value && !isTextMode.value;
   });
   const showUploadButton = useComputed(() => {
-    return fileInputEnabled && !isDisconnected.value;
+    // File upload is only exposed alongside the text input — without a textarea
+    // there's nowhere to preview the attachment or send it.
+    return (
+      fileInputEnabled.value && textInputEnabled.value && !isDisconnected.value
+    );
   });
 
   return (
@@ -311,8 +321,11 @@ function SheetButtons({
       <SizeTransition visible={showUploadButton.value}>
         <UploadFileButton
           iconOnly
-          hasPendingFile={!!pendingFile.value}
-          disabled={hasReachedLimit.value}
+          disabled={
+            !!pendingFile.value ||
+            hasReachedLimit.value ||
+            status.value !== "connected"
+          }
           onFileSelect={onFileSelect}
           className="bg-base text-base-primary hover:bg-base-hover active:bg-base-active"
         />

--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -1,14 +1,22 @@
-import { Signal, useComputed, useSignal } from "@preact/signals";
+import {
+  ReadonlySignal,
+  Signal,
+  useComputed,
+  useSignal,
+} from "@preact/signals";
 import {
   KeyboardEventHandler,
   TargetedEvent,
   useCallback,
+  useRef,
 } from "preact/compat";
 import { Button } from "../components/Button";
 import { SizeTransition } from "../components/SizeTransition";
 import { useConversation } from "../contexts/conversation";
 import { useTextContents } from "../contexts/text-contents";
 import {
+  useFileInputEnabled,
+  useFileInputMaxFiles,
   useIsConversationTextOnly,
   useTextInputEnabled,
 } from "../contexts/widget-config";
@@ -16,6 +24,9 @@ import { cn } from "../utils/cn";
 import { CallButton } from "./CallButton";
 import { TriggerMuteButton } from "./TriggerMuteButton";
 import { useConversationMode } from "../contexts/conversation-mode";
+import { UploadFileButton } from "./UploadFileButton";
+import { PendingFilePreview } from "./PendingFilePreview";
+import { useFileUpload, type PendingFile } from "./useFileUpload";
 
 export function SheetActions({
   showTranscript,
@@ -25,14 +36,84 @@ export function SheetActions({
   scrollPinned: Signal<boolean>;
 }) {
   const textInputEnabled = useTextInputEnabled();
+  const fileInputEnabled = useFileInputEnabled();
+  const maxFiles = useFileInputMaxFiles();
   const userMessage = useSignal("");
   const isFocused = useSignal(false);
-  const { isDisconnected, startSession, sendUserMessage } = useConversation();
+  const text = useTextContents();
+  const {
+    isDisconnected,
+    status,
+    lastId,
+    startSession,
+    sendUserMessage,
+    sendMultimodalMessage,
+  } = useConversation();
+
+  const fileError = useSignal<string | null>(null);
+  const fileErrorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const conversationId = isDisconnected.value ? null : lastId.value;
+  const {
+    pendingFile,
+    isUploading,
+    hasReachedLimit,
+    addFile,
+    removeFile,
+    markFileAsSent,
+  } = useFileUpload({ conversationId, maxFiles: maxFiles.value });
+
+  const showFileError = useCallback(
+    (message: string) => {
+      if (fileErrorTimer.current) clearTimeout(fileErrorTimer.current);
+      fileError.value = message;
+      fileErrorTimer.current = setTimeout(() => {
+        fileError.value = null;
+      }, 4000);
+    },
+    [fileError]
+  );
+
+  const handleFileSelect = useCallback(
+    (file: File) => {
+      const error = addFile(file);
+      if (error === "unsupported_type") {
+        showFileError(text.file_type_unsupported.peek());
+      } else if (error === "too_large") {
+        showFileError(text.file_too_large.peek());
+      } else if (error === "limit_reached") {
+        showFileError(text.file_limit_reached.peek());
+      } else if (error) {
+        showFileError(error);
+      }
+    },
+    [addFile, text, showFileError]
+  );
 
   const handleSendMessage = useCallback(
     async (e: TargetedEvent<HTMLElement>) => {
       e.preventDefault();
       const message = userMessage.value.trim();
+      const pending = pendingFile.value;
+
+      if (pending?.status === "ready" && !isDisconnected.value) {
+        scrollPinned.value = true;
+        sendMultimodalMessage(
+          {
+            text: message || undefined,
+            fileId: pending.fileId,
+          },
+          {
+            fileName: pending.file.name,
+            mimeType: pending.file.type,
+            previewUrl: pending.previewUrl,
+          }
+        );
+        markFileAsSent();
+        userMessage.value = "";
+        return;
+      }
+
       if (message) {
         scrollPinned.value = true;
         userMessage.value = "";
@@ -43,13 +124,33 @@ export function SheetActions({
         }
       }
     },
-    [userMessage, scrollPinned, isDisconnected, startSession, sendUserMessage]
+    [
+      userMessage,
+      scrollPinned,
+      isDisconnected,
+      startSession,
+      sendUserMessage,
+      sendMultimodalMessage,
+      pendingFile,
+      markFileAsSent,
+    ]
   );
+
+  const canSend = useComputed(() => {
+    const hasText = !!userMessage.value.trim();
+    const hasReadyFile = pendingFile.value?.status === "ready";
+    return (hasText || hasReadyFile) && !isUploading.value;
+  });
 
   return (
     <div className="sticky bottom-0 pointer-events-none z-10 max-h-[50%] flex flex-col">
       <div className="absolute top-0 left-0 right-0 h-4 -translate-y-full bg-gradient-to-t from-base to-transparent pointer-events-none backdrop-blur-[1px] [mask-image:linear-gradient(to_top,black,transparent)] shadow-scroll-fade-top" />
       <div className="relative w-full px-3 pb-3 flex flex-col items-center pointer-events-auto min-h-0">
+        {fileError.value && (
+          <div className="w-full px-1 pb-1.5 text-xs text-base-error text-center">
+            {fileError.value}
+          </div>
+        )}
         {textInputEnabled.value && (
           <div
             className={cn(
@@ -57,6 +158,14 @@ export function SheetActions({
               isFocused.value && "ring-2 ring-accent"
             )}
           >
+            {pendingFile.value && (
+              <div className="px-3 pt-3">
+                <PendingFilePreview
+                  pendingFile={pendingFile.value}
+                  onRemove={removeFile}
+                />
+              </div>
+            )}
             <SheetTextarea
               userMessage={userMessage}
               isFocused={isFocused}
@@ -66,8 +175,13 @@ export function SheetActions({
               <div className="pointer-events-auto flex gap-1.5 items-center">
                 <SheetButtons
                   userMessage={userMessage}
+                  canSend={canSend}
                   onSendMessage={handleSendMessage}
                   showTranscript={showTranscript}
+                  fileInputEnabled={fileInputEnabled.value}
+                  pendingFile={pendingFile}
+                  hasReachedLimit={hasReachedLimit}
+                  onFileSelect={handleFileSelect}
                 />
               </div>
             </div>
@@ -77,8 +191,13 @@ export function SheetActions({
           <div className="w-full flex gap-1.5 items-center justify-end">
             <SheetButtons
               userMessage={userMessage}
+              canSend={canSend}
               onSendMessage={handleSendMessage}
               showTranscript={showTranscript}
+              fileInputEnabled={fileInputEnabled.value}
+              pendingFile={pendingFile}
+              hasReachedLimit={hasReachedLimit}
+              onFileSelect={handleFileSelect}
             />
           </div>
         )}
@@ -148,12 +267,22 @@ function SheetTextarea({
 
 function SheetButtons({
   userMessage,
+  canSend,
   onSendMessage,
   showTranscript = false,
+  fileInputEnabled,
+  pendingFile,
+  hasReachedLimit,
+  onFileSelect,
 }: {
   userMessage: Signal<string>;
+  canSend: ReadonlySignal<boolean>;
   onSendMessage: (e: TargetedEvent<HTMLElement>) => Promise<void>;
   showTranscript?: boolean;
+  fileInputEnabled: boolean;
+  pendingFile: ReadonlySignal<PendingFile | null>;
+  hasReachedLimit: ReadonlySignal<boolean>;
+  onFileSelect: (file: File) => void;
 }) {
   const text = useTextContents();
   const textOnly = useIsConversationTextOnly();
@@ -161,23 +290,32 @@ function SheetButtons({
   const { isDisconnected, status } = useConversation();
   const { isTextMode } = useConversationMode();
 
-  const showSendButton = useComputed(() => !!userMessage.value.trim());
   const showSendButtonControl = useComputed(() => {
     return textInputEnabled.value;
   });
   const showCallButton = useComputed(() => {
-    // 1. Do not show the call button if text only -> user use text input to initiate
-    // 2. Always show the call button for users ends the conversation
     return !isDisconnected.value || (!textOnly.value && showTranscript);
   });
   const showMuteButton = useComputed(() => {
     return !textOnly.value && !isDisconnected.value && !isTextMode.value;
+  });
+  const showUploadButton = useComputed(() => {
+    return fileInputEnabled && !isDisconnected.value;
   });
 
   return (
     <>
       <SizeTransition visible={showMuteButton.value}>
         <TriggerMuteButton className="bg-base text-base-primary hover:bg-base-hover active:bg-base-active" />
+      </SizeTransition>
+      <SizeTransition visible={showUploadButton.value}>
+        <UploadFileButton
+          iconOnly
+          hasPendingFile={!!pendingFile.value}
+          disabled={hasReachedLimit.value}
+          onFileSelect={onFileSelect}
+          className="bg-base text-base-primary hover:bg-base-hover active:bg-base-active"
+        />
       </SizeTransition>
       <SizeTransition visible={showCallButton.value}>
         <CallButton
@@ -194,7 +332,7 @@ function SheetButtons({
           icon="send"
           onClick={onSendMessage}
           variant="primary"
-          disabled={!showSendButton.value}
+          disabled={!canSend.value}
           aria-label={text.send_message.value}
         />
       )}

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -17,6 +17,7 @@ import {
 } from "../contexts/widget-config";
 import { stripAudioTags } from "../utils/stripAudioTags";
 import { WidgetStreamdown } from "../markdown";
+import { isImageMimeType } from "./useFileUpload";
 
 interface TranscriptMessageProps {
   entry: DisplayTranscriptEntry;
@@ -111,7 +112,7 @@ function FileAttachment({
   mimeType: string;
   previewUrl: string | null;
 }) {
-  const isImage = mimeType.startsWith("image/");
+  const isImage = isImageMimeType(mimeType);
 
   if (isImage && previewUrl) {
     return (

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -58,6 +58,7 @@ function UserMessageBubble({
   entry: Extract<DisplayTranscriptEntry, { type: "message" }>;
 }) {
   const { previewUrl } = useAvatarConfig();
+  const fileInput = entry.fileInput;
 
   return (
     <div
@@ -75,18 +76,80 @@ function UserMessageBubble({
           className="bg-base-border shrink-0 w-5 h-5 rounded-full"
         />
       )}
-      <div
-        dir="auto"
-        className={clsx(
-          "px-3 py-2.5 rounded-bubble text-sm min-w-0 wrap-break-word whitespace-pre-wrap",
-          entry.role === "user"
-            ? "bg-accent text-accent-primary"
-            : "bg-base-active text-base-primary"
+      <div className="flex flex-col items-end gap-1.5 min-w-0">
+        {fileInput && (
+          <FileAttachment
+            fileName={fileInput.fileName}
+            mimeType={fileInput.mimeType}
+            previewUrl={fileInput.previewUrl}
+          />
         )}
-      >
-        {entry.message}
+        {entry.message && (
+          <div
+            dir="auto"
+            className={clsx(
+              "px-3 py-2.5 rounded-bubble text-sm min-w-0 wrap-break-word whitespace-pre-wrap",
+              entry.role === "user"
+                ? "bg-accent text-accent-primary"
+                : "bg-base-active text-base-primary"
+            )}
+          >
+            {entry.message}
+          </div>
+        )}
       </div>
     </div>
+  );
+}
+
+function FileAttachment({
+  fileName,
+  mimeType,
+  previewUrl,
+}: {
+  fileName: string;
+  mimeType: string;
+  previewUrl: string | null;
+}) {
+  const isImage = mimeType.startsWith("image/");
+
+  if (isImage && previewUrl) {
+    return (
+      <div className="rounded-bubble border border-base-border shadow-sm p-1">
+        <img
+          src={previewUrl}
+          alt={fileName}
+          className="max-w-[180px] rounded-input object-cover"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2.5 rounded-bubble bg-accent text-accent-primary">
+      <FileDocIcon />
+      <span className="truncate text-sm">{fileName}</span>
+    </div>
+  );
+}
+
+function FileDocIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className="shrink-0 opacity-70"
+    >
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+      <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+    </svg>
   );
 }
 

--- a/packages/convai-widget-core/src/widget/UploadFileButton.test.ts
+++ b/packages/convai-widget-core/src/widget/UploadFileButton.test.ts
@@ -1,0 +1,82 @@
+import { page, userEvent } from "@vitest/browser/context";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { Worker } from "../mocks/browser";
+import { setupWebComponent } from "../mocks/web-component";
+
+describe("Upload File Button", () => {
+  beforeAll(() => Worker.start({ quiet: true }));
+  afterAll(() => Worker.stop());
+
+  // Trigger session start by sending a first text message. Upload UI is gated
+  // on !isDisconnected, so we need a live conversation before the attach
+  // button can appear.
+  async function connect() {
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("hi");
+    await userEvent.keyboard("{Enter}");
+    await expect.element(page.getByText("hi")).toBeInTheDocument();
+  }
+
+  function getHiddenFileInput(widget: HTMLElement): HTMLInputElement {
+    const input =
+      widget.shadowRoot?.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!input) throw new Error("hidden file input not found");
+    return input;
+  }
+
+  it("does not render the attach button when file_input_enabled is false", async () => {
+    setupWebComponent({ "agent-id": "no_file_upload" });
+    await connect();
+
+    await expect
+      .element(page.getByRole("button", { name: "Attach file" }))
+      .not.toBeInTheDocument();
+  });
+
+  // The attach button becomes visible as soon as the session leaves the
+  // "disconnected" state, but `addFile` silently no-ops until `status ===
+  // "connected"` (that's when conversationId is exposed). Waiting for the
+  // button to be not-disabled is the visible proxy for that transition.
+  async function waitForUploadReady() {
+    const attach = page.getByRole("button", { name: "Attach file" });
+    await expect.element(attach).toBeVisible();
+    await expect.element(attach).not.toBeDisabled();
+  }
+
+  it("shows a preview and enables send after a successful upload", async () => {
+    const widget = setupWebComponent({ "agent-id": "file_upload" });
+    await connect();
+    await waitForUploadReady();
+
+    const input = getHiddenFileInput(widget);
+    await userEvent.upload(
+      input,
+      new File(["hello"], "photo.png", { type: "image/png" })
+    );
+
+    await expect.element(page.getByText("photo.png")).toBeVisible();
+    await expect
+      .element(page.getByRole("button", { name: "Send" }))
+      .not.toBeDisabled();
+  });
+
+  it("removes the pending file when Remove file is clicked", async () => {
+    const widget = setupWebComponent({ "agent-id": "file_upload" });
+    await connect();
+    await waitForUploadReady();
+
+    const input = getHiddenFileInput(widget);
+    await userEvent.upload(
+      input,
+      new File(["x"], "doc.pdf", { type: "application/pdf" })
+    );
+
+    await expect.element(page.getByText("doc.pdf")).toBeVisible();
+
+    await page.getByRole("button", { name: "Remove file" }).click();
+
+    await expect.element(page.getByText("doc.pdf")).not.toBeInTheDocument();
+  });
+});

--- a/packages/convai-widget-core/src/widget/UploadFileButton.test.ts
+++ b/packages/convai-widget-core/src/widget/UploadFileButton.test.ts
@@ -26,7 +26,7 @@ describe("Upload File Button", () => {
     return input;
   }
 
-  it("does not render the attach button when file_input_enabled is false", async () => {
+  it("does not render the attach button when file_input_config.enabled is false", async () => {
     setupWebComponent({ "agent-id": "no_file_upload" });
     await connect();
 

--- a/packages/convai-widget-core/src/widget/UploadFileButton.tsx
+++ b/packages/convai-widget-core/src/widget/UploadFileButton.tsx
@@ -5,14 +5,12 @@ import { ACCEPTED_FILE_EXTENSIONS } from "./useFileUpload";
 
 interface UploadFileButtonProps extends BaseButtonProps {
   iconOnly?: boolean;
-  hasPendingFile?: boolean;
   disabled?: boolean;
   onFileSelect: (file: File) => void;
 }
 
 export function UploadFileButton({
   iconOnly,
-  hasPendingFile,
   disabled,
   onFileSelect,
   children,
@@ -44,7 +42,7 @@ export function UploadFileButton({
         variant="secondary"
         icon="paperclip"
         onClick={handleClick}
-        disabled={hasPendingFile || disabled}
+        disabled={disabled}
         aria-label={text.attach_file}
         {...props}
       >

--- a/packages/convai-widget-core/src/widget/UploadFileButton.tsx
+++ b/packages/convai-widget-core/src/widget/UploadFileButton.tsx
@@ -1,0 +1,62 @@
+import { useRef, useCallback } from "preact/compat";
+import { useTextContents } from "../contexts/text-contents";
+import { BaseButtonProps, Button } from "../components/Button";
+import { ACCEPTED_FILE_EXTENSIONS } from "./useFileUpload";
+
+interface UploadFileButtonProps extends BaseButtonProps {
+  iconOnly?: boolean;
+  hasPendingFile?: boolean;
+  disabled?: boolean;
+  onFileSelect: (file: File) => void;
+}
+
+export function UploadFileButton({
+  iconOnly,
+  hasPendingFile,
+  disabled,
+  onFileSelect,
+  children,
+  ...props
+}: UploadFileButtonProps) {
+  const text = useTextContents();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = useCallback((e: Event) => {
+    e.stopPropagation();
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: Event) => {
+      const input = e.target as HTMLInputElement;
+      const file = input.files?.[0];
+      if (file) {
+        onFileSelect(file);
+      }
+      input.value = "";
+    },
+    [onFileSelect]
+  );
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        icon="paperclip"
+        onClick={handleClick}
+        disabled={hasPendingFile || disabled}
+        aria-label={text.attach_file}
+        {...props}
+      >
+        {!iconOnly ? (children ?? text.attach_file) : undefined}
+      </Button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_FILE_EXTENSIONS}
+        className="hidden"
+        onChange={handleFileChange}
+      />
+    </>
+  );
+}

--- a/packages/convai-widget-core/src/widget/UploadFileButton.tsx
+++ b/packages/convai-widget-core/src/widget/UploadFileButton.tsx
@@ -51,7 +51,7 @@ export function UploadFileButton({
       <input
         ref={fileInputRef}
         type="file"
-        accept={ACCEPTED_FILE_EXTENSIONS}
+        accept={ACCEPTED_FILE_EXTENSIONS.join(",")}
         className="hidden"
         onChange={handleFileChange}
       />

--- a/packages/convai-widget-core/src/widget/useFileUpload.ts
+++ b/packages/convai-widget-core/src/widget/useFileUpload.ts
@@ -1,0 +1,203 @@
+import { signal, ReadonlySignal, computed } from "@preact/signals";
+import { useCallback, useEffect, useRef } from "preact/compat";
+import { useMemo } from "preact/compat";
+import { useServerLocation } from "../contexts/server-location";
+
+const ACCEPTED_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+] as const;
+
+export const ACCEPTED_FILE_EXTENSIONS =
+  ".png,.jpg,.jpeg,.gif,.webp,.pdf" as const;
+
+const MAX_IMAGE_SIZE_MB = 10;
+const MAX_PDF_SIZE_MB = 20;
+
+function isImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+function isAcceptedMimeType(mimeType: string): boolean {
+  return (ACCEPTED_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+function getMaxSizeBytes(mimeType: string): number {
+  const mb = isImageMimeType(mimeType) ? MAX_IMAGE_SIZE_MB : MAX_PDF_SIZE_MB;
+  return mb * 1024 * 1024;
+}
+
+export type PendingFile =
+  | { status: "uploading"; file: File; previewUrl: string | null }
+  | {
+      status: "ready";
+      file: File;
+      fileId: string;
+      previewUrl: string | null;
+    }
+  | {
+      status: "error";
+      file: File;
+      error: string;
+      previewUrl: string | null;
+    };
+
+interface UseFileUploadOptions {
+  conversationId: string | null;
+  maxFiles: number | null;
+}
+
+export function useFileUpload({
+  conversationId,
+  maxFiles,
+}: UseFileUploadOptions) {
+  const { serverUrl } = useServerLocation();
+  const pendingFile = useMemo(() => signal<PendingFile | null>(null), []);
+  const sentFileCount = useMemo(() => signal(0), []);
+  const lastConversationIdRef = useRef<string | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
+  // Preview URLs for sent files — kept alive so TranscriptMessage can still
+  // render the image thumbnail; revoked on unmount.
+  const sentUrlsRef = useRef<string[]>([]);
+
+  // Reset the per-conversation file counter when the conversation changes.
+  if (conversationId !== lastConversationIdRef.current) {
+    lastConversationIdRef.current = conversationId;
+    sentFileCount.value = 0;
+  }
+
+  useEffect(() => {
+    return () => {
+      revokeUrl(previewUrlRef.current);
+      sentUrlsRef.current.forEach(revokeUrl);
+    };
+  }, []);
+
+  const hasReachedLimit = useMemo(
+    () =>
+      computed(() => {
+        if (maxFiles == null) return false;
+        const pendingCount = pendingFile.value ? 1 : 0;
+        return sentFileCount.value + pendingCount >= maxFiles;
+      }),
+    [maxFiles, pendingFile, sentFileCount]
+  );
+
+  const isUploading = useMemo(
+    () => computed(() => pendingFile.value?.status === "uploading"),
+    [pendingFile]
+  );
+
+  /** Validate and start uploading. Returns an error code on failure, null on success. */
+  const addFile = useCallback(
+    (file: File): string | null => {
+      if (!conversationId) {
+        return "Cannot upload files before the conversation is connected.";
+      }
+
+      if (hasReachedLimit.peek()) {
+        return "limit_reached";
+      }
+
+      if (!isAcceptedMimeType(file.type)) {
+        return "unsupported_type";
+      }
+
+      if (file.size > getMaxSizeBytes(file.type)) {
+        return "too_large";
+      }
+
+      revokeUrl(previewUrlRef.current);
+      previewUrlRef.current = null;
+
+      const previewUrl = isImageMimeType(file.type)
+        ? URL.createObjectURL(file)
+        : null;
+      previewUrlRef.current = previewUrl;
+
+      pendingFile.value = { file, status: "uploading", previewUrl };
+
+      const formData = new FormData();
+      formData.append("file", file);
+
+      fetch(
+        `${serverUrl.peek()}/v1/convai/conversations/${conversationId}/files`,
+        { method: "POST", body: formData }
+      )
+        .then(async res => {
+          if (!res.ok) {
+            const body = await res.json().catch(() => null);
+            throw new Error(
+              body?.detail?.message ?? body?.detail ?? "Upload failed"
+            );
+          }
+          return res.json();
+        })
+        .then(data => {
+          if (pendingFile.peek()?.file === file) {
+            pendingFile.value = {
+              ...pendingFile.peek()!,
+              status: "ready",
+              fileId: data.file_id,
+            } as PendingFile;
+          }
+        })
+        .catch(err => {
+          if (pendingFile.peek()?.file === file) {
+            pendingFile.value = {
+              ...pendingFile.peek()!,
+              status: "error",
+              error: err?.message ?? "Upload failed",
+            } as PendingFile;
+          }
+        });
+
+      return null;
+    },
+    [conversationId, pendingFile, serverUrl, hasReachedLimit]
+  );
+
+  /** Cancel/discard the pending file (deletes it server-side if already uploaded). */
+  const removeFile = useCallback(() => {
+    const current = pendingFile.peek();
+    if (!current) return;
+
+    if (current.status === "ready" && conversationId) {
+      fetch(
+        `${serverUrl.peek()}/v1/convai/conversations/${conversationId}/files/${current.fileId}`,
+        { method: "DELETE" }
+      ).catch(() => {});
+    }
+
+    revokeUrl(previewUrlRef.current);
+    previewUrlRef.current = null;
+    pendingFile.value = null;
+  }, [pendingFile, conversationId, serverUrl]);
+
+  /** Mark the pending file as sent — increments the per-conversation counter. */
+  const markFileAsSent = useCallback(() => {
+    if (previewUrlRef.current) {
+      sentUrlsRef.current.push(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    pendingFile.value = null;
+    sentFileCount.value++;
+  }, [pendingFile, sentFileCount]);
+
+  return {
+    pendingFile: pendingFile as ReadonlySignal<PendingFile | null>,
+    isUploading,
+    hasReachedLimit,
+    addFile,
+    removeFile,
+    markFileAsSent,
+  };
+}
+
+/** Release a blob URL's underlying memory. No-op if null. */
+function revokeUrl(url: string | null) {
+  if (url) URL.revokeObjectURL(url);
+}

--- a/packages/convai-widget-core/src/widget/useFileUpload.ts
+++ b/packages/convai-widget-core/src/widget/useFileUpload.ts
@@ -1,15 +1,14 @@
 import { signal, ReadonlySignal, computed } from "@preact/signals";
-import { useCallback, useEffect, useRef } from "preact/compat";
-import { useMemo } from "preact/compat";
+import { useCallback, useEffect, useMemo, useRef } from "preact/compat";
 import { useServerLocation } from "../contexts/server-location";
 
-const ACCEPTED_MIME_TYPES = [
+const ACCEPTED_MIME_TYPES: readonly string[] = [
   "image/png",
   "image/jpeg",
   "image/gif",
   "image/webp",
   "application/pdf",
-] as const;
+];
 
 export const ACCEPTED_FILE_EXTENSIONS =
   ".png,.jpg,.jpeg,.gif,.webp,.pdf" as const;
@@ -17,12 +16,12 @@ export const ACCEPTED_FILE_EXTENSIONS =
 const MAX_IMAGE_SIZE_MB = 10;
 const MAX_PDF_SIZE_MB = 20;
 
-function isImageMimeType(mimeType: string): boolean {
+export function isImageMimeType(mimeType: string): boolean {
   return mimeType.startsWith("image/");
 }
 
 function isAcceptedMimeType(mimeType: string): boolean {
-  return (ACCEPTED_MIME_TYPES as readonly string[]).includes(mimeType);
+  return ACCEPTED_MIME_TYPES.includes(mimeType);
 }
 
 function getMaxSizeBytes(mimeType: string): number {
@@ -45,6 +44,28 @@ export type PendingFile =
       previewUrl: string | null;
     };
 
+export type AddFileError = "unsupported_type" | "too_large" | "limit_reached";
+
+interface UploadResponse {
+  file_id: string;
+}
+
+function filesEndpoint(baseUrl: string, conversationId: string): string {
+  return `${baseUrl}/v1/convai/conversations/${conversationId}/files`;
+}
+
+/** Fire-and-forget DELETE for a server-side file. Errors are swallowed
+ * because the pending slot has already been released locally. */
+function deleteUploadedFile(
+  baseUrl: string,
+  conversationId: string,
+  fileId: string
+): void {
+  fetch(`${filesEndpoint(baseUrl, conversationId)}/${fileId}`, {
+    method: "DELETE",
+  }).catch(() => {});
+}
+
 interface UseFileUploadOptions {
   conversationId: string | null;
   maxFiles: number | null;
@@ -59,58 +80,44 @@ export function useFileUpload({
   const sentFileCount = useMemo(() => signal(0), []);
   const lastConversationIdRef = useRef<string | null>(null);
   const previewUrlRef = useRef<string | null>(null);
-  // Preview URLs for sent files — kept alive so TranscriptMessage can still
-  // render the image thumbnail. Revoked only when a new conversation starts
-  // (the previous transcript is cleared) or on unmount.
+  // Preview URLs for already-sent files — kept alive for the transcript
+  // thumbnails, revoked on new conversation or unmount.
   const sentUrlsRef = useRef<string[]>([]);
   const uploadAbortRef = useRef<AbortController | null>(null);
 
-  // Reset state when the conversation changes — the old fileId is no longer valid.
+  /** Release the pending slot: abort an in-flight upload, delete a ready
+   * file server-side, revoke the preview URL. Clears the signal first so
+   * any in-flight upload resolution falls into the orphan-DELETE branch. */
+  const discardPending = (convId: string | null): void => {
+    const pendingFileToDiscard = pendingFile.peek();
+    if (!pendingFileToDiscard) return;
+    pendingFile.value = null;
+    if (pendingFileToDiscard.status === "uploading") {
+      uploadAbortRef.current?.abort();
+    } else if (pendingFileToDiscard.status === "ready" && convId) {
+      deleteUploadedFile(serverUrl.peek(), convId, pendingFileToDiscard.fileId);
+    }
+    revokeUrl(previewUrlRef.current);
+    previewUrlRef.current = null;
+  };
+
+  // Reset state on conversation change — the old fileId is no longer valid.
   if (conversationId !== lastConversationIdRef.current) {
-    const prev = pendingFile.value;
     const prevConversationId = lastConversationIdRef.current;
     lastConversationIdRef.current = conversationId;
     sentFileCount.value = 0;
-    // Keep sent URLs alive while the previous transcript is still visible
-    // (i.e. we just disconnected). Only reclaim them when a new conversation
-    // starts and the transcript is about to be cleared.
+    // Only reclaim sent-file blob URLs when a new conversation starts — while
+    // disconnected the previous transcript (and its <img> refs) is still shown.
     if (conversationId !== null) {
       sentUrlsRef.current.forEach(revokeUrl);
       sentUrlsRef.current = [];
     }
-    if (prev) {
-      if (prev.status === "uploading") {
-        // Abort best-effort. The .then handler will still fire a DELETE if
-        // the server accepted the upload before we aborted.
-        uploadAbortRef.current?.abort();
-      } else if (prev.status === "ready" && prevConversationId) {
-        fetch(
-          `${serverUrl.peek()}/v1/convai/conversations/${prevConversationId}/files/${prev.fileId}`,
-          { method: "DELETE" }
-        ).catch(() => {});
-      }
-      revokeUrl(previewUrlRef.current);
-      previewUrlRef.current = null;
-      pendingFile.value = null;
-    }
+    discardPending(prevConversationId);
   }
 
   useEffect(() => {
     return () => {
-      const current = pendingFile.peek();
-      // Null out the pending file *before* aborting so the upload's .then
-      // handler sees the file is no longer ours and falls into the orphan
-      // DELETE branch if the server accepted the upload after the abort.
-      pendingFile.value = null;
-      uploadAbortRef.current?.abort();
-      // Clean up a ready-but-unsent file server-side.
-      if (current?.status === "ready" && lastConversationIdRef.current) {
-        fetch(
-          `${serverUrl.peek()}/v1/convai/conversations/${lastConversationIdRef.current}/files/${current.fileId}`,
-          { method: "DELETE" }
-        ).catch(() => {});
-      }
-      revokeUrl(previewUrlRef.current);
+      discardPending(lastConversationIdRef.current);
       sentUrlsRef.current.forEach(revokeUrl);
     };
   }, []);
@@ -130,24 +137,16 @@ export function useFileUpload({
     [pendingFile]
   );
 
-  /** Validate and start uploading. Returns an error code on failure, null on success. */
+  /** Validate and start uploading the file. */
   const addFile = useCallback(
-    (file: File): string | null => {
-      if (!conversationId) {
-        return "Cannot upload files before the conversation is connected.";
-      }
+    (file: File): AddFileError | null => {
+      // Defensive: the upload button is disabled while disconnected, so this
+      // should be unreachable. Silently no-op if it isn't.
+      if (!conversationId) return null;
 
-      if (hasReachedLimit.peek()) {
-        return "limit_reached";
-      }
-
-      if (!isAcceptedMimeType(file.type)) {
-        return "unsupported_type";
-      }
-
-      if (file.size > getMaxSizeBytes(file.type)) {
-        return "too_large";
-      }
+      if (hasReachedLimit.peek()) return "limit_reached";
+      if (!isAcceptedMimeType(file.type)) return "unsupported_type";
+      if (file.size > getMaxSizeBytes(file.type)) return "too_large";
 
       revokeUrl(previewUrlRef.current);
       previewUrlRef.current = null;
@@ -169,15 +168,12 @@ export function useFileUpload({
       const uploadConversationId = conversationId;
       const baseUrl = serverUrl.peek();
 
-      fetch(
-        `${baseUrl}/v1/convai/conversations/${uploadConversationId}/files`,
-        {
-          method: "POST",
-          body: formData,
-          signal: controller.signal,
-        }
-      )
-        .then(async res => {
+      fetch(filesEndpoint(baseUrl, uploadConversationId), {
+        method: "POST",
+        body: formData,
+        signal: controller.signal,
+      })
+        .then(async (res): Promise<UploadResponse> => {
           if (!res.ok) {
             const body = await res.json().catch(() => null);
             throw new Error(
@@ -187,31 +183,31 @@ export function useFileUpload({
           return res.json();
         })
         .then(data => {
-          if (pendingFile.peek()?.file === file) {
+          const currentPendingFile = pendingFile.peek();
+          if (currentPendingFile?.file === file) {
             pendingFile.value = {
-              ...pendingFile.peek()!,
               status: "ready",
+              file: currentPendingFile.file,
+              previewUrl: currentPendingFile.previewUrl,
               fileId: data.file_id,
-            } as PendingFile;
+            };
           } else {
-            // The upload was discarded (cancelled or conversation changed)
-            // while the request was in flight but the server still accepted
-            // it — clean up the orphan.
-            fetch(
-              `${baseUrl}/v1/convai/conversations/${uploadConversationId}/files/${data.file_id}`,
-              { method: "DELETE" }
-            ).catch(() => {});
+            // Pending slot was released mid-flight but the server still
+            // accepted the upload — clean up the orphan.
+            deleteUploadedFile(baseUrl, uploadConversationId, data.file_id);
           }
         })
         .catch(err => {
           if (err?.name === "AbortError") return;
           console.warn("[convai] file upload failed:", err);
-          if (pendingFile.peek()?.file === file) {
+          const currentPendingFile = pendingFile.peek();
+          if (currentPendingFile?.file === file) {
             pendingFile.value = {
-              ...pendingFile.peek()!,
               status: "error",
+              file: currentPendingFile.file,
+              previewUrl: currentPendingFile.previewUrl,
               error: err?.message ?? "Upload failed",
-            } as PendingFile;
+            };
           }
         })
         .finally(() => {
@@ -225,29 +221,12 @@ export function useFileUpload({
     [conversationId, pendingFile, serverUrl, hasReachedLimit]
   );
 
-  /** Cancel/discard the pending file (aborts in-flight uploads and deletes
-   * the file server-side if it was already accepted). */
   const removeFile = useCallback(() => {
-    const current = pendingFile.peek();
-    if (!current) return;
+    discardPending(conversationId);
+  }, [conversationId]);
 
-    if (current.status === "uploading") {
-      // Abort best-effort; if the server still accepts the upload the .then
-      // handler in addFile will fire a DELETE for the orphan.
-      uploadAbortRef.current?.abort();
-    } else if (current.status === "ready" && conversationId) {
-      fetch(
-        `${serverUrl.peek()}/v1/convai/conversations/${conversationId}/files/${current.fileId}`,
-        { method: "DELETE" }
-      ).catch(() => {});
-    }
-
-    revokeUrl(previewUrlRef.current);
-    previewUrlRef.current = null;
-    pendingFile.value = null;
-  }, [pendingFile, conversationId, serverUrl]);
-
-  /** Mark the pending file as sent — increments the per-conversation counter. */
+  /** Promote the pending file to "sent": retain its preview URL for the
+   * transcript image, free the pending slot, count it against the limit. */
   const markFileAsSent = useCallback(() => {
     if (previewUrlRef.current) {
       sentUrlsRef.current.push(previewUrlRef.current);
@@ -267,7 +246,6 @@ export function useFileUpload({
   };
 }
 
-/** Release a blob URL's underlying memory. No-op if null. */
 function revokeUrl(url: string | null) {
   if (url) URL.revokeObjectURL(url);
 }

--- a/packages/convai-widget-core/src/widget/useFileUpload.ts
+++ b/packages/convai-widget-core/src/widget/useFileUpload.ts
@@ -60,17 +60,56 @@ export function useFileUpload({
   const lastConversationIdRef = useRef<string | null>(null);
   const previewUrlRef = useRef<string | null>(null);
   // Preview URLs for sent files — kept alive so TranscriptMessage can still
-  // render the image thumbnail; revoked on unmount.
+  // render the image thumbnail. Revoked only when a new conversation starts
+  // (the previous transcript is cleared) or on unmount.
   const sentUrlsRef = useRef<string[]>([]);
+  const uploadAbortRef = useRef<AbortController | null>(null);
 
-  // Reset the per-conversation file counter when the conversation changes.
+  // Reset state when the conversation changes — the old fileId is no longer valid.
   if (conversationId !== lastConversationIdRef.current) {
+    const prev = pendingFile.value;
+    const prevConversationId = lastConversationIdRef.current;
     lastConversationIdRef.current = conversationId;
     sentFileCount.value = 0;
+    // Keep sent URLs alive while the previous transcript is still visible
+    // (i.e. we just disconnected). Only reclaim them when a new conversation
+    // starts and the transcript is about to be cleared.
+    if (conversationId !== null) {
+      sentUrlsRef.current.forEach(revokeUrl);
+      sentUrlsRef.current = [];
+    }
+    if (prev) {
+      if (prev.status === "uploading") {
+        // Abort best-effort. The .then handler will still fire a DELETE if
+        // the server accepted the upload before we aborted.
+        uploadAbortRef.current?.abort();
+      } else if (prev.status === "ready" && prevConversationId) {
+        fetch(
+          `${serverUrl.peek()}/v1/convai/conversations/${prevConversationId}/files/${prev.fileId}`,
+          { method: "DELETE" }
+        ).catch(() => {});
+      }
+      revokeUrl(previewUrlRef.current);
+      previewUrlRef.current = null;
+      pendingFile.value = null;
+    }
   }
 
   useEffect(() => {
     return () => {
+      const current = pendingFile.peek();
+      // Null out the pending file *before* aborting so the upload's .then
+      // handler sees the file is no longer ours and falls into the orphan
+      // DELETE branch if the server accepted the upload after the abort.
+      pendingFile.value = null;
+      uploadAbortRef.current?.abort();
+      // Clean up a ready-but-unsent file server-side.
+      if (current?.status === "ready" && lastConversationIdRef.current) {
+        fetch(
+          `${serverUrl.peek()}/v1/convai/conversations/${lastConversationIdRef.current}/files/${current.fileId}`,
+          { method: "DELETE" }
+        ).catch(() => {});
+      }
       revokeUrl(previewUrlRef.current);
       sentUrlsRef.current.forEach(revokeUrl);
     };
@@ -123,9 +162,20 @@ export function useFileUpload({
       const formData = new FormData();
       formData.append("file", file);
 
+      const controller = new AbortController();
+      uploadAbortRef.current = controller;
+      // Capture the conversation id at upload time so orphan cleanup targets
+      // the right conversation even if the user has since switched.
+      const uploadConversationId = conversationId;
+      const baseUrl = serverUrl.peek();
+
       fetch(
-        `${serverUrl.peek()}/v1/convai/conversations/${conversationId}/files`,
-        { method: "POST", body: formData }
+        `${baseUrl}/v1/convai/conversations/${uploadConversationId}/files`,
+        {
+          method: "POST",
+          body: formData,
+          signal: controller.signal,
+        }
       )
         .then(async res => {
           if (!res.ok) {
@@ -143,15 +193,30 @@ export function useFileUpload({
               status: "ready",
               fileId: data.file_id,
             } as PendingFile;
+          } else {
+            // The upload was discarded (cancelled or conversation changed)
+            // while the request was in flight but the server still accepted
+            // it — clean up the orphan.
+            fetch(
+              `${baseUrl}/v1/convai/conversations/${uploadConversationId}/files/${data.file_id}`,
+              { method: "DELETE" }
+            ).catch(() => {});
           }
         })
         .catch(err => {
+          if (err?.name === "AbortError") return;
+          console.warn("[convai] file upload failed:", err);
           if (pendingFile.peek()?.file === file) {
             pendingFile.value = {
               ...pendingFile.peek()!,
               status: "error",
               error: err?.message ?? "Upload failed",
             } as PendingFile;
+          }
+        })
+        .finally(() => {
+          if (uploadAbortRef.current === controller) {
+            uploadAbortRef.current = null;
           }
         });
 
@@ -160,12 +225,17 @@ export function useFileUpload({
     [conversationId, pendingFile, serverUrl, hasReachedLimit]
   );
 
-  /** Cancel/discard the pending file (deletes it server-side if already uploaded). */
+  /** Cancel/discard the pending file (aborts in-flight uploads and deletes
+   * the file server-side if it was already accepted). */
   const removeFile = useCallback(() => {
     const current = pendingFile.peek();
     if (!current) return;
 
-    if (current.status === "ready" && conversationId) {
+    if (current.status === "uploading") {
+      // Abort best-effort; if the server still accepts the upload the .then
+      // handler in addFile will fire a DELETE for the orphan.
+      uploadAbortRef.current?.abort();
+    } else if (current.status === "ready" && conversationId) {
       fetch(
         `${serverUrl.peek()}/v1/convai/conversations/${conversationId}/files/${current.fileId}`,
         { method: "DELETE" }

--- a/packages/convai-widget-core/src/widget/useFileUpload.ts
+++ b/packages/convai-widget-core/src/widget/useFileUpload.ts
@@ -10,8 +10,14 @@ const ACCEPTED_MIME_TYPES: readonly string[] = [
   "application/pdf",
 ];
 
-export const ACCEPTED_FILE_EXTENSIONS =
-  ".png,.jpg,.jpeg,.gif,.webp,.pdf" as const;
+export const ACCEPTED_FILE_EXTENSIONS = [
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".pdf",
+] as const;
 
 const MAX_IMAGE_SIZE_MB = 10;
 const MAX_PDF_SIZE_MB = 20;


### PR DESCRIPTION
### Summary

Adding file upload capability to the embedded widget.

- The widget receives `file_input_config.enabled` and `file_input_config._max_files_per_conversation` configs from the backend during intialization (https://github.com/elevenlabs/xi/pull/31843)
- If `file_input_config.enabled` is true, a 📎  button shows up in the widget and allows uploading a PDF or an image file.
- The file gets uploaded via a POST endpoint, which returns a file ID. If the user clicks `x` on the file before sending it in a message, we call a DELETE endpoint to delete the file from the bucket.
- When the message with a file gets sent, we call `sendMultimodalMessage(...)` to pass the file ID along with an optional text message via WS and we attach a new entry to the transcript to show the file there.

### Testing
Tested locally, confirmed that:

- the agent "sees" file contents
- can't upload more that 10 files per conversation (the 📎  button becomes disabled)
- can't upload too large files (shows an error)

File upload button (📎  icon)
<img width="428" height="137" alt="Screenshot 2026-04-16 at 13 57 16" src="https://github.com/user-attachments/assets/a1c0dd8f-de8f-432f-b518-4b85bd702adb" />

Attaching an image to the message
<img width="415" height="199" alt="Screenshot 2026-04-16 at 13 58 28" src="https://github.com/user-attachments/assets/70ee60c8-5231-45a9-88d4-f0761848fcc7" />
<img width="409" height="191" alt="Screenshot 2026-04-16 at 13 58 43" src="https://github.com/user-attachments/assets/22a44f98-a4b7-4b87-bc80-3b1c7e80436b" />

Attaching a pdf
<img width="426" height="209" alt="Screenshot 2026-04-16 at 14 05 54" src="https://github.com/user-attachments/assets/7626f5a8-58fe-403b-b380-f797d4af0f25" />

Image in the transcript
<img width="422" height="564" alt="Screenshot 2026-04-16 at 13 59 04" src="https://github.com/user-attachments/assets/185e6b60-1e9c-4b3b-8005-1aa59b85548d" />

PDF in the transcript
<img width="422" height="176" alt="Screenshot 2026-04-16 at 14 00 05" src="https://github.com/user-attachments/assets/58918e65-5c1d-4ac9-8a96-43934b2b5415" />

Trying to upload a large file
<img width="440" height="148" alt="Screenshot 2026-04-16 at 14 14 29" src="https://github.com/user-attachments/assets/7740ffed-691a-4da6-91d3-c76f206737bc" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds client-side file upload flow (POST/DELETE) and multimodal message sending, touching conversation state and UI input handling; regressions could affect message sending or cause orphaned uploads/URLs.
> 
> **Overview**
> Adds **optional file upload** to the embedded ConvAI widget gated by new `file_input_config` (enable flag + per-conversation limit), exposing hooks `useFileInputEnabled`/`useFileInputMaxFiles` and updating config/types accordingly.
> 
> Introduces a full upload/send pipeline: a new `useFileUpload` hook validates type/size/limits, uploads via `POST /v1/convai/conversations/:id/files`, cleans up via `DELETE` on removal/orphans, and `SheetActions` now supports attaching a pending file, showing a preview/error state, and sending via `sendMultimodalMessage` (with transcript entries storing `fileInput`).
> 
> Updates transcript rendering to display attached images/PDFs, adds a `paperclip` icon + `UploadFileButton`/`PendingFilePreview` components, extends mocks to cover file endpoints/config scenarios, and adds browser tests for attach visibility, preview, and removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ed692ddc9b8619ccb08ec956b37344a42e6e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->