### PR TITLE
Fix missing end_call check in full payload handler

### DIFF
--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -20,6 +20,7 @@ import type {
   VadScoreEvent,
   MCPToolCallClientEvent,
   AgentToolResponseEvent,
+  AgentToolResponseFullPayloadEvent,
   ConversationMetadataEvent,
   AsrInitiationMetadataEvent,
   MCPConnectionStatusEvent,
@@ -359,6 +360,21 @@ export abstract class BaseConversation {
     }
   }
 
+  protected handleAgentToolResponseFullPayload(
+    event: AgentToolResponseFullPayloadEvent
+  ) {
+    if (event.agent_tool_response_full_payload.tool_name === "end_call") {
+      this.endSessionWithDetails({
+        reason: "agent",
+        context: new CloseEvent("end_call", { reason: "Agent ended the call" }),
+      });
+    }
+
+    if (this.options.onAgentToolResponse) {
+      this.options.onAgentToolResponse(event.agent_tool_response_full_payload);
+    }
+  }
+
   protected handleConversationMetadata(event: ConversationMetadataEvent) {
     if (this.options.onConversationMetadata) {
       this.options.onConversationMetadata(
@@ -484,11 +500,7 @@ export abstract class BaseConversation {
       }
 
       case "agent_tool_response_full_payload": {
-        if (this.options.onAgentToolResponse) {
-          this.options.onAgentToolResponse(
-            parsedEvent.agent_tool_response_full_payload
-          );
-        }
+        this.handleAgentToolResponseFullPayload(parsedEvent);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Add `handleAgentToolResponseFullPayload` method that checks for `end_call` before dispatching to the callback
- Mirrors the existing `handleAgentToolResponse` pattern
- Fixes [review comment](https://github.com/elevenlabs/packages/pull/757#discussion_r3210814854): if the server sends an `agent_tool_response_full_payload` for an `end_call` tool, the session now properly terminates

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual test: verify session ends when `end_call` arrives as a full payload event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to client event handling to ensure `end_call` terminates the session when delivered via `agent_tool_response_full_payload`. Main risk is unintended disconnects if the server mislabels tool responses.
> 
> **Overview**
> Fixes a missed termination path by adding `handleAgentToolResponseFullPayload`, mirroring the existing `agent_tool_response` handler to **end the session when the agent invokes `end_call`**.
> 
> The `agent_tool_response_full_payload` switch case now routes through this shared handler, while still forwarding the full payload to the existing `onAgentToolResponse` callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b416922e01e772794d1e19a89e482571bc662f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->