### PR TITLE
Add `uploadConversationFile`

### DIFF
--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -7,7 +7,10 @@ import {
   TouchableOpacity,
   Keyboard,
   TextInput,
+  Image,
+  ActivityIndicator,
 } from "react-native";
+import * as ImagePicker from "expo-image-picker";
 import { VolumeBar } from "./VolumeBar";
 import { FrequencyBands } from "./FrequencyBands";
 import {
@@ -37,9 +40,13 @@ const ConversationScreen = () => {
     sendUserMessage,
     sendContextualUpdate,
     sendUserActivity,
+    sendMultimodalMessage,
+    uploadConversationFile,
     getId,
   } = useConversationControls();
   const isStarting = status === "connecting";
+  const [isUploading, setIsUploading] = useState(false);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
   const handleSubmitText = () => {
     if (textInput.trim()) {
@@ -65,6 +72,30 @@ const ConversationScreen = () => {
       endSession();
     } catch (error) {
       console.error("Failed to end conversation:", error);
+    }
+  };
+
+  const handlePickAndUploadImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      quality: 0.8,
+    });
+    if (result.canceled) return;
+
+    const asset = result.assets[0];
+    setSelectedImage(asset.uri);
+    setIsUploading(true);
+
+    try {
+      const blob = await fetch(asset.uri).then(r => r.blob());
+      const { fileId } = await uploadConversationFile(blob);
+      sendMultimodalMessage({ fileId, text: textInput.trim() || undefined });
+      setTextInput("");
+    } catch (error) {
+      console.error("Failed to upload image:", error);
+    } finally {
+      setIsUploading(false);
+      setSelectedImage(null);
     }
   };
 
@@ -299,6 +330,32 @@ const ConversationScreen = () => {
               <Text style={styles.buttonText}>Send Context</Text>
             </TouchableOpacity>
           </View>
+
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.uploadButton,
+              isUploading && styles.disabledButton,
+            ]}
+            onPress={handlePickAndUploadImage}
+            disabled={isUploading}
+          >
+            {isUploading ? (
+              <View style={styles.uploadingRow}>
+                <ActivityIndicator color="white" size="small" />
+                <Text style={styles.buttonText}>Uploading...</Text>
+              </View>
+            ) : (
+              <Text style={styles.buttonText}>Upload Image</Text>
+            )}
+          </TouchableOpacity>
+
+          {selectedImage && (
+            <Image
+              source={{ uri: selectedImage }}
+              style={styles.imagePreview}
+            />
+          )}
         </View>
       )}
     </ScrollView>
@@ -548,5 +605,20 @@ const styles = StyleSheet.create({
   },
   toggleButtonPassive: {
     borderColor: "transparent",
+  },
+  uploadButton: {
+    backgroundColor: "#8B5CF6",
+    marginTop: 12,
+  },
+  uploadingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  imagePreview: {
+    width: "100%",
+    height: 200,
+    borderRadius: 8,
+    marginTop: 12,
   },
 });

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -20,6 +20,7 @@
     "@livekit/react-native-webrtc": "^137.0.2",
     "expo": "~54.0.31",
     "expo-dev-client": "~6.0.20",
+    "expo-image-picker": "~17.0.10",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -1,14 +1,37 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 import {
   BaseConversation,
   Options,
   PartialOptions,
 } from "./BaseConversation.js";
+import type { BaseConnection } from "./utils/BaseConnection.js";
+
+const noopConnection = {
+  conversationId: "test-conversation-id",
+  onMessage: () => {},
+  onDisconnect: () => {},
+  onModeChange: () => {},
+  close: () => {},
+  sendMessage: () => {},
+} as unknown as BaseConnection;
 
 class TestConversation extends BaseConversation {
   public static getFullOptions(partialOptions: PartialOptions): Options {
     return super.getFullOptions(partialOptions);
+  }
+
+  public static create(options: { origin?: string } = {}): TestConversation {
+    const fullOptions = TestConversation.getFullOptions({
+      agentId: "test-agent-id",
+      connectionType: "webrtc",
+      ...options,
+    });
+    return new TestConversation(fullOptions, noopConnection);
+  }
+
+  constructor(options: Options, connection: BaseConnection) {
+    super(options, connection);
   }
 
   public setVolume(): void {}
@@ -75,5 +98,65 @@ describe("BaseConversation", () => {
         );
       }
     );
