### PR TITLE
Update conversation subclasses to use emit

### DIFF
--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -132,17 +132,6 @@ export abstract class BaseConversation {
     const textOnly = isTextOnly(partialOptions);
     return {
       clientTools: {},
-      onConnect: () => {},
-      onDebug: () => {},
-      onDisconnect: () => {},
-      onError: () => {},
-      onMessage: () => {},
-      onAudio: () => {},
-      onModeChange: () => {},
-      onStatusChange: () => {},
-      onCanSendFeedbackChange: () => {},
-      onInterruption: () => {},
-      onAgentResponseCorrection: () => {},
       ...partialOptions,
       textOnly,
       overrides: {

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -176,13 +176,13 @@ export class VoiceConversation extends BaseConversation {
   protected override handleAudio(event: AgentAudioEvent) {
     super.handleAudio(event);
 
-    if (event.audio_event.alignment && this.options.onAudioAlignment) {
-      this.options.onAudioAlignment(event.audio_event.alignment);
+    if (event.audio_event.alignment) {
+      this.emit("audio-alignment", event.audio_event.alignment);
     }
 
     if (this.lastInterruptTimestamp <= event.audio_event.event_id) {
       if (event.audio_event.audio_base_64) {
-        this.options.onAudio?.(event.audio_event.audio_base_64);
+        this.emit("audio", event.audio_event.audio_base_64);
         // Audio routing is handled by attachConnectionToOutput for WebSocket
         // WebRTC handles audio playback directly through LiveKit tracks
       }
@@ -197,7 +197,7 @@ export class VoiceConversation extends BaseConversation {
 
   public setMicMuted(isMuted: boolean) {
     this.input.setMuted(isMuted).catch(error => {
-      this.options.onError?.("Failed to set input muted state", error);
+      this.emit("error", "Failed to set input muted state", error);
     });
   }
 


### PR DESCRIPTION
## Summary
- Replace `this.options.onAudio`, `this.options.onAudioAlignment`, and `this.options.onError` in `VoiceConversation` with `this.emit()` calls
- Remove no-op callback defaults from `getFullOptions` — the emitter handles the no-listeners case naturally
- Keep pre-instance callbacks (`onStatusChange`, `onConnect`, etc.) as direct `fullOptions.onXxx()` calls since errors during `startSession` must propagate to the caller

Part of #738 (PR 5/6).

## Test plan
- [x] All 97 client tests pass (including "preserves the original startup error when cleanup throws")
- [x] All 32 turbo tasks pass (build, check-types, lint across all packages)
- [x] Pre-instance callbacks still fire correctly during `startSession`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `VoiceConversation` surfaces audio/alignment/error notifications (now via `emit` instead of direct option callbacks) and removes default no-op callbacks, which could affect consumers that relied on those option handlers being invoked implicitly.
> 
> **Overview**
> Updates `VoiceConversation` to emit `audio`, `audio-alignment`, and `error` events instead of calling `options.onAudio`, `options.onAudioAlignment`, and `options.onError` directly.
> 
> Removes the no-op default callback assignments from `BaseConversation.getFullOptions`, relying on the emitter’s no-listener behavior rather than pre-populating option handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa661f6093c484297d3b53ab171886e031389549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->