### PR TITLE
Fix LLM prompt override typing

### DIFF
--- a/.changeset/honest-zoos-film.md
+++ b/.changeset/honest-zoos-film.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react": patch
+"@elevenlabs/types": patch
+---
+
+Add `llm` to the typed agent prompt override for conversation sessions.

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -25,6 +25,7 @@ const CLIENT_TOOL_HANDLER = "CLIENT_TOOL_HANDLER";
 const CLIENT_TOOL_CALL_ID = "CLIENT_TOOL_CALL_ID";
 const CLIENT_TOOL_PARAMETERS = { some: "param" };
 const CUSTOM_PROMPT = "CUSTOM_PROMPT";
+const CUSTOM_LLM = "gpt-4o-mini";
 const CUSTOM_LLM_EXTRA_BODY = "CUSTOM_LLM_EXTRA_BODY";
 const TEST_USER_ID = "test-user-123";
 const AGENT_CHAT_RESPONSE_CHUNK_1 = "Hello";
@@ -64,6 +65,7 @@ describe("Conversation", () => {
           agent: {
             prompt: {
               prompt: CUSTOM_PROMPT,
+              llm: CUSTOM_LLM,
             },
           },
         },
@@ -153,7 +155,7 @@ describe("Conversation", () => {
         JSON.stringify({
           type: "conversation_initiation_client_data",
           conversation_config_override: {
-            agent: { prompt: { prompt: "CUSTOM_PROMPT" } },
+            agent: { prompt: { prompt: CUSTOM_PROMPT, llm: CUSTOM_LLM } },
             tts: {},
             conversation: {
               text_only: conversationType === "text",

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -1,11 +1,13 @@
 import type { IncomingSocketEvent, OutgoingSocketEvent } from "./events.js";
 import type { Mode } from "../BaseConversation.js";
 import type {
+  ConversationConfigOverrideAgentPrompt,
   DisconnectionDetails,
   ConversationConfigOverrideAgentLanguage as Language,
 } from "@elevenlabs/types";
 
 export type {
+  ConversationConfigOverrideAgentPrompt,
   DisconnectionDetails,
   ConversationConfigOverrideAgentLanguage as Language,
 } from "@elevenlabs/types";
@@ -30,9 +32,7 @@ export type BaseSessionConfig = {
   livekitUrl?: string;
   overrides?: {
     agent?: {
-      prompt?: {
-        prompt?: string;
-      };
+      prompt?: ConversationConfigOverrideAgentPrompt;
       firstMessage?: string;
       language?: Language;
     };

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -146,6 +146,7 @@ export type ConversationConfigOverrideAgentLanguage =
 
 export interface ConversationConfigOverrideAgentPrompt {
   prompt?: string;
+  llm?: string;
 }
 
 export interface ConversationConfigOverrideTts {

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -1201,6 +1201,10 @@ components:
           type: string
           nullable: true
           description: The system prompt that defines the agent's behavior
+        llm:
+          type: string
+          nullable: true
+          description: The LLM model to use for the conversation
 
     TTSConversationalConfigOverride:
       type: object


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `llm` to the agent prompt override AsyncAPI schema and generated types
- Reuse the generated prompt override type in the client session config so React inherits the field through `SessionConfig`
- Cover serialization of `overrides.agent.prompt.llm` in the client session test

## Tests
- `pnpm --dir packages/types generate-types`
- Commit hook ran `pnpm lint`, `pnpm build`, and type checks successfully
- `pnpm --filter @elevenlabs/client exec vitest run src/index.test.ts`
- `pnpm turbo check-types --filter=@elevenlabs/client --filter=@elevenlabs/types --filter=@elevenlabs/react`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e27b1e19-d44e-4c5e-8431-89297dc26b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e27b1e19-d44e-4c5e-8431-89297dc26b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

