### PR TITLE
Set pnpm minimumReleaseAge to 7 days

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ packages:
   - "apps/*"
   - "packages/*"
   - "examples/*"
+
+# Don't resolve package versions published less than 7 days ago.
+# This mitigates supply chain attacks where malicious versions are typically
+# detected and removed within hours. See https://pnpm.io/supply-chain-security
+minimumReleaseAge: 10080 # 7 days


### PR DESCRIPTION
## Summary
- Configures `minimumReleaseAge: 10080` (7 days) in `pnpm-workspace.yaml`
- Prevents pnpm from resolving package versions published less than 7 days ago
- Mitigates supply chain attacks like the recent [TanStack compromise](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack) where malicious versions are typically detected and removed within hours

## Test plan
- [x] Verified `pnpm turbo lint` passes with the new setting
- [ ] Confirm `pnpm install` still resolves existing lockfile versions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change, but it can cause `pnpm install` to fail or select older versions if dependencies were published within the last 7 days.
> 
> **Overview**
> Adds `minimumReleaseAge: 10080` to `pnpm-workspace.yaml` so pnpm will not resolve dependency versions published in the last 7 days, as a supply-chain hardening measure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d9b4d2daaf737d6b58452734d85360a2bee8cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->