### PR TITLE
Fix React Scribe microphone deviceId constraint type

### DIFF
--- a/.changeset/smart-buses-shake.md
+++ b/.changeset/smart-buses-shake.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/react": patch
+---
+
+Allow `useScribe` microphone `deviceId` to use full `ConstrainDOMString` constraints.

--- a/packages/react/src/scribe.test.tsx
+++ b/packages/react/src/scribe.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Scribe } from "@elevenlabs/client";
+import type { RealtimeConnection } from "@elevenlabs/client";
+import { useScribe } from "./scribe.js";
+
+vi.mock("@elevenlabs/client", async importOriginal => {
+  const actual = await importOriginal<typeof import("@elevenlabs/client")>();
+  return {
+    ...actual,
+    Scribe: {
+      connect: vi.fn(),
+    },
+  };
+});
+
+function createMockConnection(): RealtimeConnection {
+  return {
+    on: vi.fn(),
+    close: vi.fn(),
+    send: vi.fn(),
+    commit: vi.fn(),
+  } as unknown as RealtimeConnection;
+}
+
+describe("useScribe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Scribe.connect).mockReturnValue(createMockConnection());
+  });
+
+  it("passes constrained microphone device IDs through to the client", async () => {
+    const deviceId = { exact: "selected-microphone-id" };
+
+    const { result } = renderHook(() => useScribe());
+
+    await act(async () => {
+      await result.current.connect({
+        token: "test-token",
+        modelId: "scribe_v2_realtime",
+        microphone: {
+          deviceId,
+        },
+      });
+    });
+
+    expect(Scribe.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        microphone: expect.objectContaining({
+          deviceId,
+        }),
+      })
+    );
+  });
+});

--- a/packages/react/src/scribe.ts
+++ b/packages/react/src/scribe.ts
@@ -96,13 +96,7 @@ export interface ScribeHookOptions extends ScribeCallbacks {
   languageCode?: string;
 
   // Microphone options (for automatic microphone mode)
-  microphone?: {
-    deviceId?: string;
-    echoCancellation?: boolean;
-    noiseSuppression?: boolean;
-    autoGainControl?: boolean;
-    channelCount?: number;
-  };
+  microphone?: MicrophoneOptions["microphone"];
 
   // Manual audio options
   audioFormat?: AudioFormat;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Align `useScribe` microphone options with the client `MicrophoneOptions` type so `deviceId` accepts full `ConstrainDOMString` constraints.
- Add a React hook test covering `{ exact: ... }` device IDs being passed through unchanged.
- Add a patch changeset for `@elevenlabs/react`.

## React Native context
- `@elevenlabs/react-native` builds on the React/client packages and its type/build checks pass with this change.
- Existing conversation device switching still accepts a selected device ID string and converts it internally to platform-appropriate media constraints, including the iOS/RN defensive `{ ideal: ... }` path.

## Testing
- Commit hook: monorepo lint/type/build pipeline passed.
- `pnpm --filter @elevenlabs/react test -- src/scribe.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6985b08c-f00b-435a-b7c4-c0181a77b5be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6985b08c-f00b-435a-b7c4-c0181a77b5be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

