### PR TITLE
Add keyterms and noVerbatim to Scribe realtime API

### DIFF
--- a/.changeset/add-keyterms-no-verbatim.md
+++ b/.changeset/add-keyterms-no-verbatim.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": minor
+---
+
+Add `keyterms` option (`string[]`) to the Scribe realtime API. Biases the model towards specific terms (max 50 keyterms, each up to 20 chars), passed as repeated query params on the WebSocket URL.

--- a/.changeset/add-no-verbatim.md
+++ b/.changeset/add-no-verbatim.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": minor
+---
+
+Add `noVerbatim` option (`boolean`) to the Scribe realtime API. When enabled, removes filler words, false starts, and disfluencies from transcripts.

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -194,6 +194,44 @@ describe("Scribe", () => {
       }).toThrow("minSilenceDurationMs must be between 50 and 2000");
     });
 
+    it("builds URI with keyterms as repeated query params", () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&keyterms=ElevenLabs&keyterms=Scribe"
+      );
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+        keyterms: ["ElevenLabs", "Scribe"],
+      });
+
+      expect(connection).toBeDefined();
+
+      connection.close();
+      server.close();
+    });
+
+    it("builds URI with noVerbatim", () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&no_verbatim=true"
+      );
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+        noVerbatim: true,
+      });
+
+      expect(connection).toBeDefined();
+
+      connection.close();
+      server.close();
+    });
+
     it("accepts valid parameter values", () => {
       const server = new Server(
         "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&vad_silence_threshold_secs=1.5&vad_threshold=0.5&min_speech_duration_ms=100&min_silence_duration_ms=200"

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -66,6 +66,16 @@ interface BaseOptions {
    * @default false
    */
   includeTimestamps?: boolean;
+  /**
+   * List of keyterms to bias the model towards.
+   * Maximum 50 keyterms, each up to 20 characters.
+   */
+  keyterms?: string[];
+  /**
+   * If true, removes filler words, false starts and disfluencies from the transcript.
+   * @default false
+   */
+  noVerbatim?: boolean;
 }
 
 export interface AudioOptions extends BaseOptions {
@@ -171,6 +181,14 @@ export class ScribeRealtime {
         "include_timestamps",
         options.includeTimestamps ? "true" : "false"
       );
+    }
+    if (options.keyterms !== undefined) {
+      for (const term of options.keyterms) {
+        params.append("keyterms", term);
+      }
+    }
+    if (options.noVerbatim !== undefined) {
+      params.append("no_verbatim", options.noVerbatim ? "true" : "false");
     }
 
     const queryString = params.toString();

--- a/packages/react/src/scribe.ts
+++ b/packages/react/src/scribe.ts
@@ -113,6 +113,10 @@ export interface ScribeHookOptions extends ScribeCallbacks {
 
   // Include timestamps
   includeTimestamps?: boolean;
+
+  // Keyterms and verbatim control
+  keyterms?: string[];
+  noVerbatim?: boolean;
 }
 
 export interface UseScribeReturn {
@@ -186,6 +190,10 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
 
     // Timestamps
     includeTimestamps: defaultIncludeTimestamps,
+
+    // Keyterms and verbatim control
+    keyterms: defaultKeyterms,
+    noVerbatim: defaultNoVerbatim,
   } = options;
 
   const connectionRef = useRef<RealtimeConnection | null>(null);
@@ -260,6 +268,8 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
               runtimeOptions.minSilenceDurationMs ||
               defaultMinSilenceDurationMs,
             languageCode: runtimeOptions.languageCode || defaultLanguageCode,
+            keyterms: runtimeOptions.keyterms || defaultKeyterms,
+            noVerbatim: runtimeOptions.noVerbatim ?? defaultNoVerbatim,
             microphone,
             includeTimestamps,
           } as MicrophoneOptions);
@@ -281,6 +291,8 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
               runtimeOptions.minSilenceDurationMs ||
               defaultMinSilenceDurationMs,
             languageCode: runtimeOptions.languageCode || defaultLanguageCode,
+            keyterms: runtimeOptions.keyterms || defaultKeyterms,
+            noVerbatim: runtimeOptions.noVerbatim ?? defaultNoVerbatim,
             includeTimestamps,
             audioFormat,
             sampleRate,
@@ -464,6 +476,8 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
       defaultAudioFormat,
       defaultSampleRate,
       defaultIncludeTimestamps,
+      defaultKeyterms,
+      defaultNoVerbatim,
       onSessionStarted,
       onPartialTranscript,
       onCommittedTranscript,

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -688,6 +688,8 @@ export interface Config {
   min_silence_duration_ms?: number;
   model_id?: string;
   disable_logging?: boolean;
+  keyterms?: string[];
+  no_verbatim?: boolean;
 }
 
 export type ConfigAudioFormat =

--- a/packages/types/schemas/scribe.asyncapi.yaml
+++ b/packages/types/schemas/scribe.asyncapi.yaml
@@ -350,6 +350,14 @@ components:
             disable_logging:
               type: boolean
               description: Whether to disable logging
+            keyterms:
+              type: array
+              items:
+                type: string
+              description: List of keyterms the model is biased towards.
+            no_verbatim:
+              type: boolean
+              description: Whether filler words and disfluencies are removed from the transcript.
 
     PartialTranscriptPayload:
       type: object


### PR DESCRIPTION
## Summary
- Add `keyterms` option (`string[]`) to bias the Scribe model towards specific terms (max 50 keyterms, each up to 20 chars). Passed as repeated query params on the WebSocket URL.
- Add `noVerbatim` option (`boolean`) to remove filler words, false starts, and disfluencies from transcripts.
- Both options are exposed across the types (asyncapi schema + generated), client (`BaseOptions` + URI building), and react (`useScribe` hook) packages.

Mirrors upstream spec changes from elevenlabs/elevenlabs-dx#2141.

## Test plan
- [x] Types regenerated and `Config` interface includes `keyterms?: string[]` and `no_verbatim?: boolean`
- [x] Full build passes (`pnpm turbo build`)
- [x] All 186 client tests pass including 2 new tests for `keyterms` and `noVerbatim` URI building
- [ ] Manual verification with a real Scribe realtime session using keyterms
- [ ] Manual verification with `noVerbatim: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change that only extends Scribe realtime connection options and wire-format schema, but could affect integrations if query param ordering/encoding assumptions exist.
> 
> **Overview**
> Adds two new Scribe realtime options: `keyterms: string[]` (sent as repeated `keyterms=` query params) and `noVerbatim: boolean` (sent as `no_verbatim=true`) to control term biasing and transcript disfluency removal.
> 
> Propagates these fields through the public surface area: client option types + URI builder, `useScribe` hook defaults/connection wiring, and the AsyncAPI schema + generated `Config` types; includes new client tests validating the constructed WebSocket URLs and changesets for minor releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b817db293e9a3ec31053db732fec9c7d6854d9f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->