### PR TITLE
Remove tsx from types codegen and use Node.js 24 on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: lts/*
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: lts/Krypton
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: lts/*
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: lts/Krypton
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: lts/Krypton
           registry-url: https://registry.npmjs.org
 
       - name: Set up pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: lts/*
           registry-url: https://registry.npmjs.org
 
       - name: Set up pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: lts/Krypton
           registry-url: https://registry.npmjs.org
           cache: 'pnpm'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/Krypton
+          node-version: lts/*
           registry-url: https://registry.npmjs.org
           cache: 'pnpm'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: lts/*
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: lts/Krypton
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "packages",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "create": "node scripts/create",
     "lint": "turbo lint",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,7 +9,7 @@
     "generated"
   ],
   "scripts": {
-    "generate-types": "tsx ./scripts/generate-all-types.ts && prettier --write ./generated/types/**/*.ts",
+    "generate-types": "node ./scripts/generate-all-types.ts && prettier --write ./generated/types/**/*.ts",
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf dist generated/types",
@@ -25,7 +25,6 @@
     "eslint": "^10.3.0",
     "glob": "^11.0.3",
     "prettier": "^3.0.0",
-    "tsx": "^4.0.0",
     "typescript": "^5.9.2"
   },
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,9 +541,6 @@ importers:
       prettier:
         specifier: ^3.0.0
         version: 3.7.4
-      tsx:
-        specifier: ^4.0.0
-        version: 4.21.0
       typescript:
         specifier: ^5.9.2
         version: 5.9.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the `@elevenlabs/types` `generate-types` runner with native Node.js TypeScript execution
- Remove `tsx` from `@elevenlabs/types` devDependencies and lockfile importer metadata
- Align CI workflows on Node.js Krypton LTS and declare Node 24+ for workspace-level scripts

## Testing
- `pnpm turbo generate-types`
- `pnpm install --frozen-lockfile`
- `pnpm lint` (via pre-commit hook)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da381f7e-b672-43ee-bcf2-ccbedf1aded5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da381f7e-b672-43ee-bcf2-ccbedf1aded5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

