### PR TITLE
Fix root npmrc Node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-node-version=v22.22.0
+node-version=v24.15.0
 link-workspace-packages=true
 prefer-workspace-packages=true
 shared-workspace-lockfile=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the root `.npmrc` `node-version` pin from Node 22 Jod to Node 24 Krypton
- Align pnpm's engine-resolution version with the Node 24 requirement and CI setup from #741

## Testing
- `pnpm run lint` / repo check/build pipeline via pre-commit hook
- `pnpm install --frozen-lockfile`
- `pnpm config get node-version`

Follow-up to #741.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-510d6698-3a35-43ce-b05f-72066fe9afe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-510d6698-3a35-43ce-b05f-72066fe9afe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

