### PR TITLE
feat: add optional contextId to sendContextualUpdate

### DIFF
--- a/.changeset/context-id-contextual-update.md
+++ b/.changeset/context-id-contextual-update.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": minor
+---
+
+Add optional `contextId` to `sendContextualUpdate` for deduplicating contextual updates

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -548,10 +548,14 @@ export abstract class BaseConversation {
     this.updateCanSendFeedback();
   }
 
-  public sendContextualUpdate(text: string) {
+  public sendContextualUpdate(
+    text: string,
+    options?: { contextId?: string }
+  ) {
     this.connection.sendMessage({
       type: "contextual_update",
       text,
+      ...(options?.contextId ? { context_id: options.contextId } : {}),
     });
   }
 

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -49,6 +49,10 @@ export type ConversationLifecycleOptions = {
   onConversationCreated?: ConversationCreatedCallback;
 };
 
+export type ContextualUpdateOptions = {
+  contextId?: string;
+};
+
 export type Options = SessionConfig &
   Callbacks &
   ConversationLifecycleOptions &
@@ -548,7 +552,7 @@ export abstract class BaseConversation {
     this.updateCanSendFeedback();
   }
 
-  public sendContextualUpdate(text: string, options?: { contextId?: string }) {
+  public sendContextualUpdate(text: string, options?: ContextualUpdateOptions) {
     this.connection.sendMessage({
       type: "contextual_update",
       text,

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -548,10 +548,7 @@ export abstract class BaseConversation {
     this.updateCanSendFeedback();
   }
 
-  public sendContextualUpdate(
-    text: string,
-    options?: { contextId?: string }
-  ) {
+  public sendContextualUpdate(text: string, options?: { contextId?: string }) {
     this.connection.sendMessage({
       type: "contextual_update",
       text,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -15,6 +15,7 @@ export type {
   UploadFileResult,
   ConversationCreatedCallback,
   ConversationLifecycleOptions,
+  ContextualUpdateOptions,
 } from "./BaseConversation.js";
 export type { InputController, InputDeviceConfig } from "./InputController.js";
 export type {

--- a/packages/react/src/conversation/ConversationControls.test.tsx
+++ b/packages/react/src/conversation/ConversationControls.test.tsx
@@ -83,7 +83,8 @@ describe("useConversationControls", () => {
     });
 
     expect(mockConversation.sendContextualUpdate).toHaveBeenCalledWith(
-      "context info"
+      "context info",
+      undefined
     );
   });
 

--- a/packages/react/src/conversation/ConversationControls.tsx
+++ b/packages/react/src/conversation/ConversationControls.tsx
@@ -6,6 +6,7 @@ import {
   type OutputConfig,
   type MultimodalMessageInput,
   type UploadFileResult,
+  type ContextualUpdateOptions,
 } from "@elevenlabs/client";
 import type { HookOptions } from "./types.js";
 import { ConversationContext } from "./ConversationContext.js";
@@ -20,7 +21,7 @@ export type ConversationControlsValue = {
   uploadFile: (file: Blob) => Promise<UploadFileResult>;
   sendContextualUpdate: (
     text: string,
-    options?: { contextId?: string }
+    options?: ContextualUpdateOptions
   ) => void;
   sendUserActivity: () => void;
   sendMCPToolApprovalResult: (toolCallId: string, isApproved: boolean) => void;
@@ -89,7 +90,7 @@ export function ConversationControlsProvider({
   );
 
   const sendContextualUpdate = useCallback(
-    (text: string, options?: { contextId?: string }) => {
+    (text: string, options?: ContextualUpdateOptions) => {
       getConversation().sendContextualUpdate(text, options);
     },
     [getConversation]

--- a/packages/react/src/conversation/ConversationControls.tsx
+++ b/packages/react/src/conversation/ConversationControls.tsx
@@ -18,7 +18,10 @@ export type ConversationControlsValue = {
   sendUserMessage: (text: string) => void;
   sendMultimodalMessage: (options: MultimodalMessageInput) => void;
   uploadFile: (file: Blob) => Promise<UploadFileResult>;
-  sendContextualUpdate: (text: string) => void;
+  sendContextualUpdate: (
+    text: string,
+    options?: { contextId?: string }
+  ) => void;
   sendUserActivity: () => void;
   sendMCPToolApprovalResult: (toolCallId: string, isApproved: boolean) => void;
   setVolume: (options: { volume: number }) => void;
@@ -86,8 +89,8 @@ export function ConversationControlsProvider({
   );
 
   const sendContextualUpdate = useCallback(
-    (text: string) => {
-      getConversation().sendContextualUpdate(text);
+    (text: string, options?: { contextId?: string }) => {
+      getConversation().sendContextualUpdate(text, options);
     },
     [getConversation]
   );

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -45,6 +45,7 @@ export interface McpToolApprovalResult {
 export interface ContextualUpdate {
   type: "contextual_update";
   text: string;
+  context_id?: string;
 }
 
 export interface ConversationInitiation {
@@ -646,6 +647,7 @@ export interface McpToolApprovalResultClientToOrchestratorEvent {
 export interface ContextualUpdateClientToOrchestratorEvent {
   type: "contextual_update";
   text: string;
+  context_id?: string;
 }
 
 export interface ConversationInitiationClientToOrchestratorEvent {

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -646,6 +646,9 @@ components:
           const: contextual_update
         text:
           type: string
+        context_id:
+          type: string
+          description: Optional identifier for deduplicating contextual updates. When set, only the most recent update with a given context_id is kept in the LLM context.
 
     ConversationInitiationPayload:
       type: object


### PR DESCRIPTION
## Summary

- Adds an optional `{ contextId }` parameter to `sendContextualUpdate` in `@elevenlabs/client` and `@elevenlabs/react`
- When provided, `context_id` is included in the websocket message, enabling backend dedup (only the latest update per context_id is sent to the LLM)
- Updates the AsyncAPI schema and regenerates types

Pairs with https://github.com/elevenlabs/xi/pull/31540 which adds backend support for context_id-based deduplication of contextual updates.

## Test plan

- Existing tests pass (contextId is optional, backward compatible)
- Manual QA with support chat sending `{ contextId: "page_snapshot" }` to verify dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, backward-compatible API extension that only adds an optional field to a websocket payload and updates generated types; main risk is downstream callers needing updated type signatures in tests/TS builds.
> 
> **Overview**
> Adds an optional `contextId` to `sendContextualUpdate` in `@elevenlabs/client`/`@elevenlabs/react`, and conditionally includes `context_id` in the `contextual_update` websocket message to enable server-side deduplication.
> 
> Updates the AsyncAPI schema and regenerated `@elevenlabs/types` so `ContextualUpdate` events can carry `context_id`, and adjusts the React hook test expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3777379d47cf86432979951cebdf63dc786f7e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->