### PR TITLE
[Widget] Fix same-turn user/agent transcript ordering race

### DIFF
--- a/.changeset/fix-widget-cross-conversation-ordering.md
+++ b/.changeset/fix-widget-cross-conversation-ordering.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Scope transcript reordering by `conversationIndex` and break ties on shared `eventId` with user-before-agent. Fixes two issues in voice/DTMF mode: (1) cross-conversation interleaving when `event_id` resets between sessions, and (2) agent message rendering before user transcript when both share the same turn `event_id`.

--- a/.changeset/fix-widget-cross-conversation-ordering.md
+++ b/.changeset/fix-widget-cross-conversation-ordering.md
@@ -2,4 +2,4 @@
 "@elevenlabs/convai-widget-core": patch
 ---
 
-Scope transcript reordering by `conversationIndex` and break ties on shared `eventId` with user-before-agent. Fixes two issues in voice/DTMF mode: (1) cross-conversation interleaving when `event_id` resets between sessions, and (2) agent message rendering before user transcript when both share the same turn `event_id`.
+Break ties on shared `eventId` with user-before-agent in transcript ordering. Fixes voice/DTMF turns where the agent message could render before the user transcript when both events of the turn carry the same `event_id`.

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -315,39 +315,6 @@ describe("buildDisplayTranscript", () => {
       });
     });
 
