### PR TITLE
Make VoiceConversation platform-agnostic (Phase 4)

### DIFF
--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -98,10 +98,10 @@ export class VoiceConversation extends BaseConversation {
   protected override async handleEndSession() {
     this.playbackEventTarget?.removeListener(this.handlePlaybackEvent);
     this.playbackEventTarget = null;
-    await super.handleEndSession();
     await this.cleanUp();
     await this.input.close();
     await this.output.close();
+    await super.handleEndSession();
   }
 
   protected override handleInterruption(event: InterruptionEvent) {

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -6,7 +6,6 @@ import type {
 } from "./OutputController.js";
 import type { BaseConnection, FormatConfig } from "./utils/BaseConnection.js";
 import type { AgentAudioEvent, InterruptionEvent } from "./utils/events.js";
-import { applyDelay, resolveDelay } from "./utils/applyDelay.js";
 import {
   BaseConversation,
   type Options,
@@ -15,21 +14,10 @@ import {
 import type { InputController } from "./InputController.js";
 import type { OutputController } from "./OutputController.js";
 import { setupStrategy } from "./platform/VoiceSessionSetup.js";
+import type { VoiceSessionSetupResult } from "./platform/VoiceSessionSetup.js";
 
 export class VoiceConversation extends BaseConversation {
   readonly type = "voice";
-
-  private static async requestWakeLock(): Promise<WakeLockSentinel | null> {
-    if ("wakeLock" in navigator) {
-      // unavailable without HTTPS, including localhost in dev
-      try {
-        return await navigator.wakeLock.request("screen");
-      } catch (_e) {
-        // Wake Lock is not required for the conversation to work
-      }
-    }
-    return null;
-  }
 
   public static async startSession(
     options: PartialOptions
@@ -43,45 +31,19 @@ export class VoiceConversation extends BaseConversation {
       fullOptions.onCanSendFeedbackChange({ canSendFeedback: false });
     }
 
-    let preliminaryInputStream: MediaStream | null = null;
     let conversation: VoiceConversation | null = null;
-
-    const useWakeLock = options.useWakeLock ?? true;
-    let wakeLock: WakeLockSentinel | null = null;
-    if (useWakeLock) {
-      wakeLock = await VoiceConversation.requestWakeLock();
-    }
+    let sessionSetup: VoiceSessionSetupResult | null = null;
 
     try {
-      // some browsers won't allow calling getSupportedConstraints or enumerateDevices
-      // before getting approval for microphone access
-      preliminaryInputStream = await navigator.mediaDevices.getUserMedia({
-        audio: true,
-      });
-
-      // TODO: resolveDelay is called without a platform argument, so the
-      // previous default Android delay (3s for AudioManager mode switch) is
-      // lost. Move delay application into the platform-specific setup strategy,
-      // which can detect the platform and apply the correct delay.
-      await applyDelay(resolveDelay(fullOptions.connectionDelay));
-
-      // Platform-specific strategy creates the connection and sets up input/output
+      // Platform-specific strategy handles wake lock, mic permission,
+      // delay, connection creation, and input/output setup.
       if (!setupStrategy) {
         throw new Error(
           "No voice session setup strategy registered. " +
             'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
         );
       }
-      const sessionSetup = await setupStrategy(fullOptions);
-
-      // Stop the preliminary stream after setting up the session.
-      // Its only purpose was triggering the browser's microphone permission
-      // prompt; it must remain alive until the strategy finishes because
-      // MediaDeviceInput.create (WebSocket path) needs mic access granted.
-      preliminaryInputStream?.getTracks().forEach(track => {
-        track.stop();
-      });
-      preliminaryInputStream = null;
+      sessionSetup = await setupStrategy(fullOptions);
 
       conversation = new VoiceConversation(
         fullOptions,
@@ -89,8 +51,7 @@ export class VoiceConversation extends BaseConversation {
         sessionSetup.input,
         sessionSetup.output,
         sessionSetup.playbackEventTarget,
-        sessionSetup.detach,
-        wakeLock
+        sessionSetup.detach
       );
       fullOptions.onConversationCreated?.(conversation);
       conversation.markConnected();
@@ -99,25 +60,21 @@ export class VoiceConversation extends BaseConversation {
       });
       return conversation;
     } catch (error) {
-      preliminaryInputStream?.getTracks().forEach(track => {
-        track.stop();
-      });
       if (conversation) {
         await conversation.endSession().catch(() => {});
       } else {
+        // Strategy returned but conversation wasn't created — clean up
+        if (sessionSetup) {
+          await sessionSetup.detach().catch(() => {});
+        }
         fullOptions.onStatusChange?.({ status: "disconnected" });
       }
-      try {
-        await wakeLock?.release();
-        wakeLock = null;
-      } catch (_e) {}
       throw error;
     }
   }
 
   private inputFrequencyData?: Uint8Array<ArrayBuffer>;
   private outputFrequencyData?: Uint8Array<ArrayBuffer>;
-  private visibilityChangeHandler: (() => void) | null = null;
 
   private handlePlaybackEvent: PlaybackListener = event => {
     if (event.data.type === "process") {
@@ -131,48 +88,18 @@ export class VoiceConversation extends BaseConversation {
     private input: InputController,
     private output: OutputController,
     private playbackEventTarget: PlaybackEventTarget | null,
-    private cleanUp: () => void,
-    private wakeLock: WakeLockSentinel | null
+    private cleanUp: () => Promise<void>
   ) {
     super(options, connection);
 
     playbackEventTarget?.addListener(this.handlePlaybackEvent);
-
-    if (wakeLock) {
-      // Wake locks are automatically released when a page is hidden like when switching tabs
-      // so attempt to re-acquire lock when page becomes visible again
-      this.visibilityChangeHandler = () => {
-        if (document.visibilityState === "visible" && this.wakeLock?.released) {
-          VoiceConversation.requestWakeLock().then(lock => {
-            this.wakeLock = lock;
-          });
-        }
-      };
-      document.addEventListener(
-        "visibilitychange",
-        this.visibilityChangeHandler
-      );
-    }
   }
 
   protected override async handleEndSession() {
-    this.cleanUp();
     this.playbackEventTarget?.removeListener(this.handlePlaybackEvent);
     this.playbackEventTarget = null;
     await super.handleEndSession();
-
-    if (this.visibilityChangeHandler) {
-      document.removeEventListener(
-        "visibilitychange",
-        this.visibilityChangeHandler
-      );
-    }
-
-    try {
-      await this.wakeLock?.release();
-      this.wakeLock = null;
-    } catch (_e) {}
-
+    await this.cleanUp();
     await this.input.close();
     await this.output.close();
   }

--- a/packages/client/src/platform/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/VoiceSessionSetup.ts
@@ -10,7 +10,7 @@ export type VoiceSessionSetupResult = {
   input: InputController;
   output: OutputController;
   playbackEventTarget: PlaybackEventTarget | null;
-  detach: () => void;
+  detach: () => Promise<void>;
 };
 
 export type VoiceSessionSetupStrategy = (
@@ -51,6 +51,6 @@ export function setupWebRTCSession(
     input: connection.input,
     output: connection.output,
     playbackEventTarget: null,
-    detach: () => {},
+    detach: async () => {},
   };
 }

--- a/packages/client/src/platform/web/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/web/VoiceSessionSetup.ts
@@ -12,6 +12,26 @@ import { WebRTCConnection } from "../../utils/WebRTCConnection.js";
 import { attachInputToConnection } from "../../utils/attachInputToConnection.js";
 import { attachConnectionToOutput } from "../../utils/attachConnectionToOutput.js";
 import { createConnection } from "../../utils/ConnectionFactory.js";
+import { applyDelay, resolveDelay } from "../../utils/applyDelay.js";
+import { isAndroidDevice, isIosDevice } from "./compatibility.js";
+
+function detectPlatform(): "android" | "ios" | "default" {
+  if (isAndroidDevice()) return "android";
+  if (isIosDevice()) return "ios";
+  return "default";
+}
+
+async function requestWakeLock(): Promise<WakeLockSentinel | null> {
+  if ("wakeLock" in navigator) {
+    // unavailable without HTTPS, including localhost in dev
+    try {
+      return await navigator.wakeLock.request("screen");
+    } catch (_e) {
+      // Wake Lock is not required for the conversation to work
+    }
+  }
+  return null;
+}
 
 /**
  * Sets up WebSocket-specific input and output controllers using
@@ -43,7 +63,7 @@ async function setupWebSocketIO(
     input,
     output,
     playbackEventTarget: output,
-    detach: () => {
+    detach: async () => {
       detachInput();
       detachOutput();
     },
@@ -52,20 +72,92 @@ async function setupWebSocketIO(
 
 /**
  * Web platform session setup strategy.
- * Creates a connection and sets up input/output based on the connection type.
+ * Handles wake lock, preliminary mic permission, platform-specific delay,
+ * connection creation, and input/output setup.
  */
 export async function webSessionSetup(
   options: Options
 ): Promise<VoiceSessionSetupResult> {
-  const connection = await createConnection(options);
+  const useWakeLock = options.useWakeLock ?? true;
+  let wakeLock: WakeLockSentinel | null = null;
+  let preliminaryInputStream: MediaStream | null = null;
 
-  if (connection instanceof WebSocketConnection) {
-    const io = await setupWebSocketIO(options, connection);
-    return { connection, ...io };
+  try {
+    if (useWakeLock) {
+      wakeLock = await requestWakeLock();
+    }
+
+    // Some browsers won't allow calling getSupportedConstraints or
+    // enumerateDevices before getting approval for microphone access.
+    preliminaryInputStream = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+    });
+
+    const platform = detectPlatform();
+    await applyDelay(resolveDelay(options.connectionDelay, platform));
+
+    const connection = await createConnection(options);
+
+    let io: Omit<VoiceSessionSetupResult, "connection">;
+    if (connection instanceof WebSocketConnection) {
+      io = await setupWebSocketIO(options, connection);
+    } else {
+      io = setupWebRTCSession(connection);
+    }
+
+    // Stop the preliminary stream after setting up the session.
+    // Its only purpose was triggering the browser's microphone permission
+    // prompt; it must remain alive until the strategy finishes because
+    // MediaDeviceInput.create (WebSocket path) needs mic access granted.
+    preliminaryInputStream?.getTracks().forEach(track => {
+      track.stop();
+    });
+    preliminaryInputStream = null;
+
+    // Set up visibility change handler for wake lock re-acquisition.
+    // Wake locks are automatically released when a page is hidden (e.g.
+    // switching tabs), so attempt to re-acquire when visible again.
+    let visibilityChangeHandler: (() => void) | null = null;
+    if (wakeLock) {
+      visibilityChangeHandler = () => {
+        if (document.visibilityState === "visible" && wakeLock?.released) {
+          requestWakeLock().then(lock => {
+            wakeLock = lock;
+          });
+        }
+      };
+      document.addEventListener("visibilitychange", visibilityChangeHandler);
+    }
+
+    const originalDetach = io.detach;
+    return {
+      connection,
+      ...io,
+      detach: async () => {
+        await originalDetach();
+        if (visibilityChangeHandler) {
+          document.removeEventListener(
+            "visibilitychange",
+            visibilityChangeHandler
+          );
+        }
+        try {
+          await wakeLock?.release();
+          wakeLock = null;
+        } catch (_e) {}
+      },
+    };
+  } catch (error) {
+    // Clean up on setup failure
+    preliminaryInputStream?.getTracks().forEach(track => {
+      track.stop();
+    });
+    try {
+      await wakeLock?.release();
+      wakeLock = null;
+    } catch (_e) {}
+    throw error;
   }
-
-  // WebRTC — platform-agnostic setup
-  return setupWebRTCSession(connection);
 }
 
 // Register the web strategy as the default

--- a/packages/client/src/platform/web/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/web/VoiceSessionSetup.ts
@@ -99,10 +99,15 @@ export async function webSessionSetup(
     const connection = await createConnection(options);
 
     let io: Omit<VoiceSessionSetupResult, "connection">;
-    if (connection instanceof WebSocketConnection) {
-      io = await setupWebSocketIO(options, connection);
-    } else {
-      io = setupWebRTCSession(connection);
+    try {
+      if (connection instanceof WebSocketConnection) {
+        io = await setupWebSocketIO(options, connection);
+      } else {
+        io = setupWebRTCSession(connection);
+      }
+    } catch (ioError) {
+      connection.close();
+      throw ioError;
     }
 
     // Stop the preliminary stream after setting up the session.

--- a/packages/react-native/src/index.react-native.ts
+++ b/packages/react-native/src/index.react-native.ts
@@ -55,8 +55,8 @@ async function reactNativeSessionSetup(
   const originalDetach = result.detach;
   return {
     ...result,
-    detach: () => {
-      originalDetach();
+    detach: async () => {
+      await originalDetach();
       AudioSession.stopAudioSession();
     },
   };

--- a/packages/react-native/src/index.react-native.ts
+++ b/packages/react-native/src/index.react-native.ts
@@ -56,8 +56,11 @@ async function reactNativeSessionSetup(
   return {
     ...result,
     detach: async () => {
-      await originalDetach();
-      AudioSession.stopAudioSession();
+      try {
+        await originalDetach();
+      } finally {
+        await AudioSession.stopAudioSession();
+      }
     },
   };
 }

--- a/packages/react-native/src/nativeVolume.ts
+++ b/packages/react-native/src/nativeVolume.ts
@@ -265,9 +265,9 @@ export function attachNativeVolume(
   const originalDetach = result.detach;
   return {
     ...result,
-    detach: () => {
+    detach: async () => {
       cleanup();
-      originalDetach();
+      await originalDetach();
     },
   };
 }


### PR DESCRIPTION
## Summary

- Move wake lock management, preliminary mic permission (`getUserMedia`), platform-specific delay, and visibility change handling from `VoiceConversation` into the web setup strategy
- `VoiceConversation` now has **zero DOM references** (`navigator`, `document`, `MediaStream`, `WakeLockSentinel` all removed)
- `detach` callback becomes `async` (`() => Promise<void>`) to support wake lock release on cleanup
- Restores previously-lost Android platform delay by detecting the platform in the web strategy via `compatibility.ts`
- Web setup strategy now handles its own error cleanup (wake lock release, preliminary stream stop) on failure

## Changes

| File | Change |
|------|--------|
| `VoiceConversation.ts` | Remove `requestWakeLock`, `visibilityChangeHandler`, `wakeLock` field, preliminary `getUserMedia`, `applyDelay`/`resolveDelay` — delegate everything to the setup strategy |
| `platform/VoiceSessionSetup.ts` | `detach` type → `() => Promise<void>`, `setupWebRTCSession` detach → `async` |
| `platform/web/VoiceSessionSetup.ts` | Absorb wake lock, preliminary mic permission, platform-specific delay, visibility change handler; add error cleanup; make all `detach` callbacks async |
| `react-native/index.react-native.ts` | Make `detach` async, `await originalDetach()` |

## Test plan

- [x] Web tsconfig (`tsconfig.web.json`) compiles cleanly
- [x] `VoiceConversation.ts` no longer appears in `tsconfig.common.json` errors
- [x] All 79 unit tests pass
- [ ] Browser tests pass (wake lock acquire/release, visibility re-acquisition, `useWakeLock: false`) — requires Playwright/Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves wake lock/mic permission/delay handling and cleanup into the web setup strategy and changes `detach` to async across platforms, which can affect session lifecycle and teardown ordering. Risk is moderate due to cross-platform behavioral changes in connection setup/cleanup (especially wake locks and delays).
> 
> **Overview**
> Refactors `VoiceConversation.startSession` to be platform-agnostic by delegating mic permission prompting, connection delays, wake lock management, and other DOM-related setup/teardown to the platform `setupStrategy`.
> 
> Updates the session setup contract so `VoiceSessionSetupResult.detach` is now `async`, and adjusts web and React Native strategies to perform full async cleanup (stop preliminary mic stream, close connections on IO setup failure, manage wake lock re-acquisition via `visibilitychange`, and ensure AudioSession/native volume teardown runs reliably). Restores Android-specific connection delay handling in the web strategy via platform detection (`compatibility.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea614b129bf18e3c56cdb78fdebccde8459ba2bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->