### PR TITLE
fix(client): surface onAudioAlignment on WebRTC transport

### DIFF
--- a/.changeset/fix-onaudioalignment-webrtc.md
+++ b/.changeset/fix-onaudioalignment-webrtc.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Fix `onAudioAlignment` callback never firing on the WebRTC transport. The `WebRTCConnection` `DataReceived` handler dropped the entire `type: "audio"` JSON message because audio bytes flow over LiveKit audio tracks, but the same message carries the `alignment` metadata (chars + `char_start_times_ms` + `char_durations_ms`) — which got dropped along with it. Now audio messages are routed through `handleMessage` so `VoiceConversation.handleAudio` can surface alignment, then return before the audio_base_64 playback path (LiveKit still handles playback via the audio track).

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -385,8 +385,20 @@ export class WebRTCConnection extends BaseConnection {
         try {
           const message = JSON.parse(new TextDecoder().decode(payload));
 
-          // Filter out audio messages for WebRTC - they're handled via audio tracks
+          // Audio bytes flow over LiveKit audio tracks, NOT the data channel —
+          // but the same JSON message carries the alignment metadata
+          // (chars + char_start_times_ms + char_durations_ms). Dropping
+          // the whole message drops alignment along with it, which
+          // prevents onAudioAlignment from firing on the WebRTC transport
+          // even though the WebSocket transport surfaces it correctly.
+          // Route audio messages through handleMessage so
+          // VoiceConversation.handleAudio can fire onAudioAlignment, then
+          // return without re-playing audio_base_64 (LiveKit already
+          // plays it via the audio track).
           if (message.type === "audio") {
+            if (isValidSocketEvent(message)) {
+              this.handleMessage(message);
+            }
             return;
           }
 


### PR DESCRIPTION
## Problem

`VoiceConversation.handleAudio()` fires the `onAudioAlignment` callback when an audio event with alignment metadata arrives, but on the **WebRTC transport** this callback never fires.

In `WebRTCConnection.ts`, the `RoomEvent.DataReceived` handler drops the entire JSON message when `message.type === "audio"`, with the comment "Filter out audio messages for WebRTC - they're handled via audio tracks." That comment is true for the *audio bytes* (`audio_base_64`) — LiveKit's audio track plays them — but the alignment metadata (`chars`, `char_start_times_ms`, `char_durations_ms`) lives in the same message and gets dropped with it.

Net effect: consumers using `onAudioAlignment` on `@elevenlabs/react-native` or any WebRTC-transport `@elevenlabs/client` user receive nothing. The Swift SDK exposes alignment correctly; the WebSocket transport exposes alignment correctly; only WebRTC drops it.

## Fix

Route audio messages through `handleMessage()` so `VoiceConversation.handleAudio` can fire `onAudioAlignment`, then return without further processing (since LiveKit audio tracks already handle playback).

```diff
 if (message.type === "audio") {
+  if (isValidSocketEvent(message)) {
+    this.handleMessage(message);
+  }
   return;
 }
```

## Verification

Tested end-to-end against a live `@elevenlabs/react-native@1.0.1` session on iOS. Prior to the fix `onAudioAlignment` never fired on WebRTC; after the fix it fires per audio chunk with the expected `{ chars, char_start_times_ms, char_durations_ms }` payload, matching the WebSocket transport's behavior. Per-word karaoke transcript stays synced to agent speech end-to-end across a multi-turn conversation.

## Side effects audited

`VoiceConversation.handleAudio` does the following after `onAudioAlignment`:

1. Fires `onAudio(audio_base_64)` if subscribed. Harmless on WebRTC for consumers who don't subscribe; if they do, raw bytes are what they opted into.
2. Updates `currentEventId` and `canSendFeedback`. Previously these didn't advance on WebRTC audio events, which was arguably a pre-existing bug (`sendFeedback` couldn't reference WebRTC event IDs).
3. Calls `updateMode("speaking")`. Already fires elsewhere on WebRTC via mode events; idempotent here.

No behavior regression observed.

## Changeset

Patch-level bump to `@elevenlabs/client`. Changeset included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to WebRTC data-channel message routing to ensure `audio` events reach existing handlers; main risk is unintended side effects from processing additional `audio` messages (e.g., duplicate `onAudio` callbacks) if downstream consumers subscribe.
> 
> **Overview**
> Fixes WebRTC conversations dropping `type: "audio"` data-channel messages by routing them through `handleMessage` (when valid) before returning, so `VoiceConversation.handleAudio` can emit `onAudioAlignment` from the alignment metadata.
> 
> Adds a patch changeset for `@elevenlabs/client` documenting the alignment callback fix on the WebRTC transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b65aa02315b50fb2ffa95798df932897be9939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->