### PR TITLE
[Fix] - Cancel fade out if new agent audio arrives before timeout

### DIFF
--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -169,14 +169,8 @@ export class VoiceConversation extends BaseConversation {
 
   protected override handleInterruption(event: InterruptionEvent) {
     super.handleInterruption(event);
-
-    const interruptId = event.interruption_event?.event_id;
-    const skipOutputFlush =
-      interruptId !== undefined && interruptId < this.currentEventId;
-    if (!skipOutputFlush) {
-      this.updateMode("listening");
-      this.output.interrupt();
-    }
+    this.updateMode("listening");
+    this.output.interrupt();
   }
 
   protected override handleAudio(event: AgentAudioEvent) {

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -10,12 +10,8 @@ import {
 import { Client, Server } from "mock-socket";
 import chunk from "./__tests__/chunk.js";
 import { Mode, Status, Conversation } from "./index.js";
-import type { Options, PartialOptions } from "./BaseConversation.js";
-import type { InputController } from "./InputController.js";
-import type { OutputController } from "./OutputController.js";
-import { VoiceConversation } from "./VoiceConversation.js";
 import { createConnection } from "./utils/ConnectionFactory.js";
-import type { BaseConnection, SessionConfig } from "./utils/BaseConnection.js";
+import type { SessionConfig } from "./utils/BaseConnection.js";
 import { PACKAGE_VERSION } from "./version.js";
 
 const CONVERSATION_ID = "TEST_CONVERSATION_ID";
@@ -1694,58 +1690,6 @@ describe("Wake Lock", () => {
     expect(mockSentinel.release).toHaveBeenCalled();
 
     server.close();
-  });
-
-  it("skips output interrupt when interruption id is below currentEventId", () => {
-    const interrupt = vi.fn();
-    const conn = {
-      conversationId: "c",
-      onMessage: () => {},
-      onDisconnect: () => {},
-      onModeChange: () => {},
-      close: () => {},
-      sendMessage: () => {},
-    } as unknown as BaseConnection;
-    const input: InputController = {
-      close: vi.fn().mockResolvedValue(undefined),
-      setDevice: vi.fn().mockResolvedValue(undefined),
-      setMuted: vi.fn().mockResolvedValue(undefined),
-      isMuted: () => false,
-      getAnalyser: () => undefined,
-      getVolume: () => 0,
-      getByteFrequencyData: () => {},
-    };
-    const output = {
-      interrupt,
-      close: vi.fn().mockResolvedValue(undefined),
-      setDevice: vi.fn().mockResolvedValue(undefined),
-      setVolume: vi.fn(),
-      getAnalyser: () => undefined,
-      getVolume: () => 0,
-      getByteFrequencyData: () => {},
-    } as unknown as OutputController & { interrupt: typeof interrupt };
-
-    class V extends VoiceConversation {
-      static opts(): Options {
-        return super.getFullOptions({
-          signedUrl: "wss://api.elevenlabs.io/voice/interrupt-test/1",
-          connectionDelay: { default: 0 },
-        } as PartialOptions);
-      }
-      constructor() {
-        super(V.opts(), conn, input, output, null, () => {}, null);
-      }
-      run() {
-        this.updateMode("speaking");
-        this.currentEventId = 44;
-        this.handleInterruption({
-          type: "interruption",
-          interruption_event: { event_id: 43 },
-        });
-      }
-    }
-    new V().run();
-    expect(interrupt).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/client/src/utils/output.ts
+++ b/packages/client/src/utils/output.ts
@@ -169,7 +169,13 @@ export class MediaDeviceOutput
   }
 
   public playAudio(chunk: ArrayBuffer): void {
-    if (this.interrupted) return;
+    this.gain.gain.cancelScheduledValues(this.context.currentTime);
+    this.gain.gain.value = this.volume;
+    if (this.interruptTimeout) {
+      clearTimeout(this.interruptTimeout);
+      this.interruptTimeout = null;
+    }
+    this.worklet.port.postMessage({ type: "clearInterrupted" });
     this.worklet.port.postMessage({ type: "buffer", buffer: chunk });
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches real-time audio playback interruption/fade logic and changes when output buffers are flushed, which can impact perceived audio glitches or stuck states but does not affect auth or persisted data.
> 
> **Overview**
> Fixes voice playback so an `interrupt()` fade-out is cancelled when new agent audio arrives: `MediaDeviceOutput.playAudio()` now clears scheduled gain ramps, restores the configured volume, clears any pending interrupt timeout, and resets the worklet’s interrupted state before buffering new audio.
> 
> Simplifies interruption handling in `VoiceConversation.handleInterruption()` to always switch back to `listening` and interrupt output (removing the prior event-id-based skip), and removes the corresponding unit test that asserted the skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97887d8354decc3b04867a39f3269c9f95d9f999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->