### PR TITLE
Update changeset for onAgentToolResponse full payload support

### DIFF
--- a/.changeset/agent-tool-response-full-payload.md
+++ b/.changeset/agent-tool-response-full-payload.md
@@ -5,13 +5,11 @@
 "@elevenlabs/react-native": minor
 ---
 
-Merge `onAgentToolResponseFullPayload` into `onAgentToolResponse`.
+Add full tool result payload support to `onAgentToolResponse`.
 
-The `onAgentToolResponse` callback now accepts a union of the summary (`agent_tool_response`) and full payload (`agent_tool_response_full_payload`) event types. Both server events are dispatched through the single `onAgentToolResponse` callback. Consumers can distinguish between the two by checking for the presence of `full_tool_result` on the payload.
+The `onAgentToolResponse` callback now also receives `agent_tool_response_full_payload` server events, delivering the raw `full_tool_result` string (capped at 64 KB) alongside the existing summary events. Consumers can distinguish between the two by checking for the presence of `full_tool_result` on the payload. To receive full payloads, enable the `agent_tool_response_full_payload` client event in the agent's configuration UI.
 
 ```tsx
-import { ConversationProvider } from "@elevenlabs/react-native";
-
 <ConversationProvider
   agentId="…"
   onAgentToolResponse={payload => {


### PR DESCRIPTION
## Summary
- Reframe changeset as a new feature addition since `onAgentToolResponseFullPayload` was never released as a separate callback
- Clarify that the `agent_tool_response_full_payload` event must be enabled in the agent's server configuration UI

## Test plan
- [x] Changeset-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changeset-only update with no runtime/code changes; risk is limited to release notes/versioning accuracy.
> 
> **Overview**
> Updates the changeset messaging to frame `onAgentToolResponse` as **adding support for full tool result payloads**, rather than merging a separate unreleased callback.
> 
> Clarifies that `onAgentToolResponse` can receive `agent_tool_response_full_payload` events (including `full_tool_result` capped at 64KB and `truncated`), and notes that consumers must enable the `agent_tool_response_full_payload` event in the agent configuration UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e72012f32f4299ccc30c41f663e352d8f7f4383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->