### PR TITLE
[Widget] Handle voice transcript ordering on insert

### DIFF
--- a/.changeset/slow-ravens-listen.md
+++ b/.changeset/slow-ravens-listen.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix voice widget transcripts so streamed agent response parts are ignored for voice sessions and late user transcripts are inserted before their matching agent response.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -76,6 +76,35 @@ export type TranscriptEntry =
       conversationIndex: number;
     };
 
+// Voice user transcripts can arrive after the agent response for the same
+// server turn. Insert those late user messages before the matching agent row;
+// keep local text/multimodal messages anchored by normal append order.
+function appendTranscriptMessage(
+  entries: TranscriptEntry[],
+  entry: Extract<TranscriptEntry, { type: "message" }>
+): TranscriptEntry[] {
+  if (entry.role !== "user" || entry.eventId == null) {
+    return [...entries, entry];
+  }
+
+  const matchingAgentIndex = entries.findIndex(
+    candidate =>
+      candidate.type === "message" &&
+      candidate.role === "agent" &&
+      candidate.eventId === entry.eventId &&
+      candidate.conversationIndex === entry.conversationIndex
+  );
+  if (matchingAgentIndex === -1) {
+    return [...entries, entry];
+  }
+
+  return [
+    ...entries.slice(0, matchingAgentIndex),
+    entry,
+    ...entries.slice(matchingAgentIndex),
+  ];
+}
+
 export function ConversationProvider({ children }: ConversationProviderProps) {
   const value = useConversationSetup();
 
@@ -252,22 +281,22 @@ function useConversationSetup() {
                 return;
               }
 
-              transcript.value = [
-                ...transcript.peek(),
-                {
-                  type: "message",
-                  role,
-                  message,
-                  isText: false,
-                  conversationIndex: conversationIndex.peek(),
-                  eventId: event_id,
-                },
-              ];
+              transcript.value = appendTranscriptMessage(transcript.peek(), {
+                type: "message",
+                role,
+                message,
+                isText: false,
+                conversationIndex: conversationIndex.peek(),
+                eventId: event_id,
+              });
             },
             onAgentChatResponsePart: ({ text, type, event_id }) => {
+              if (conversationTextOnly.peek() !== true) {
+                return;
+              }
+
               if (
                 firstMessage.peek() &&
-                conversationTextOnly.peek() === true &&
                 !receivedFirstMessageRef.current
               ) {
                 // Text mode is always started by the user sending a text message.

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -293,16 +293,16 @@ describe("buildDisplayTranscript", () => {
     });
   });
 
