### PR TITLE
fix tool call sound interrupting agent

### DIFF
--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -170,7 +170,13 @@ export class VoiceConversation extends BaseConversation {
   protected override handleInterruption(event: InterruptionEvent) {
     super.handleInterruption(event);
     this.updateMode("listening");
-    this.output.interrupt();
+
+    const interruptId = event.interruption_event?.event_id;
+    const skipOutputFlush =
+      interruptId !== undefined && interruptId < this.currentEventId;
+    if (!skipOutputFlush) {
+      this.output.interrupt();
+    }
   }
 
   protected override handleAudio(event: AgentAudioEvent) {

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -169,12 +169,12 @@ export class VoiceConversation extends BaseConversation {
 
   protected override handleInterruption(event: InterruptionEvent) {
     super.handleInterruption(event);
-    this.updateMode("listening");
 
     const interruptId = event.interruption_event?.event_id;
     const skipOutputFlush =
       interruptId !== undefined && interruptId < this.currentEventId;
     if (!skipOutputFlush) {
+      this.updateMode("listening");
       this.output.interrupt();
     }
   }

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -10,8 +10,12 @@ import {
 import { Client, Server } from "mock-socket";
 import chunk from "./__tests__/chunk.js";
 import { Mode, Status, Conversation } from "./index.js";
+import type { Options, PartialOptions } from "./BaseConversation.js";
+import type { InputController } from "./InputController.js";
+import type { OutputController } from "./OutputController.js";
+import { VoiceConversation } from "./VoiceConversation.js";
 import { createConnection } from "./utils/ConnectionFactory.js";
-import type { SessionConfig } from "./utils/BaseConnection.js";
+import type { BaseConnection, SessionConfig } from "./utils/BaseConnection.js";
 import { PACKAGE_VERSION } from "./version.js";
 
 const CONVERSATION_ID = "TEST_CONVERSATION_ID";
@@ -1690,6 +1694,58 @@ describe("Wake Lock", () => {
     expect(mockSentinel.release).toHaveBeenCalled();
 
     server.close();
+  });
+
+  it("skips output interrupt when interruption id is below currentEventId", () => {
+    const interrupt = vi.fn();
+    const conn = {
+      conversationId: "c",
+      onMessage: () => {},
+      onDisconnect: () => {},
+      onModeChange: () => {},
+      close: () => {},
+      sendMessage: () => {},
+    } as unknown as BaseConnection;
+    const input: InputController = {
+      close: vi.fn().mockResolvedValue(undefined),
+      setDevice: vi.fn().mockResolvedValue(undefined),
+      setMuted: vi.fn().mockResolvedValue(undefined),
+      isMuted: () => false,
+      getAnalyser: () => undefined,
+      getVolume: () => 0,
+      getByteFrequencyData: () => {},
+    };
+    const output = {
+      interrupt,
+      close: vi.fn().mockResolvedValue(undefined),
+      setDevice: vi.fn().mockResolvedValue(undefined),
+      setVolume: vi.fn(),
+      getAnalyser: () => undefined,
+      getVolume: () => 0,
+      getByteFrequencyData: () => {},
+    } as unknown as OutputController & { interrupt: typeof interrupt };
+
+    class V extends VoiceConversation {
+      static opts(): Options {
+        return super.getFullOptions({
+          signedUrl: "wss://api.elevenlabs.io/voice/interrupt-test/1",
+          connectionDelay: { default: 0 },
+        } as PartialOptions);
+      }
+      constructor() {
+        super(V.opts(), conn, input, output, null, () => {}, null);
+      }
+      run() {
+        this.updateMode("speaking");
+        this.currentEventId = 44;
+        this.handleInterruption({
+          type: "interruption",
+          interruption_event: { event_id: 43 },
+        });
+      }
+    }
+    new V().run();
+    expect(interrupt).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes voice interruption handling to conditionally skip flushing/interrupting output based on event ordering, which can affect user-perceived audio playback behavior. Scope is small and covered by a new unit test, but incorrect ordering assumptions could leave audio playing when it should stop.
> 
> **Overview**
> Prevents *stale* `interruption` events from interrupting current agent playback in `VoiceConversation`: the output flush (`output.interrupt()`) and mode switch back to `listening` now only occur when the interruption `event_id` is **not older** than `currentEventId`.
> 
> Adds a regression test ensuring an interruption with an `event_id` below `currentEventId` does **not** call `interrupt()`, and updates test imports to construct a minimal `VoiceConversation` instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd80d6348375364be84e77a19c98255f9a8992c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->