### PR TITLE
Replace DOM event constructors with platform-agnostic types (Phase 2)

### DIFF
--- a/.changeset/disconnection-context.md
+++ b/.changeset/disconnection-context.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Replace DOM `Event`/`CloseEvent` constructors in `DisconnectionDetails` with a platform-agnostic `DisconnectionContext` type. The `context` property on disconnection details is now `{ type: string; reason?: string; code?: number }` instead of a DOM event object. This fixes runtime failures on React Native where `Event` and `CloseEvent` constructors are not available.

--- a/.changeset/runtime-globals-and-disconnection-context.md
+++ b/.changeset/runtime-globals-and-disconnection-context.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Add cross-platform runtime type declarations (WebSocket, fetch, encoding, URL) and replace DOM `Event`/`CloseEvent` constructors in `DisconnectionDetails` with a platform-agnostic `DisconnectionContext` type. The `context` property on disconnection details is now `{ type: string; reason?: string; code?: number }` instead of a DOM event object. This fixes runtime failures on React Native where `Event` and `CloseEvent` constructors are not available.

--- a/.changeset/runtime-globals-and-disconnection-context.md
+++ b/.changeset/runtime-globals-and-disconnection-context.md
@@ -1,5 +1,0 @@
----
-"@elevenlabs/client": minor
----
-
-Add cross-platform runtime type declarations (WebSocket, fetch, encoding, URL) and replace DOM `Event`/`CloseEvent` constructors in `DisconnectionDetails` with a platform-agnostic `DisconnectionContext` type. The `context` property on disconnection details is now `{ type: string; reason?: string; code?: number }` instead of a DOM event object. This fixes runtime failures on React Native where `Event` and `CloseEvent` constructors are not available.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -273,4 +273,85 @@ describe("BaseConversation", () => {
       expect(received.full_tool_result.length).toBeGreaterThan(64_000);
     });
   });
