### PR TITLE
Move manual types from @elevenlabs/types to @elevenlabs/client

### DIFF
--- a/.changeset/move-types-to-client.md
+++ b/.changeset/move-types-to-client.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/types": minor
+---
+
+Remove manually maintained types (`Role`, `Mode`, `Status`, `Callbacks`, `CALLBACK_KEYS`, `DisconnectionDetails`, `MessagePayload`, `AudioAlignmentEvent`) from `@elevenlabs/types`. These types now live in `@elevenlabs/client` — import them from there instead. The types package now contains only generated code.

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -1,4 +1,4 @@
-import { Callbacks, Mode, Status } from "@elevenlabs/types";
+import { Callbacks, Mode, Status } from "./types.js";
 import type {
   BaseConnection,
   DisconnectionDetails,
@@ -33,8 +33,8 @@ import type { OutputConfig } from "./utils/output.js";
 
 const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
 
-export type { Role, Mode, Status, Callbacks } from "@elevenlabs/types";
-export { CALLBACK_KEYS } from "@elevenlabs/types";
+export type { Role, Mode, Status, Callbacks } from "./types.js";
+export { CALLBACK_KEYS } from "./types.js";
 
 /** Allows self-hosting the worklets to avoid whitelisting blob: and data: in the CSP script-src  */
 export type AudioWorkletConfig = {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,11 +1,24 @@
-import type * as Generated from "../generated/types/asyncapi-types.js";
+import type {
+  AudioEventAlignment,
+  ClientToolCallClientEvent,
+  McpToolCallClientEvent,
+  McpConnectionStatusClientEvent,
+  AgentToolRequestClientEvent,
+  AgentToolResponseClientEvent,
+  AgentToolResponseFullPayloadClientEvent,
+  ConversationMetadata,
+  AsrInitiationMetadataEvent,
+  Interruption,
+  AgentResponseCorrection,
+  AgentChatResponsePartClientEvent,
+} from "@elevenlabs/types";
 
 /**
  * Role in the conversation
  */
 export type Role = "user" | "agent";
 
-export type AudioAlignmentEvent = Generated.AudioEventAlignment;
+export type AudioAlignmentEvent = AudioEventAlignment;
 
 /**
  * Current mode of the conversation
@@ -65,42 +78,36 @@ export type Callbacks = {
   onStatusChange?: (prop: { status: Status }) => void;
   onCanSendFeedbackChange?: (prop: { canSendFeedback: boolean }) => void;
   onUnhandledClientToolCall?: (
-    params: Generated.ClientToolCallClientEvent["client_tool_call"]
+    params: ClientToolCallClientEvent["client_tool_call"]
   ) => void;
   onVadScore?: (props: { vadScore: number }) => void;
-  onMCPToolCall?: (
-    props: Generated.McpToolCallClientEvent["mcp_tool_call"]
-  ) => void;
+  onMCPToolCall?: (props: McpToolCallClientEvent["mcp_tool_call"]) => void;
   onMCPConnectionStatus?: (
-    props: Generated.McpConnectionStatusClientEvent["mcp_connection_status"]
+    props: McpConnectionStatusClientEvent["mcp_connection_status"]
   ) => void;
   onAgentToolRequest?: (
-    props: Generated.AgentToolRequestClientEvent["agent_tool_request"]
+    props: AgentToolRequestClientEvent["agent_tool_request"]
   ) => void;
   onAgentToolResponse?: (
     props:
-      | Generated.AgentToolResponseClientEvent["agent_tool_response"]
-      | Generated.AgentToolResponseFullPayloadClientEvent["agent_tool_response_full_payload"]
+      | AgentToolResponseClientEvent["agent_tool_response"]
+      | AgentToolResponseFullPayloadClientEvent["agent_tool_response_full_payload"]
   ) => void;
   onConversationMetadata?: (
-    props: Generated.ConversationMetadata["conversation_initiation_metadata_event"]
+    props: ConversationMetadata["conversation_initiation_metadata_event"]
   ) => void;
   onAsrInitiationMetadata?: (
-    props: Generated.AsrInitiationMetadataEvent["asr_initiation_metadata_event"]
+    props: AsrInitiationMetadataEvent["asr_initiation_metadata_event"]
   ) => void;
-  onInterruption?: (
-    props: Generated.Interruption["interruption_event"]
-  ) => void;
+  onInterruption?: (props: Interruption["interruption_event"]) => void;
   onAgentResponseCorrection?: (
-    props: Generated.AgentResponseCorrection["agent_response_correction_event"]
+    props: AgentResponseCorrection["agent_response_correction_event"]
   ) => void;
   onAgentChatResponsePart?: (
-    props: Generated.AgentChatResponsePartClientEvent["text_response_part"]
+    props: AgentChatResponsePartClientEvent["text_response_part"]
   ) => void;
   onGuardrailTriggered?: () => void;
-  onAudioAlignment?: (
-    props: AudioAlignmentEvent
-  ) => void;
+  onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   // internal debug events, not to be used
   onDebug?: (props: any) => void;
 };

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -2,15 +2,15 @@ import type { IncomingSocketEvent, OutgoingSocketEvent } from "./events.js";
 import type { Mode } from "../BaseConversation.js";
 import type {
   ConversationConfigOverrideAgentPrompt,
-  DisconnectionDetails,
   ConversationConfigOverrideAgentLanguage as Language,
 } from "@elevenlabs/types";
+import type { DisconnectionDetails } from "../types.js";
 
 export type {
   ConversationConfigOverrideAgentPrompt,
-  DisconnectionDetails,
   ConversationConfigOverrideAgentLanguage as Language,
 } from "@elevenlabs/types";
+export type { DisconnectionDetails } from "../types.js";
 
 export type DelayConfig = {
   default: number;

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -6,7 +6,6 @@ import type {
   AgentToolResponseFullPayloadClientEvent,
   AsrInitiationMetadataEvent as AsrMetadataEvent,
   Audio,
-  AudioAlignmentEvent,
   AgentToolRequestClientEvent,
   ClientToolCallMessage,
   ConversationMetadata,
@@ -21,6 +20,7 @@ import type {
   UserTranscript,
   VadScore,
 } from "@elevenlabs/types";
+import type { AudioAlignmentEvent } from "../types.js";
 
 // Compatibility layer - incoming events
 export type UserTranscriptionEvent = UserTranscript;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,3 @@ export * as Incoming from "../generated/types/incoming.js";
 export * as Outgoing from "../generated/types/outgoing.js";
 
 export * from "../generated/types/asyncapi-types.js";
-
-// SDK-specific shared types
-export * from "./types.js";


### PR DESCRIPTION
## Summary
- Moves manually-maintained types (`Role`, `Mode`, `Status`, `Callbacks`, `CALLBACK_KEYS`, `DisconnectionDetails`, `MessagePayload`, `AudioAlignmentEvent`) from `@elevenlabs/types` to `@elevenlabs/client/src/types.ts`
- Removes the manual types export from `@elevenlabs/types`, leaving it as a generated-types-only package
- Updates all internal imports in the client package to reference the new location

This is Phase 0 of the DOM API isolation effort (#661, #662). Moving `DisconnectionDetails` into the client package enables a later phase to replace its `Event`/`CloseEvent` references with platform-agnostic types.

This is largely a re-application of the type moves from #739 (which was merged into `kh/event-emitter` but never landed on main). With this PR, #739 should be considered obsolete.

## Test plan
- [x] `pnpm turbo build` passes (all packages)
- [x] `pnpm turbo lint` passes (all packages)
- [ ] `pnpm turbo test` passes (client & widget-core tests require Playwright browsers — pre-existing issue, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a type-only refactor, but it changes public exports/import paths between `@elevenlabs/types` and `@elevenlabs/client`, which can cause downstream compile-time breakage if consumers don’t update imports.
> 
> **Overview**
> Moves the manually maintained conversation SDK types (e.g. `Role`, `Mode`, `Status`, `Callbacks`, `CALLBACK_KEYS`, `DisconnectionDetails`, `MessagePayload`, `AudioAlignmentEvent`) out of `@elevenlabs/types` and into `@elevenlabs/client` (via `client/src/types.ts`), updating client internals to import/re-export them from the new location.
> 
> `@elevenlabs/types` is reduced to **generated types only** by removing the SDK-specific `./types.js` re-export, and a changeset is added to publish this as a minor version bump with migration guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4b95728c41e49ad03dac73fb8f941fdafa1439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->