### PR TITLE
chore: group remark CJK dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      remark-cjk-friendly:
+        patterns:
+          - "remark-cjk-friendly"
+          - "remark-cjk-friendly-gfm-strikethrough"
       react:
         patterns:
           - "react"


### PR DESCRIPTION
Fixes https://github.com/elevenlabs/packages/pull/736#discussion_r3195677515

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Group `remark-cjk-friendly` and `remark-cjk-friendly-gfm-strikethrough` in Dependabot updates.
- Keeps future sibling package bumps together so their shared CJK markdown utilities stay aligned.

## Testing
- Parsed `.github/dependabot.yml` with Python/PyYAML and verified the new group patterns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81642552-c504-4032-a697-d96e5e154343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81642552-c504-4032-a697-d96e5e154343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

