### PR TITLE
[zrm] enable scribe zrm in packages

### DIFF
--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -91,6 +91,62 @@ describe("Scribe", () => {
       server.close();
     });
 
+    it("builds URI with enableLogging set to false", () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&enable_logging=false"
+      );
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+        enableLogging: false,
+      });
+
+      expect(connection).toBeDefined();
+
+      connection.close();
+      server.close();
+    });
+
+    it("builds URI with enableLogging set to true", () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&enable_logging=true"
+      );
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+        enableLogging: true,
+      });
+
+      expect(connection).toBeDefined();
+
+      connection.close();
+      server.close();
+    });
+
+    it("omits enable_logging from URI when not specified", () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123"
+      );
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+      });
+
+      expect(connection).toBeDefined();
+
+      connection.close();
+      server.close();
+    });
+
     it("throws error when modelId is missing", () => {
       expect(() => {
         Scribe.connect({

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -66,6 +66,11 @@ interface BaseOptions {
    * @default false
    */
   includeTimestamps?: boolean;
+  /**
+   * Whether to enable logging for this session.
+   * When set to false, logging will be disabled.
+   */
+  enableLogging?: boolean;
 }
 
 export interface AudioOptions extends BaseOptions {
@@ -170,6 +175,12 @@ export class ScribeRealtime {
       params.append(
         "include_timestamps",
         options.includeTimestamps ? "true" : "false"
+      );
+    }
+    if (options.enableLogging !== undefined) {
+      params.append(
+        "enable_logging",
+        options.enableLogging ? "true" : "false"
       );
     }
 

--- a/packages/react/src/scribe.ts
+++ b/packages/react/src/scribe.ts
@@ -113,6 +113,9 @@ export interface ScribeHookOptions extends ScribeCallbacks {
 
   // Include timestamps
   includeTimestamps?: boolean;
+
+  // Logging
+  enableLogging?: boolean;
 }
 
 export interface UseScribeReturn {
@@ -186,6 +189,9 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
 
     // Timestamps
     includeTimestamps: defaultIncludeTimestamps,
+
+    // Logging
+    enableLogging: defaultEnableLogging,
   } = options;
 
   const connectionRef = useRef<RealtimeConnection | null>(null);
@@ -242,6 +248,9 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
             onCommittedTranscriptWithTimestamps
           );
 
+        const enableLogging =
+          runtimeOptions.enableLogging ?? defaultEnableLogging;
+
         if (microphone) {
           // Microphone mode
           connection = Scribe.connect({
@@ -262,6 +271,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
             languageCode: runtimeOptions.languageCode || defaultLanguageCode,
             microphone,
             includeTimestamps,
+            enableLogging,
           } as MicrophoneOptions);
         } else if (audioFormat && sampleRate) {
           // Manual audio mode
@@ -282,6 +292,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
               defaultMinSilenceDurationMs,
             languageCode: runtimeOptions.languageCode || defaultLanguageCode,
             includeTimestamps,
+            enableLogging,
             audioFormat,
             sampleRate,
           } as AudioOptions);
@@ -464,6 +475,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
       defaultAudioFormat,
       defaultSampleRate,
       defaultIncludeTimestamps,
+      defaultEnableLogging,
       onSessionStarted,
       onPartialTranscript,
       onCommittedTranscript,


### PR DESCRIPTION
## description
threads through the enable logging param, see #545 
## testing 

added test

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `enable_logging` query parameter that changes server-side logging behavior for Scribe sessions; risk is limited but could affect observability and request compatibility if the backend expects different defaults.
> 
> **Overview**
> Adds an `enableLogging` option to Scribe realtime connections and propagates it through the React `useScribe` hook so callers can explicitly enable/disable session logging.
> 
> Updates WebSocket URI construction to include `enable_logging=true|false` only when specified, and adds unit tests to cover true/false/omitted cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f07261ef3d22f77b2aa4be9a7c6702e352172bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->