### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      tanstack-start-router:
+        patterns:
+          - "@tanstack/react-router"
+          - "@tanstack/react-router-*"
+          - "@tanstack/react-start"
+          - "@tanstack/react-start-*"
+          - "@tanstack/router-*"
+          - "@tanstack/start-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      eslint:
+        patterns:
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "eslint"
+          - "eslint-*"
+          - "typescript-eslint"
       tanstack-start-router:
         patterns:
           - "@tanstack/react-router"
@@ -13,3 +20,10 @@ updates:
           - "@tanstack/react-start-*"
           - "@tanstack/router-*"
           - "@tanstack/start-*"
+      vite:
+        patterns:
+          - "@vitejs/*"
+          - "@vitest/*"
+          - "vite"
+          - "vite-*"
+          - "vitest"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Dependabot groups for tightly coupled dependency families:
  - TanStack Start/Router packages
  - Vite/Vitest build tooling packages
  - ESLint/TypeScript-ESLint lint tooling packages
- Groups cover the packages involved in the recent TanStack, Vite, and ESLint Dependabot PRs plus related package name patterns so future updates are proposed together

## Verification
- Parsed `.github/dependabot.yml` with Python YAML loader and asserted all three groups exist with expected patterns
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b10697e5-033d-4995-8774-f386b94566f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b10697e5-033d-4995-8774-f386b94566f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