-  describe("eventId sorting", () => {
-    it("same eventId: user before agent when agent_response arrives first (shared turn id)", () => {
+  describe("message ordering", () => {
+    it("preserves source order for same eventId messages", () => {
       const input = [
         msg("agent", "Hello!", { eventId: 1, isText: false }),
         msg("user", "Hi", { eventId: 1, isText: false }),
       ];
       const result = build(input);
       expect(result).toHaveLength(2);
-      expect(result[0]).toMatchObject({ role: "user", message: "Hi" });
-      expect(result[1]).toMatchObject({ role: "agent", message: "Hello!" });
+      expect(result[0]).toMatchObject({ role: "agent", message: "Hello!" });
+      expect(result[1]).toMatchObject({ role: "user", message: "Hi" });
     });
 
     it("same eventId: agent-only turn stays agent without invented user", () => {
@@ -329,15 +329,15 @@ describe("buildDisplayTranscript", () => {
       expect(result[1]).toMatchObject({ role: "agent", message: "server" });
     });
 
-    it("reorders agent before user when agent_response arrives first in voice mode", () => {
+    it("preserves source order across different eventIds", () => {
       const input = [
         msg("agent", "Hello!", { eventId: 2, isText: false }),
         msg("user", "Hi", { eventId: 1, isText: false }),
       ];
       const result = build(input);
       expect(result).toHaveLength(2);
-      expect(result[0]).toMatchObject({ role: "user", message: "Hi" });
-      expect(result[1]).toMatchObject({ role: "agent", message: "Hello!" });
+      expect(result[0]).toMatchObject({ role: "agent", message: "Hello!" });
+      expect(result[1]).toMatchObject({ role: "user", message: "Hi" });
     });
 
     it("preserves order when eventIds are already sequential", () => {
@@ -351,7 +351,7 @@ describe("buildDisplayTranscript", () => {
       expect(result[1]).toMatchObject({ role: "agent", message: "Hello!" });
     });
 
-    it("sorts correctly when non-message entries sit between misordered messages", () => {
+    it("preserves non-message entries between messages", () => {
       const input: TranscriptEntry[] = [
         msg("agent", "Hello!", { eventId: 2, isText: false }),
         { type: "mode_toggle", mode: "text", conversationIndex: 0 },
@@ -359,10 +359,9 @@ describe("buildDisplayTranscript", () => {
       ];
       const result = build(input);
       expect(result).toHaveLength(3);
-      // Messages with eventId are reordered; mode_toggle stays in place
-      expect(result[0]).toMatchObject({ role: "user", message: "Hi" });
+      expect(result[0]).toMatchObject({ role: "agent", message: "Hello!" });
       expect(result[1]).toMatchObject({ type: "mode_toggle" });
-      expect(result[2]).toMatchObject({ role: "agent", message: "Hello!" });
+      expect(result[2]).toMatchObject({ role: "user", message: "Hi" });
     });
 
     it("keeps entries without eventId in their original position", () => {

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -51,28 +51,6 @@ export interface DisplayTranscriptConfig {
   firstMessageConversationIndex?: number;
 }
 
-type SortableDisplayMessage = {
-  entry: Extract<DisplayTranscriptEntry, { type: "message" }>;
-  originalIndex: number;
-};
-
-function compareSortableDisplayMessages(
-  a: SortableDisplayMessage,
-  b: SortableDisplayMessage
-): number {
-  const aEventId = a.entry.eventId!;
-  const bEventId = b.entry.eventId!;
-  if (aEventId !== bEventId) {
-    return aEventId - bEventId;
-  }
-  const roleRank = (role: Role) => (role === "user" ? 0 : 1);
-  const roleDelta = roleRank(a.entry.role) - roleRank(b.entry.role);
-  if (roleDelta !== 0) {
-    return roleDelta;
-  }
-  return a.originalIndex - b.originalIndex;
-}
-
 export function buildDisplayTranscript(
   entries: TranscriptEntry[],
   config: DisplayTranscriptConfig
@@ -158,34 +136,10 @@ export function buildDisplayTranscript(
     result.push(entry);
   }
 
-  // Reorder only message rows that carry a server eventId: sort by turn id,
-  // then user-before-agent when both events of a turn share the same eventId
-  // (the backend ships user_transcript via create_task and agent_response via
-  // await, so within a turn either can win the wire). Rows without eventId
-  // keep their slots; non-message rows stay fixed.
-  const sortable: SortableDisplayMessage[] = [];
-  for (let i = 0; i < result.length; i++) {
-    const entry = result[i];
-    if (entry.type === "message" && entry.eventId != null) {
-      sortable.push({
-        entry: entry as Extract<DisplayTranscriptEntry, { type: "message" }>,
-        originalIndex: i,
-      });
-    }
-  }
-  const sortableIndices = sortable
-    .map(row => row.originalIndex)
-    .sort((a, b) => a - b);
-  sortable.sort(compareSortableDisplayMessages);
-  const sorted = [...result];
-  for (let i = 0; i < sortable.length; i++) {
-    sorted[sortableIndices[i]] = sortable[i].entry;
-  }
-
   // Attach tool status to agent messages
   if (config.showAgentStatus) {
-    for (let i = 0; i < sorted.length; i++) {
-      const entry = sorted[i];
+    for (let i = 0; i < result.length; i++) {
+      const entry = result[i];
       if (
         entry.type !== "message" ||
         entry.role !== "agent" ||
@@ -201,9 +155,9 @@ export function buildDisplayTranscript(
           : status.error > 0
             ? ToolCallStatus.ERROR
             : ToolCallStatus.SUCCESS;
-      sorted[i] = { ...entry, toolStatus };
+      result[i] = { ...entry, toolStatus };
     }
   }
 
-  return sorted;
+  return result;
 }


### PR DESCRIPTION
Why:
Voice sessions can receive final agent responses before matching user transcripts, while also receiving agent response parts. The widget should avoid treating voice response parts as transcript messages and should keep same-turn user transcripts before their agent response when the server transcript arrives late.

What:
- Ignore `agent_chat_response_part` transcript updates for voice sessions while preserving text-only streaming behavior.
- Insert late server user transcripts before an existing matching agent message for the same conversation and event id.
- Remove broad display-time event id sorting so `buildDisplayTranscript` only filters, groups, and attaches tool status.

Testing:
- Updated `display-transcript` unit coverage for source-order preserving display behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transcript ordering logic for live conversations and removes display-time eventId sorting, which could alter message sequencing in edge cases across voice/text sessions. Impact is user-visible but limited to transcript rendering/stream handling.
> 
> **Overview**
> Fixes voice-session transcript behavior by **ignoring streamed `agent_chat_response_part` updates unless in text-only mode** and by **inserting late-arriving server user transcripts before the matching agent message** for the same `eventId`/`conversationIndex`.
> 
> Removes broad eventId-based reordering from `buildDisplayTranscript`, so display building now preserves source order (while still filtering/grouping and attaching tool status), and updates unit tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce369428045d3a6180703e4e10046eacc09f254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->