### PR TITLE
Add new environment for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Require approvals for releasing new versions of each package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code complexity, but it changes the release/publishing pipeline and could block or delay package publication if the `npm-publish` environment is misconfigured.
> 
> **Overview**
> Adds `environment: npm-publish` to the `Publish package` GitHub Actions workflow, enabling environment-based protections (e.g., required reviewers) to gate npm publishing on release events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5dbf8726d5066ff8ba0e4c7687fb53e1c78b5c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->