+
+  describe("disconnection context", () => {
+    // endSessionWithDetails is async and fire-and-forget, so we need to flush
+    // microtasks after receiving the message.
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("disconnects with end_call context on agent_tool_response", async () => {
+      const onDisconnect = vi.fn();
+      const conversation = TestConversation.create({ onDisconnect });
+
+      await conversation.receiveMessage({
+        type: "agent_tool_response",
+        agent_tool_response: {
+          tool_name: "end_call",
+          tool_call_id: "call_end",
+          tool_type: "system",
+          is_error: false,
+          is_called: true,
+          event_id: 1,
+        },
+      });
+      await flush();
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "agent",
+        context: { type: "end_call", reason: "Agent ended the call" },
+      });
+    });
+
+    it("disconnects with end_call context on agent_tool_response_full_payload", async () => {
+      const onDisconnect = vi.fn();
+      const conversation = TestConversation.create({ onDisconnect });
+
+      await conversation.receiveMessage({
+        type: "agent_tool_response_full_payload",
+        agent_tool_response_full_payload: {
+          tool_name: "end_call",
+          tool_call_id: "call_end",
+          tool_type: "system",
+          is_error: false,
+          is_blocked: false,
+          is_called: true,
+          event_id: 1,
+          full_tool_result: "",
+          truncated: false,
+        },
+      });
+      await flush();
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "agent",
+        context: { type: "end_call", reason: "Agent ended the call" },
+      });
+    });
+
+    it("disconnects with max_duration_exceeded context on error event", async () => {
+      const onDisconnect = vi.fn();
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const conversation = TestConversation.create({ onDisconnect });
+
+      await conversation.receiveMessage({
+        type: "error",
+        error_event: {
+          code: 1000 as const,
+          error_type: "max_duration_exceeded",
+          message: "Maximum duration exceeded",
+        },
+      });
+      await flush();
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "error",
+        message: "Maximum duration exceeded",
+        context: { type: "max_duration_exceeded" },
+      });
+    });
+  });
 });

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -351,7 +351,7 @@ export abstract class BaseConversation {
     if (event.agent_tool_response.tool_name === "end_call") {
       this.endSessionWithDetails({
         reason: "agent",
-        context: new CloseEvent("end_call", { reason: "Agent ended the call" }),
+        context: { type: "end_call", reason: "Agent ended the call" },
       });
     }
 
@@ -366,7 +366,7 @@ export abstract class BaseConversation {
     if (event.agent_tool_response_full_payload.tool_name === "end_call") {
       this.endSessionWithDetails({
         reason: "agent",
-        context: new CloseEvent("end_call", { reason: "Agent ended the call" }),
+        context: { type: "end_call", reason: "Agent ended the call" },
       });
     }
 
@@ -410,7 +410,7 @@ export abstract class BaseConversation {
       this.endSessionWithDetails({
         reason: "error",
         message: message,
-        context: new Event("max_duration_exceeded"),
+        context: { type: "max_duration_exceeded" },
       });
       return;
     }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -33,6 +33,7 @@ export type {
 export type {
   SessionConfig,
   BaseSessionConfig,
+  DisconnectionContext,
   DisconnectionDetails,
   Language,
   ConnectionType,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -35,19 +35,30 @@ export type Status =
   | "disconnecting";
 
 /**
+ * Platform-agnostic representation of the event that triggered a disconnection.
+ * Replaces the former `Event` / `CloseEvent` DOM constructors which are
+ * not available on React Native.
+ */
+export type DisconnectionContext = {
+  type: string;
+  reason?: string;
+  code?: number;
+};
+
+/**
  * Reason for the disconnection
  */
 export type DisconnectionDetails =
   | {
       reason: "error";
       message: string;
-      context: Event;
+      context: DisconnectionContext;
       closeCode?: number;
       closeReason?: string;
     }
   | {
       reason: "agent";
-      context?: CloseEvent;
+      context?: DisconnectionContext;
       closeCode?: number;
       closeReason?: string;
     }

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -10,7 +10,7 @@ export type {
   ConversationConfigOverrideAgentPrompt,
   ConversationConfigOverrideAgentLanguage as Language,
 } from "@elevenlabs/types";
-export type { DisconnectionDetails } from "../types.js";
+export type { DisconnectionContext, DisconnectionDetails } from "../types.js";
 
 export type DelayConfig = {
   default: number;

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -254,6 +254,78 @@ describe("WebRTCConnection", () => {
     connection.close();
   });
 
+  describe("disconnection context", () => {
+    async function createWithHandlers() {
+      const mockRoom = new Room() as any;
+      const eventHandlers = new Map<string, Function>();
+
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: Function) => {
+          eventHandlers.set(event, callback);
+          if (event === "connected") {
+            queueMicrotask(() => callback());
+          }
+        }
+      );
+      (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: Function) => {
+          if (event === "signalConnected") {
+            queueMicrotask(() => callback());
+          }
+        }
+      );
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
+
+      return { connection, eventHandlers, mockRoom };
+    }
+
+    it("emits agent disconnect with context on RoomEvent.Disconnected", async () => {
+      const { connection, eventHandlers } = await createWithHandlers();
+      const onDisconnect = vi.fn();
+      connection.onDisconnect(onDisconnect);
+
+      eventHandlers.get("disconnected")?.("client_initiated");
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "agent",
+        context: { type: "close", reason: "client_initiated" },
+      });
+    });
+
+    it("emits error disconnect with context on ConnectionStateChanged to Disconnected", async () => {
+      const { connection, eventHandlers } = await createWithHandlers();
+      const onDisconnect = vi.fn();
+      connection.onDisconnect(onDisconnect);
+
+      eventHandlers.get("connectionStateChanged")?.("disconnected");
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "error",
+        message: "LiveKit connection state changed to disconnected",
+        context: { type: "connection_state_changed" },
+      });
+    });
+
+    it("emits agent disconnect with context on agent ParticipantDisconnected", async () => {
+      const { connection, eventHandlers } = await createWithHandlers();
+      const onDisconnect = vi.fn();
+      connection.onDisconnect(onDisconnect);
+
+      eventHandlers.get("participantDisconnected")?.({
+        identity: "agent_123",
+      });
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "agent",
+        context: { type: "close", reason: "agent disconnected" },
+      });
+    });
+  });
+
   it.each([
     { textOnly: true, shouldEnableMic: false },
     { textOnly: false, shouldEnableMic: true },

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -368,7 +368,7 @@ export class WebRTCConnection extends BaseConnection {
       this.isConnected = false;
       this.disconnect({
         reason: "agent",
-        context: new CloseEvent("close", { reason: reason?.toString() }),
+        context: { type: "close", reason: reason?.toString() },
       });
     });
 
@@ -378,7 +378,7 @@ export class WebRTCConnection extends BaseConnection {
         this.disconnect({
           reason: "error",
           message: `LiveKit connection state changed to ${state}`,
-          context: new Event("connection_state_changed"),
+          context: { type: "connection_state_changed" },
         });
       }
     });