+  });
+
+  describe("uploadConversationFile", () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function mockFetchSuccess() {
+      fetchSpy = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ file_id: "test-file-id" }),
+      });
+      globalThis.fetch = fetchSpy;
+    }
+
+    function getUploadedFilename(): string {
+      const formData = fetchSpy.mock.calls[0][1].body as FormData;
+      return (formData.get("file") as File).name;
+    }
+
+    it("converts wss:// origin to https://", async () => {
+      mockFetchSuccess();
+      const conversation = TestConversation.create({
+        origin: "wss://api.elevenlabs.io",
+      });
+
+      await conversation.uploadConversationFile(new Blob(["test"]));
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("https://api.elevenlabs.io/"),
+        expect.anything()
+      );
+    });
+
+    it("converts ws:// origin to http://", async () => {
+      mockFetchSuccess();
+      const conversation = TestConversation.create({
+        origin: "ws://localhost:8080",
+      });
+
+      await conversation.uploadConversationFile(new Blob(["test"]));
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("http://localhost:8080/"),
+        expect.anything()
+      );
+    });
+
+    it("strips +suffix from MIME subtype for filename", async () => {
+      mockFetchSuccess();
+      const conversation = TestConversation.create();
+
+      await conversation.uploadConversationFile(
+        new Blob(["<svg/>"], { type: "image/svg+xml" })
+      );
+
+      expect(getUploadedFilename()).toBe("upload.svg");
+    });
   });
 });

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -590,10 +590,9 @@ export abstract class BaseConversation {
   public async uploadConversationFile(
     file: Blob
   ): Promise<UploadConversationFileResult> {
-    const origin = (this.options.origin ?? HTTPS_API_ORIGIN).replace(
-      /^wss?:\/\//,
-      "https://"
-    );
+    const origin = (this.options.origin ?? HTTPS_API_ORIGIN)
+      .replace(/^wss:\/\//, "https://")
+      .replace(/^ws:\/\//, "http://");
 
     const filename =
       "name" in file && typeof file.name === "string"

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -28,6 +28,8 @@ import type {
 import type { InputConfig } from "./utils/input.js";
 import type { OutputConfig } from "./utils/output.js";
 
+const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
+
 export type { Role, Mode, Status, Callbacks } from "@elevenlabs/types";
 export { CALLBACK_KEYS } from "@elevenlabs/types";
 
@@ -66,6 +68,10 @@ export type PartialOptions = SessionConfig &
 export type MultimodalMessageInput = {
   text?: string;
   fileId?: string;
+};
+
+export type UploadConversationFileResult = {
+  fileId: string;
 };
 
 export type ClientToolsConfig = {
@@ -579,5 +585,29 @@ export abstract class BaseConversation {
         ? { type: "file_input" as const, file_id: options.fileId }
         : undefined,
     });
+  }
+
+  public async uploadConversationFile(
+    file: Blob
+  ): Promise<UploadConversationFileResult> {
+    const origin = (this.options.origin ?? HTTPS_API_ORIGIN).replace(
+      /^wss:\/\//,
+      "https://"
+    );
+
+    const body = new FormData();
+    body.append("file", file);
+
+    const response = await fetch(
+      `${origin}/v1/convai/conversations/${this.connection.conversationId}/files`,
+      { method: "POST", body }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Upload failed: ${response.status}`);
+    }
+
+    const { file_id } = await response.json();
+    return { fileId: file_id };
   }
 }

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -591,14 +591,14 @@ export abstract class BaseConversation {
     file: Blob
   ): Promise<UploadConversationFileResult> {
     const origin = (this.options.origin ?? HTTPS_API_ORIGIN).replace(
-      /^wss:\/\//,
+      /^wss?:\/\//,
       "https://"
     );
 
     const filename =
       "name" in file && typeof file.name === "string"
         ? file.name
-        : `upload.${(file.type || "image/png").split("/").pop()}`;
+        : `upload.${(file.type || "image/png").split("/").pop()?.split("+")[0]}`;
 
     const body = new FormData();
     body.append("file", file, filename);

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -595,8 +595,13 @@ export abstract class BaseConversation {
       "https://"
     );
 
+    const filename =
+      "name" in file && typeof file.name === "string"
+        ? file.name
+        : `upload.${(file.type || "image/png").split("/").pop()}`;
+
     const body = new FormData();
-    body.append("file", file);
+    body.append("file", file, filename);
 
     const response = await fetch(
       `${origin}/v1/convai/conversations/${this.connection.conversationId}/files`,
@@ -604,7 +609,8 @@ export abstract class BaseConversation {
     );
 
     if (!response.ok) {
-      throw new Error(`Upload failed: ${response.status}`);
+      const text = await response.text().catch(() => "");
+      throw new Error(`Upload failed: ${response.status} ${text}`);
     }
 
     const { file_id } = await response.json();

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,6 +12,7 @@ export type {
   Status,
   AudioWorkletConfig,
   MultimodalMessageInput,
+  UploadConversationFileResult,
   ConversationCreatedCallback,
   ConversationLifecycleOptions,
 } from "./BaseConversation.js";

--- a/packages/react/src/conversation/ConversationControls.tsx
+++ b/packages/react/src/conversation/ConversationControls.tsx
@@ -5,6 +5,7 @@ import {
   type InputDeviceConfig,
   type OutputConfig,
   type MultimodalMessageInput,
+  type UploadConversationFileResult,
 } from "@elevenlabs/client";
 import type { HookOptions } from "./types.js";
 import { ConversationContext } from "./ConversationContext.js";
@@ -16,12 +17,10 @@ export type ConversationControlsValue = {
   endSession: () => void;
   sendUserMessage: (text: string) => void;
   sendMultimodalMessage: (options: MultimodalMessageInput) => void;
+  uploadConversationFile: (file: Blob) => Promise<UploadConversationFileResult>;
   sendContextualUpdate: (text: string) => void;
   sendUserActivity: () => void;
-  sendMCPToolApprovalResult: (
-    toolCallId: string,
-    isApproved: boolean
-  ) => void;
+  sendMCPToolApprovalResult: (toolCallId: string, isApproved: boolean) => void;
   setVolume: (options: { volume: number }) => void;
   changeInputDevice: (
     config: Partial<FormatConfig> & InputDeviceConfig
@@ -65,9 +64,12 @@ export function ConversationControlsProvider({
     return conversation;
   }, [conversationRef]);
 
-  const sendUserMessage = useCallback((text: string) => {
-    getConversation().sendUserMessage(text);
-  }, [getConversation]);
+  const sendUserMessage = useCallback(
+    (text: string) => {
+      getConversation().sendUserMessage(text);
+    },
+    [getConversation]
+  );
 
   const sendMultimodalMessage = useCallback(
     (options: MultimodalMessageInput) => {
@@ -76,9 +78,19 @@ export function ConversationControlsProvider({
     [getConversation]
   );
 
-  const sendContextualUpdate = useCallback((text: string) => {
-    getConversation().sendContextualUpdate(text);
-  }, [getConversation]);
+  const uploadConversationFile = useCallback(
+    (file: Blob) => {
+      return getConversation().uploadConversationFile(file);
+    },
+    [getConversation]
+  );
+
+  const sendContextualUpdate = useCallback(
+    (text: string) => {
+      getConversation().sendContextualUpdate(text);
+    },
+    [getConversation]
+  );
 
   const sendUserActivity = useCallback(() => {
     getConversation().sendUserActivity();
@@ -91,9 +103,12 @@ export function ConversationControlsProvider({
     [getConversation]
   );
 
-  const setVolume = useCallback((options: { volume: number }) => {
-    getConversation().setVolume(options);
-  }, [getConversation]);
+  const setVolume = useCallback(
+    (options: { volume: number }) => {
+      getConversation().setVolume(options);
+    },
+    [getConversation]
+  );
 
   const changeInputDevice = useCallback(
     async (config: Partial<FormatConfig> & InputDeviceConfig) => {
@@ -122,11 +137,17 @@ export function ConversationControlsProvider({
   );
 
   const getInputByteFrequencyData = useCallback(() => {
-    return conversationRef.current?.getInputByteFrequencyData() ?? EMPTY_FREQUENCY_DATA;
+    return (
+      conversationRef.current?.getInputByteFrequencyData() ??
+      EMPTY_FREQUENCY_DATA
+    );
   }, [conversationRef]);
 
   const getOutputByteFrequencyData = useCallback(() => {
-    return conversationRef.current?.getOutputByteFrequencyData() ?? EMPTY_FREQUENCY_DATA;
+    return (
+      conversationRef.current?.getOutputByteFrequencyData() ??
+      EMPTY_FREQUENCY_DATA
+    );
   }, [conversationRef]);
 
   const getInputVolume = useCallback(() => {
@@ -147,6 +168,7 @@ export function ConversationControlsProvider({
       endSession: ctx.endSession,
       sendUserMessage,
       sendMultimodalMessage,
+      uploadConversationFile,
       sendContextualUpdate,
       sendUserActivity,
       sendMCPToolApprovalResult,
@@ -164,6 +186,7 @@ export function ConversationControlsProvider({
       ctx.endSession,
       sendUserMessage,
       sendMultimodalMessage,
+      uploadConversationFile,
       sendContextualUpdate,
       sendUserActivity,
       sendMCPToolApprovalResult,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       expo-dev-client:
         specifier: ~6.0.20
         version: 6.0.20(expo@54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
+      expo-image-picker:
+        specifier: ~17.0.10
+        version: 17.0.10(expo@54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -507,7 +510,7 @@ importers:
     devDependencies:
       '@asyncapi/cli':
         specifier: ^6.0.0
-        version: 6.0.0(@babel/core@7.12.9)(@types/babel__core@7.20.5)(@types/node@22.19.2)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
+        version: 6.0.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(@types/node@22.19.2)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
       '@asyncapi/modelina':
         specifier: ^5.10.1
         version: 5.10.1(encoding@0.1.13)
@@ -7134,6 +7137,16 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-image-loader@6.0.0:
+    resolution: {integrity: sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-picker@17.0.10:
+    resolution: {integrity: sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==}
+    peerDependencies:
+      expo: '*'
+
   expo-json-utils@0.15.0:
     resolution: {integrity: sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==}
 
@@ -12116,7 +12129,7 @@ snapshots:
       js-yaml: 4.1.1
       lodash: 4.17.23
 
-  '@asyncapi/cli@6.0.0(@babel/core@7.12.9)(@types/babel__core@7.20.5)(@types/node@22.19.2)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))':
+  '@asyncapi/cli@6.0.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(@types/node@22.19.2)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))':
     dependencies:
       '@asyncapi/avro-schema-parser': 3.0.24(encoding@0.1.13)
       '@asyncapi/bundler': 0.6.4
@@ -12130,7 +12143,7 @@ snapshots:
       '@asyncapi/problem': 1.0.0
       '@asyncapi/protobuf-schema-parser': 3.6.0(encoding@0.1.13)
       '@asyncapi/raml-dt-schema-parser': 4.0.24(encoding@0.1.13)
-      '@asyncapi/studio': 1.2.0(@babel/core@7.12.9)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
+      '@asyncapi/studio': 1.2.0(@babel/core@7.29.0)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
       '@changesets/changelog-git': 0.2.1
       '@clack/prompts': 0.11.0
       '@oclif/core': 4.10.2
@@ -12502,7 +12515,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@asyncapi/studio@1.2.0(@babel/core@7.12.9)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))':
+  '@asyncapi/studio@1.2.0(@babel/core@7.29.0)(csstype@3.2.3)(encoding@0.1.13)(immer@9.0.21)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))':
     dependencies:
       '@asyncapi/avro-schema-parser': 3.0.24(encoding@0.1.13)
       '@asyncapi/converter': 2.0.1(encoding@0.1.13)
@@ -12531,7 +12544,7 @@ snapshots:
       js-yaml: 4.1.1
       monaco-editor: 0.34.1
       monaco-yaml: 4.0.2(monaco-editor@0.34.1)
-      next: 14.2.35(@babel/core@7.12.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.35(@babel/core@7.29.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -21309,6 +21322,15 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
 
+  expo-image-loader@6.0.0(expo@54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      expo: 54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-image-picker@17.0.10(expo@54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      expo: 54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-image-loader: 6.0.0(expo@54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
+
   expo-json-utils@0.15.0: {}
 
   expo-keep-awake@15.0.8(expo@54.0.31(@babel/core@7.28.5)(@expo/metro-runtime@4.0.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)))(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react@19.1.0):
@@ -23762,7 +23784,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@14.2.35(@babel/core@7.12.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.35(@babel/core@7.29.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -23772,7 +23794,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.12.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -25900,12 +25922,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.1(@babel/core@7.12.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.29.0
 
   styleq@0.1.3: {}
 


### PR DESCRIPTION
Adds `uploadConversationFile` to `BaseConversation`, enabling client-side file uploads during active conversations via POST `/v1/convai/conversations/{id}/files`. The method returns a `{ fileId }` that can be passed to `sendMultimodalMessage`. 

Also wired through `useConversationControls()` in the React hooks, which surfaces it automatically in both `@elevenlabs/react` and `@elevenlabs/react-native`. The example app demonstrates the flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new network upload path (`fetch` + `FormData`) tied to active conversation IDs, which can fail due to auth/origin/CORS and introduces new error-handling paths. Surface area is moderate since it’s additive and covered by basic unit tests and an example integration.
> 
> **Overview**
> Enables **client-side file uploads within an active conversation** by adding `BaseConversation.uploadConversationFile(file: Blob)`, which POSTs to `/v1/convai/conversations/{conversationId}/files` and returns `{ fileId }` for use with `sendMultimodalMessage`.
> 
> Wires this API through `useConversationControls()` (React hooks) and exports the new `UploadConversationFileResult` type, plus adds unit tests for origin scheme normalization and filename generation. Updates the React Native Expo example to pick an image via `expo-image-picker`, upload it, and send a multimodal message with an uploading UI/preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e6d06a5ab750b34969087815bfc5fafa67f467b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->