### PR TITLE
chore: hold ESLint major Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,10 @@ updates:
           - "vite"
           - "vite-*"
           - "vitest"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@eslint/*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep the ESLint Dependabot group, but ignore semver-major updates for `eslint` and `@eslint/*`
- Prevents Dependabot from opening an ESLint 10 group while `eslint-plugin-import` only declares peer support through ESLint 9
- Allows compatible non-major ESLint ecosystem updates to continue being grouped

## Verification
- Parsed `.github/dependabot.yml` with Python YAML loader
- Asserted the ESLint group remains present and the major-version ignore rules exist
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b10697e5-033d-4995-8774-f386b94566f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b10697e5-033d-4995-8774-f386b94566f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

