### PR TITLE
Add agent response correction callback

### DIFF
--- a/.changeset/sweet-buttons-repair.md
+++ b/.changeset/sweet-buttons-repair.md
@@ -1,7 +1,7 @@
 ---
-"@elevenlabs/client": patch
-"@elevenlabs/react": patch
-"@elevenlabs/types": patch
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": minor
 ---
 
 Add an `onAgentResponseCorrection` callback for agent response correction events.

--- a/.changeset/sweet-buttons-repair.md
+++ b/.changeset/sweet-buttons-repair.md
@@ -1,3 +1,4 @@
+---
 "@elevenlabs/client": patch
 "@elevenlabs/react": patch
 "@elevenlabs/types": patch

--- a/.changeset/sweet-buttons-repair.md
+++ b/.changeset/sweet-buttons-repair.md
@@ -1,0 +1,6 @@
+"@elevenlabs/client": patch
+"@elevenlabs/react": patch
+"@elevenlabs/types": patch
+---
+
+Add an `onAgentResponseCorrection` callback for agent response correction events.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -32,6 +32,9 @@ const conversation = await Conversation.startSession({
   onMessage: (message) => {
     console.log("Message:", message);
   },
+  onAgentResponseCorrection: ({ original_agent_response, corrected_agent_response }) => {
+    console.log("Agent response corrected:", original_agent_response, "->", corrected_agent_response);
+  },
   onError: (message) => {
     console.error("Error:", message);
   },

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -48,6 +48,12 @@ class TestConversation extends BaseConversation {
   public getOutputVolume(): number {
     return 0;
   }
+
+  public receiveMessage(
+    event: Parameters<Parameters<BaseConnection["onMessage"]>[0]>[0]
+  ) {
+    return this["onMessage"](event);
+  }
 }
 
 describe("BaseConversation", () => {
@@ -158,6 +164,33 @@ describe("BaseConversation", () => {
       );
 
       expect(getUploadedFilename()).toBe("upload.svg");
+    });
+  });
+
+  describe("agent_response_correction events", () => {
+    it("calls onAgentResponseCorrection with the correction payload", async () => {
+      const onAgentResponseCorrection = vi.fn();
+      const onDebug = vi.fn();
+      const conversation = TestConversation.create({
+        onAgentResponseCorrection,
+        onDebug,
+      });
+
+      await conversation.receiveMessage({
+        type: "agent_response_correction",
+        agent_response_correction_event: {
+          original_agent_response: "The weather is sunny and warm.",
+          corrected_agent_response: "The weather is sunny",
+          event_id: 42,
+        },
+      });
+
+      expect(onAgentResponseCorrection).toHaveBeenCalledWith({
+        original_agent_response: "The weather is sunny and warm.",
+        corrected_agent_response: "The weather is sunny",
+        event_id: 42,
+      });
+      expect(onDebug).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -21,12 +21,14 @@ class TestConversation extends BaseConversation {
     return super.getFullOptions(partialOptions);
   }
 
-  public static create(options: { origin?: string } = {}): TestConversation {
+  public static create(
+    options: Partial<Options> & { origin?: string } = {}
+  ): TestConversation {
     const fullOptions = TestConversation.getFullOptions({
       agentId: "test-agent-id",
       connectionType: "webrtc",
       ...options,
-    });
+    } as PartialOptions);
     return new TestConversation(fullOptions, noopConnection);
   }
 

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -11,6 +11,7 @@ import type {
   AgentAudioEvent,
   AgentChatResponsePartEvent,
   AgentResponseEvent,
+  AgentResponseCorrectionEvent,
   ClientToolCallEvent,
   IncomingSocketEvent,
   InternalTentativeAgentResponseEvent,
@@ -127,6 +128,7 @@ export abstract class BaseConversation {
       onStatusChange: () => {},
       onCanSendFeedbackChange: () => {},
       onInterruption: () => {},
+      onAgentResponseCorrection: () => {},
       ...partialOptions,
       textOnly,
       overrides: {
@@ -218,6 +220,14 @@ export abstract class BaseConversation {
         message: event.agent_response_event.agent_response,
         event_id: event.agent_response_event.event_id,
       });
+    }
+  }
+
+  protected handleAgentResponseCorrection(event: AgentResponseCorrectionEvent) {
+    if (this.options.onAgentResponseCorrection) {
+      this.options.onAgentResponseCorrection(
+        event.agent_response_correction_event
+      );
     }
   }
 
@@ -401,6 +411,10 @@ export abstract class BaseConversation {
       }
       case "agent_response": {
         this.handleAgentResponse(parsedEvent);
+        return;
+      }
+      case "agent_response_correction": {
+        this.handleAgentResponseCorrection(parsedEvent);
         return;
       }
       case "user_transcript": {

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -40,6 +40,7 @@ export type HookCallbacks = Pick<
   | "onMCPConnectionStatus"
   | "onAsrInitiationMetadata"
   | "onAgentChatResponsePart"
+  | "onAgentResponseCorrection"
   | "onAudioAlignment"
   | "onGuardrailTriggered"
 >;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -89,6 +89,9 @@ export type Callbacks = {
   onInterruption?: (
     props: Generated.Interruption["interruption_event"]
   ) => void;
+  onAgentResponseCorrection?: (
+    props: Generated.AgentResponseCorrection["agent_response_correction_event"]
+  ) => void;
   onAgentChatResponsePart?: (
     props: Generated.AgentChatResponsePartClientEvent["text_response_part"]
   ) => void;
@@ -122,6 +125,7 @@ export const CALLBACK_KEYS = [
   "onConversationMetadata",
   "onAsrInitiationMetadata",
   "onInterruption",
+  "onAgentResponseCorrection",
   "onAgentChatResponsePart",
   "onAudioAlignment",
   "onGuardrailTriggered",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `onAgentResponseCorrection` to shared callback types and React hook callback options
- Route `agent_response_correction` events through the dedicated callback in `BaseConversation`
- Document the callback in the client README and add a focused unit test
- Mark affected packages for minor releases in the changeset

## Testing
- `pnpm --filter @elevenlabs/client exec vitest --project "Unit tests" src/BaseConversation.test.ts`
- `pnpm --filter @elevenlabs/types check-types`
- `pnpm --filter @elevenlabs/client build:esm`
- `pnpm --filter @elevenlabs/react build:esm`
- Commit hook: `pnpm lint` / Turbo lint pipeline (includes package builds/checks)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f935e441-1f54-449d-aea9-a554214f9de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f935e441-1f54-449d-aea9-a554214f9de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