-    it("second conversation stays after first when event ids reset", () => {
-      const input: TranscriptEntry[] = [
-        msg("user", "c0 user", { eventId: 1, conversationIndex: 0 }),
-        msg("agent", "c0 agent", { eventId: 2, conversationIndex: 0 }),
-        { type: "disconnection", role: "user", conversationIndex: 0 },
-        msg("agent", "c1 first", { eventId: 1, conversationIndex: 1 }),
-        msg("user", "c1 second", { eventId: 1, conversationIndex: 1 }),
-      ];
-      const result = build(input);
-      expect(result).toHaveLength(5);
-      expect(result[0]).toMatchObject({
-        role: "user",
-        message: "c0 user",
-        conversationIndex: 0,
-      });
-      expect(result[1]).toMatchObject({
-        role: "agent",
-        message: "c0 agent",
-        conversationIndex: 0,
-      });
-      expect(result[2]).toMatchObject({ type: "disconnection" });
-      expect(result[3]).toMatchObject({
-        role: "user",
-        message: "c1 second",
-        conversationIndex: 1,
-      });
-      expect(result[4]).toMatchObject({
-        role: "agent",
-        message: "c1 first",
-        conversationIndex: 1,
-      });
-    });
-
     it("local user without eventId stays before server message in same layout", () => {
       const input = [
         msg("user", "typed locally", { isText: true }),

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -294,6 +294,74 @@ describe("buildDisplayTranscript", () => {
   });
 
   describe("eventId sorting", () => {
+    it("same eventId: user before agent when agent_response arrives first (shared turn id)", () => {
+      const input = [
+        msg("agent", "Hello!", { eventId: 1, isText: false }),
+        msg("user", "Hi", { eventId: 1, isText: false }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ role: "user", message: "Hi" });
+      expect(result[1]).toMatchObject({ role: "agent", message: "Hello!" });
+    });
+
+    it("same eventId: agent-only turn stays agent without invented user", () => {
+      const input = [msg("agent", "Prologue", { eventId: 1, isText: true })];
+      const result = build(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        role: "agent",
+        message: "Prologue",
+      });
+    });
+
+    it("second conversation stays after first when event ids reset", () => {
+      const input: TranscriptEntry[] = [
+        msg("user", "c0 user", { eventId: 1, conversationIndex: 0 }),
+        msg("agent", "c0 agent", { eventId: 2, conversationIndex: 0 }),
+        { type: "disconnection", role: "user", conversationIndex: 0 },
+        msg("agent", "c1 first", { eventId: 1, conversationIndex: 1 }),
+        msg("user", "c1 second", { eventId: 1, conversationIndex: 1 }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(5);
+      expect(result[0]).toMatchObject({
+        role: "user",
+        message: "c0 user",
+        conversationIndex: 0,
+      });
+      expect(result[1]).toMatchObject({
+        role: "agent",
+        message: "c0 agent",
+        conversationIndex: 0,
+      });
+      expect(result[2]).toMatchObject({ type: "disconnection" });
+      expect(result[3]).toMatchObject({
+        role: "user",
+        message: "c1 second",
+        conversationIndex: 1,
+      });
+      expect(result[4]).toMatchObject({
+        role: "agent",
+        message: "c1 first",
+        conversationIndex: 1,
+      });
+    });
+
+    it("local user without eventId stays before server message in same layout", () => {
+      const input = [
+        msg("user", "typed locally", { isText: true }),
+        msg("agent", "server", { eventId: 5, isText: true }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        role: "user",
+        message: "typed locally",
+      });
+      expect(result[1]).toMatchObject({ role: "agent", message: "server" });
+    });
+
     it("reorders agent before user when agent_response arrives first in voice mode", () => {
       const input = [
         msg("agent", "Hello!", { eventId: 2, isText: false }),

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -51,6 +51,33 @@ export interface DisplayTranscriptConfig {
   firstMessageConversationIndex?: number;
 }
 
+type SortableDisplayMessage = {
+  entry: Extract<DisplayTranscriptEntry, { type: "message" }>;
+  originalIndex: number;
+};
+
+function compareSortableDisplayMessages(
+  a: SortableDisplayMessage,
+  b: SortableDisplayMessage
+): number {
+  const ea = a.entry;
+  const eb = b.entry;
+  if (ea.conversationIndex !== eb.conversationIndex) {
+    return ea.conversationIndex - eb.conversationIndex;
+  }
+  const aEventId = ea.eventId!;
+  const bEventId = eb.eventId!;
+  if (aEventId !== bEventId) {
+    return aEventId - bEventId;
+  }
+  const roleRank = (role: Role) => (role === "user" ? 0 : 1);
+  const roleDelta = roleRank(ea.role) - roleRank(eb.role);
+  if (roleDelta !== 0) {
+    return roleDelta;
+  }
+  return a.originalIndex - b.originalIndex;
+}
+
 export function buildDisplayTranscript(
   entries: TranscriptEntry[],
   config: DisplayTranscriptConfig
@@ -136,28 +163,27 @@ export function buildDisplayTranscript(
     result.push(entry);
   }
 
-  // Sort message entries by eventId to fix ordering when server sends
-  // agent_response before user_transcript in voice mode.
-  // Only reorder entries that have an eventId; leave others in place.
-  const sortableIndices: number[] = [];
-  const sortableEntries: DisplayTranscriptEntry[] = [];
+  // Reorder only message rows that carry a server eventId: scope by
+  // conversationIndex, sort by turn id (eventId), then user before agent when
+  // both share the same turn. Rows without eventId keep their slots; non-message
+  // rows stay fixed (mitigates live user_transcript vs agent_response races).
+  const sortable: SortableDisplayMessage[] = [];
   for (let i = 0; i < result.length; i++) {
     const entry = result[i];
     if (entry.type === "message" && entry.eventId != null) {
-      sortableIndices.push(i);
-      sortableEntries.push(entry);
+      sortable.push({
+        entry: entry as Extract<DisplayTranscriptEntry, { type: "message" }>,
+        originalIndex: i,
+      });
     }
   }
-  sortableEntries.sort((a, b) => {
-    const aId = (a as Extract<DisplayTranscriptEntry, { type: "message" }>)
-      .eventId!;
-    const bId = (b as Extract<DisplayTranscriptEntry, { type: "message" }>)
-      .eventId!;
-    return aId - bId;
-  });
+  const sortableIndices = sortable
+    .map(row => row.originalIndex)
+    .sort((a, b) => a - b);
+  sortable.sort(compareSortableDisplayMessages);
   const sorted = [...result];
-  for (let i = 0; i < sortableIndices.length; i++) {
-    sorted[sortableIndices[i]] = sortableEntries[i];
+  for (let i = 0; i < sortable.length; i++) {
+    sorted[sortableIndices[i]] = sortable[i].entry;
   }
 
   // Attach tool status to agent messages

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -60,18 +60,13 @@ function compareSortableDisplayMessages(
   a: SortableDisplayMessage,
   b: SortableDisplayMessage
 ): number {
-  const ea = a.entry;
-  const eb = b.entry;
-  if (ea.conversationIndex !== eb.conversationIndex) {
-    return ea.conversationIndex - eb.conversationIndex;
-  }
-  const aEventId = ea.eventId!;
-  const bEventId = eb.eventId!;
+  const aEventId = a.entry.eventId!;
+  const bEventId = b.entry.eventId!;
   if (aEventId !== bEventId) {
     return aEventId - bEventId;
   }
   const roleRank = (role: Role) => (role === "user" ? 0 : 1);
-  const roleDelta = roleRank(ea.role) - roleRank(eb.role);
+  const roleDelta = roleRank(a.entry.role) - roleRank(b.entry.role);
   if (roleDelta !== 0) {
     return roleDelta;
   }
@@ -163,10 +158,11 @@ export function buildDisplayTranscript(
     result.push(entry);
   }
 
-  // Reorder only message rows that carry a server eventId: scope by
-  // conversationIndex, sort by turn id (eventId), then user before agent when
-  // both share the same turn. Rows without eventId keep their slots; non-message
-  // rows stay fixed (mitigates live user_transcript vs agent_response races).
+  // Reorder only message rows that carry a server eventId: sort by turn id,
+  // then user-before-agent when both events of a turn share the same eventId
+  // (the backend ships user_transcript via create_task and agent_response via
+  // await, so within a turn either can win the wire). Rows without eventId
+  // keep their slots; non-message rows stay fixed.
   const sortable: SortableDisplayMessage[] = [];
   for (let i = 0; i < result.length; i++) {
     const entry = result[i];


### PR DESCRIPTION
## Why

In voice/DTMF mode the agent message can render before the user transcript. Cause is asymmetric send dispatch in `xi/services/python/xi_backend/xi_backend/routes/convai/utils/chat_history.py:1089-1172`: `user_transcript` (audio + DTMF path) is sent via `asyncio.create_task(send_json(...))` while `agent_response` is sent via `await send_json(...)`. The agent send can win the wire.

Both events for the same turn carry the same `source_event_id` (chat_history.py:1103-1106 and 1167-1170), so they reach the widget with an identical `eventId`. PR #660's sort had no tiebreaker on equal IDs, so display order tracked arrival order.

## What

- Sort comparator in `display-transcript.ts` now uses `(eventId, role[user-first], originalIndex)`.
- Rows without `eventId` (local optimistic user echoes from `sendUserMessage`) keep their original slots; non-message rows stay fixed.
- Tool-status attachment runs after the reorder; keys off `eventId` so it is unaffected.

## Testing

Added regression cases in `display-transcript.test.ts`:
- same `eventId` with agent received first → user displays first
- agent-only turn (no synthetic user inserted)
- local user message without `eventId` stays anchored
- non-message rows between misordered messages stay in place

Manual test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts transcript sorting logic in `buildDisplayTranscript`, which can subtly change message ordering in voice/DTMF flows and could regress edge-case rendering if the comparator is wrong. Coverage is improved with new regression tests, reducing risk.
> 
> **Overview**
> Fixes a race where voice/DTMF turns could display the agent message before the user transcript when both arrive with the same `eventId`.
> 
> `buildDisplayTranscript` now sorts server-stamped message rows by `(eventId, user-before-agent, originalIndex)` while keeping non-`eventId` messages and non-message rows anchored in place; new tests cover same-`eventId` tie-breaking and related ordering edge cases. Includes a patch `changeset` for `@elevenlabs/convai-widget-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af19518cf4c1cd8cd94f5b6381a79d81c3b26009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->