@@ -474,7 +474,7 @@ export class WebRTCConnection extends BaseConnection {
         if (participant.identity?.startsWith("agent")) {
           this.disconnect({
             reason: "agent",
-            context: new CloseEvent("close", { reason: "agent disconnected" }),
+            context: { type: "close", reason: "agent disconnected" },
           });
         }
       }

--- a/packages/client/src/utils/WebSocketConnection.test.ts
+++ b/packages/client/src/utils/WebSocketConnection.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { WebSocketConnection } from "./WebSocketConnection.js";
+
+type EventHandler = (event: any) => void;
+
+describe("WebSocketConnection", () => {
+  let listeners: Map<string, EventHandler[]>;
+  let mockSocket: Record<string, any>;
+
+  beforeEach(() => {
+    listeners = new Map();
+    mockSocket = {
+      addEventListener: vi.fn((type: string, handler: EventHandler) => {
+        if (!listeners.has(type)) listeners.set(type, []);
+        listeners.get(type)!.push(handler);
+      }),
+      removeEventListener: vi.fn(),
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    vi.stubGlobal(
+      "WebSocket",
+      vi.fn(function WebSocket() {
+        return mockSocket;
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function emit(type: string, event: any) {
+    for (const handler of listeners.get(type) ?? []) {
+      handler(event);
+    }
+  }
+
+  async function createConnection(): Promise<WebSocketConnection> {
+    const promise = WebSocketConnection.create({
+      agentId: "test-agent",
+      connectionType: "websocket",
+    });
+
+    // Simulate the WebSocket handshake: open → config message
+    emit("open", {});
+    emit("message", {
+      data: JSON.stringify({
+        type: "conversation_initiation_metadata",
+        conversation_initiation_metadata_event: {
+          conversation_id: "test-conv-id",
+          agent_output_audio_format: "pcm_16000",
+          user_input_audio_format: "pcm_16000",
+        },
+      }),
+    });
+
+    return promise;
+  }
+
+  describe("disconnection context", () => {
+    it("emits agent disconnect with context on normal close (code 1000)", async () => {
+      const connection = await createConnection();
+      const onDisconnect = vi.fn();
+      connection.onDisconnect(onDisconnect);
+
+      emit("close", { type: "close", code: 1000, reason: "" });
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "agent",
+        context: { type: "close", code: 1000, reason: undefined },
+        closeCode: 1000,
+        closeReason: undefined,
+      });
+    });
+
+    it("emits error disconnect with context on abnormal close", async () => {
+      const connection = await createConnection();
+      const onDisconnect = vi.fn();
+      connection.onDisconnect(onDisconnect);
+
+      emit("close", { type: "close", code: 1006, reason: "Connection lost" });
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "error",
+        message: "Connection lost",
+        context: { type: "close", code: 1006, reason: "Connection lost" },
+        closeCode: 1006,
+        closeReason: "Connection lost",
+      });
+    });
+
+    it("emits error disconnect with default message when close has no reason", async () => {
+      const connection = await createConnection();
+      const onDisconnect = vi.fn();
+      connection.onDisconnect(onDisconnect);
+
+      emit("close", { type: "close", code: 1006, reason: "" });
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "error",
+        message: "The connection was closed by the server.",
+        context: { type: "close", code: 1006, reason: undefined },
+        closeCode: 1006,
+        closeReason: undefined,
+      });
+    });
+
+    it("emits error disconnect with context on socket error (no close event)", async () => {
+      vi.useFakeTimers();
+      const connection = await createConnection();
+      const onDisconnect = vi.fn();
+      connection.onDisconnect(onDisconnect);
+
+      emit("error", { type: "error" });
+      vi.runAllTimers();
+
+      expect(onDisconnect).toHaveBeenCalledWith({
+        reason: "error",
+        message: "The connection was closed due to a socket error.",
+        context: { type: "error" },
+      });
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/packages/client/src/utils/WebSocketConnection.ts
+++ b/packages/client/src/utils/WebSocketConnection.ts
@@ -49,18 +49,23 @@ export class WebSocketConnection
           this.disconnect({
             reason: "error",
             message: "The connection was closed due to a socket error.",
-            context: event,
+            context: { type: event.type },
           }),
         0
       );
     });
 
     this.socket.addEventListener("close", event => {
+      const context = {
+        type: event.type,
+        code: event.code,
+        reason: event.reason || undefined,
+      };
       this.disconnect(
         event.code === 1000
           ? {
               reason: "agent",
-              context: event,
+              context,
               closeCode: event.code,
               closeReason: event.reason || undefined,
             }
@@ -68,7 +73,7 @@ export class WebSocketConnection
               reason: "error",
               message:
                 event.reason || "The connection was closed by the server.",
-              context: event,
+              context,
               closeCode: event.code,
               closeReason: event.reason || undefined,
             }

--- a/packages/client/src/utils/connection.ts
+++ b/packages/client/src/utils/connection.ts
@@ -3,6 +3,7 @@ export {
   Language,
   DelayConfig,
   FormatConfig,
+  DisconnectionContext,
   DisconnectionDetails,
   OnDisconnectCallback,
   OnMessageCallback,


### PR DESCRIPTION
## Summary
- Replace `Event`/`CloseEvent` DOM constructors in `DisconnectionDetails` with a plain `DisconnectionContext` type (`{ type, reason?, code? }`) — fixes runtime crashes on React Native where these constructors are not available
- Add `DisconnectionContext` to public exports

**Note:** The `runtime.ts` expansion and `audio.ts` btoa/atob fixes originally planned for Phase 2 have been folded into Phase 1 (#786).

Stacked on #786.

## Test plan
- [x] Web build (`tsconfig.web.json`) compiles cleanly
- [x] No new `tsconfig.common.json` errors introduced
- [x] ESLint and Prettier pass
- [ ] Verify `DisconnectionDetails.context` shape in consumer code (React SDK, widget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a public API/type change: `DisconnectionDetails.context` is no longer a DOM `Event`/`CloseEvent`, so downstream consumers may need updates. Runtime risk is moderate but localized to disconnect/error paths and is covered by new unit tests across WebSocket/WebRTC/BaseConversation.
> 
> **Overview**
> **Updates disconnection reporting to be platform-agnostic.** `DisconnectionDetails.context` now uses a new `DisconnectionContext` shape (`{ type, reason?, code? }`) instead of DOM `Event`/`CloseEvent`, and this type is exported publicly (including legacy `connection.ts` re-exports).
> 
> Disconnect emitters in `BaseConversation`, `WebRTCConnection`, and `WebSocketConnection` now populate this object (including close `code`/`reason` where available), and new tests assert the expected context for `end_call`, `max_duration_exceeded`, LiveKit disconnects, and WebSocket close/error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b56e175d4382ba705efdc164208ec1fa9f5f09c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->