### PR TITLE
Merge onAgentToolResponseFullPayload into onAgentToolResponse

### DIFF
--- a/.changeset/agent-tool-response-full-payload.md
+++ b/.changeset/agent-tool-response-full-payload.md
@@ -5,20 +5,24 @@
 "@elevenlabs/react-native": minor
 ---
 
-Add `onAgentToolResponseFullPayload` callback for the `agent_tool_response_full_payload` server event.
+Merge `onAgentToolResponseFullPayload` into `onAgentToolResponse`.
 
-The agent platform can now emit the full tool result payload as an opaque string alongside the existing `agent_tool_response` summary. Subscribe via the new callback to receive the raw `full_tool_result` (and the `truncated` flag indicating whether the server hit the 64 KB cap). The agent must include `agent_tool_response_full_payload` in its `client_events` config to deliver this event.
+The `onAgentToolResponse` callback now accepts a union of the summary (`agent_tool_response`) and full payload (`agent_tool_response_full_payload`) event types. Both server events are dispatched through the single `onAgentToolResponse` callback. Consumers can distinguish between the two by checking for the presence of `full_tool_result` on the payload.
 
 ```tsx
 import { ConversationProvider } from "@elevenlabs/react-native";
 
 <ConversationProvider
   agentId="…"
-  onAgentToolResponseFullPayload={payload => {
-    if (payload.truncated) {
-      console.warn("full payload truncated to 64 KB");
+  onAgentToolResponse={payload => {
+    if ("full_tool_result" in payload) {
+      if (payload.truncated) {
+        console.warn("full payload truncated to 64 KB");
+      }
+      console.log(payload.tool_name, payload.full_tool_result);
+    } else {
+      console.log(payload.tool_call_id, payload.is_error);
     }
-    console.log(payload.tool_name, payload.full_tool_result);
   }}
 >
   …

--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -353,9 +353,6 @@ export default function App() {
       onAgentToolResponse={event => {
         console.log("Agent Tool Response:", event);
       }}
-      onAgentToolResponseFullPayload={event => {
-        console.log("Agent Tool Response Full Payload:", event);
-      }}
       onAgentChatResponsePart={part => {
         console.log("Agent Response Part:", part);
       }}

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -209,11 +209,11 @@ describe("BaseConversation", () => {
       truncated: false,
     };
 
-    it("forwards the full JSON tool_result to onAgentToolResponseFullPayload", async () => {
-      const onAgentToolResponseFullPayload = vi.fn();
+    it("forwards the full JSON tool_result to onAgentToolResponse", async () => {
+      const onAgentToolResponse = vi.fn();
       const onDebug = vi.fn();
       const conversation = TestConversation.create({
-        onAgentToolResponseFullPayload,
+        onAgentToolResponse,
         onDebug,
       });
 
@@ -222,14 +222,14 @@ describe("BaseConversation", () => {
         agent_tool_response_full_payload: basePayload,
       });
 
-      expect(onAgentToolResponseFullPayload).toHaveBeenCalledWith(basePayload);
+      expect(onAgentToolResponse).toHaveBeenCalledWith(basePayload);
       expect(onDebug).not.toHaveBeenCalled();
     });
 
     it("forwards non-JSON full_tool_result strings verbatim", async () => {
-      const onAgentToolResponseFullPayload = vi.fn();
+      const onAgentToolResponse = vi.fn();
       const conversation = TestConversation.create({
-        onAgentToolResponseFullPayload,
+        onAgentToolResponse,
       });
 
       const nonJson = {
@@ -243,13 +243,13 @@ describe("BaseConversation", () => {
         agent_tool_response_full_payload: nonJson,
       });
 
-      expect(onAgentToolResponseFullPayload).toHaveBeenCalledWith(nonJson);
+      expect(onAgentToolResponse).toHaveBeenCalledWith(nonJson);
     });
 
     it("forwards truncated payloads with the truncated flag set", async () => {
-      const onAgentToolResponseFullPayload = vi.fn();
+      const onAgentToolResponse = vi.fn();
       const conversation = TestConversation.create({
-        onAgentToolResponseFullPayload,
+        onAgentToolResponse,
       });
 
       // The server caps at 64 KB and tags `truncated: true`. The SDK forwards
@@ -267,7 +267,7 @@ describe("BaseConversation", () => {
         agent_tool_response_full_payload: truncated,
       });
 
-      const received = onAgentToolResponseFullPayload.mock.calls[0]![0];
+      const received = onAgentToolResponse.mock.calls[0]![0];
       expect(received.truncated).toBe(true);
       expect(received.full_tool_result).toBe(truncatedBody);
       expect(received.full_tool_result.length).toBeGreaterThan(64_000);

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -20,7 +20,6 @@ import type {
   VadScoreEvent,
   MCPToolCallClientEvent,
   AgentToolResponseEvent,
-  AgentToolResponseFullPayloadEvent,
   ConversationMetadataEvent,
   AsrInitiationMetadataEvent,
   MCPConnectionStatusEvent,
@@ -360,16 +359,6 @@ export abstract class BaseConversation {
     }
   }
 
-  protected handleAgentToolResponseFullPayload(
-    event: AgentToolResponseFullPayloadEvent
-  ) {
-    if (this.options.onAgentToolResponseFullPayload) {
-      this.options.onAgentToolResponseFullPayload(
-        event.agent_tool_response_full_payload
-      );
-    }
-  }
-
   protected handleConversationMetadata(event: ConversationMetadataEvent) {
     if (this.options.onConversationMetadata) {
       this.options.onConversationMetadata(
@@ -495,7 +484,11 @@ export abstract class BaseConversation {
       }
 
       case "agent_tool_response_full_payload": {
-        this.handleAgentToolResponseFullPayload(parsedEvent);
+        if (this.options.onAgentToolResponse) {
+          this.options.onAgentToolResponse(
+            parsedEvent.agent_tool_response_full_payload
+          );
+        }
         return;
       }
 

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -34,7 +34,6 @@ export type HookCallbacks = Pick<
   | "onVadScore"
   | "onInterruption"
   | "onAgentToolResponse"
-  | "onAgentToolResponseFullPayload"
   | "onAgentToolRequest"
   | "onConversationMetadata"
   | "onMCPToolCall"

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -78,10 +78,9 @@ export type Callbacks = {
     props: Generated.AgentToolRequestClientEvent["agent_tool_request"]
   ) => void;
   onAgentToolResponse?: (
-    props: Generated.AgentToolResponseClientEvent["agent_tool_response"]
-  ) => void;
-  onAgentToolResponseFullPayload?: (
-    props: Generated.AgentToolResponseFullPayloadClientEvent["agent_tool_response_full_payload"]
+    props:
+      | Generated.AgentToolResponseClientEvent["agent_tool_response"]
+      | Generated.AgentToolResponseFullPayloadClientEvent["agent_tool_response_full_payload"]
   ) => void;
   onConversationMetadata?: (
     props: Generated.ConversationMetadata["conversation_initiation_metadata_event"]
@@ -125,7 +124,6 @@ export const CALLBACK_KEYS = [
   "onMCPConnectionStatus",
   "onAgentToolRequest",
   "onAgentToolResponse",
-  "onAgentToolResponseFullPayload",
   "onConversationMetadata",
   "onAsrInitiationMetadata",
   "onInterruption",


### PR DESCRIPTION
## Summary
- Merges the separate `onAgentToolResponseFullPayload` callback into `onAgentToolResponse` using a union type signature
- Both `agent_tool_response` and `agent_tool_response_full_payload` server events now dispatch through the single `onAgentToolResponse` callback
- Consumers can distinguish between the two by checking for `"full_tool_result" in payload`

## Test plan
- [x] All existing tests updated and passing (15/15 in BaseConversation.test.ts)
- [x] Build passes across `@elevenlabs/types`, `@elevenlabs/client`, `@elevenlabs/react`
- [x] Lint (prettier + eslint) passes
- [ ] Manual test with an agent that emits both event types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public callback API changes by removing `onAgentToolResponseFullPayload` and widening `onAgentToolResponse` to a union, which can break consumers and requires updated type narrowing at call sites.
> 
> **Overview**
> **Unifies agent tool response callbacks** by removing `onAgentToolResponseFullPayload` and routing both `agent_tool_response` and `agent_tool_response_full_payload` server events through `onAgentToolResponse` (now typed as a union of the two payload shapes).
> 
> Updates SDK dispatch logic and tests to expect the full-payload event to be forwarded via `onAgentToolResponse`, and refreshes docs/examples/React hook types accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25f1d71f73f6427055852d5ea8ab46002fa6461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->