### PR TITLE
Fix remaining tsconfig.common.json type errors (Phase 7)

### DIFF
--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -5,7 +5,7 @@ import type {
   SessionConfig,
   FormatConfig,
 } from "./utils/BaseConnection.js";
-import { extractApiErrorMessage } from "./utils/errors.js";
+import { extractApiErrorMessage, isJsonObject } from "./utils/errors.js";
 import type { Conversation } from "./index.js";
 import type {
   AgentAudioEvent,
@@ -651,7 +651,11 @@ export abstract class BaseConversation {
       throw new Error(`Upload failed: ${response.status} ${message}`);
     }
 
-    const { file_id } = (await response.json()) as Record<string, unknown>;
+    const result: unknown = await response.json();
+    if (!isJsonObject(result)) {
+      throw new Error("Upload response is not a JSON object");
+    }
+    const { file_id } = result;
     if (typeof file_id !== "string" || !file_id) {
       throw new Error("Upload response is missing a valid file_id");
     }

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -5,7 +5,8 @@ import type {
   SessionConfig,
   FormatConfig,
 } from "./utils/BaseConnection.js";
-import { extractApiErrorMessage, isJsonObject } from "./utils/errors.js";
+import { assertJsonObject } from "./utils/assert.js";
+import { extractApiErrorMessage } from "./utils/errors.js";
 import type { Conversation } from "./index.js";
 import type {
   AgentAudioEvent,
@@ -652,9 +653,7 @@ export abstract class BaseConversation {
     }
 
     const result: unknown = await response.json();
-    if (!isJsonObject(result)) {
-      throw new Error("Upload response is not a JSON object");
-    }
+    assertJsonObject(result, "Upload response is not a JSON object");
     const { file_id } = result;
     if (typeof file_id !== "string" || !file_id) {
       throw new Error("Upload response is missing a valid file_id");

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -651,7 +651,7 @@ export abstract class BaseConversation {
       throw new Error(`Upload failed: ${response.status} ${message}`);
     }
 
-    const { file_id } = await response.json();
+    const { file_id } = (await response.json()) as Record<string, unknown>;
     if (typeof file_id !== "string" || !file_id) {
       throw new Error("Upload response is missing a valid file_id");
     }

--- a/packages/client/src/runtime.ts
+++ b/packages/client/src/runtime.ts
@@ -241,6 +241,23 @@ declare global {
   }
 
   // -------------------------------------------------------------------------
+  // Web Audio (minimal — only for deprecated getAnalyser() return type)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Minimal AnalyserNode declaration for the deprecated
+   * `InputController.getAnalyser()` / `OutputController.getAnalyser()`
+   * return types. On web this resolves to the full DOM AnalyserNode; on
+   * other platforms the methods return `undefined`.
+   */
+  interface AnalyserNode {
+    readonly frequencyBinCount: number;
+    getByteFrequencyData(array: Uint8Array): void;
+    getByteTimeDomainData(array: Uint8Array): void;
+    getFloatFrequencyData(array: Float32Array): void;
+  }
+
+  // -------------------------------------------------------------------------
   // Events (minimal interfaces for WebSocket event handler type annotations)
   // -------------------------------------------------------------------------
 

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -262,10 +262,10 @@ describe("WebRTCConnection", () => {
   describe("disconnection context", () => {
     async function createWithHandlers() {
       const mockRoom = new Room() as any;
-      const eventHandlers = new Map<string, Function>();
+      const eventHandlers = new Map<string, (...args: unknown[]) => void>();
 
       (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
-        (event: string, callback: Function) => {
+        (event: string, callback: (...args: unknown[]) => void) => {
           eventHandlers.set(event, callback);
           if (event === "connected") {
             queueMicrotask(() => callback());
@@ -273,7 +273,7 @@ describe("WebRTCConnection", () => {
         }
       );
       (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
-        (event: string, callback: Function) => {
+        (event: string, callback: (...args: unknown[]) => void) => {
           if (event === "signalConnected") {
             queueMicrotask(() => callback());
           }

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -4,7 +4,8 @@ import {
   type FormatConfig,
   parseFormat,
 } from "./BaseConnection.js";
-import { extractApiErrorMessage, isJsonObject } from "./errors.js";
+import { isJsonObject } from "./assert.js";
+import { extractApiErrorMessage } from "./errors.js";
 import { sourceInfo } from "../sourceInfo.js";
 import { isValidSocketEvent, type OutgoingSocketEvent } from "./events.js";
 import {

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -4,7 +4,7 @@ import {
   type FormatConfig,
   parseFormat,
 } from "./BaseConnection.js";
-import { extractApiErrorMessage } from "./errors.js";
+import { extractApiErrorMessage, isJsonObject } from "./errors.js";
 import { sourceInfo } from "../sourceInfo.js";
 import { isValidSocketEvent, type OutgoingSocketEvent } from "./events.js";
 import {
@@ -251,7 +251,10 @@ export class WebRTCConnection extends BaseConnection {
           );
         }
 
-        const data = (await response.json()) as { token: string };
+        const data: unknown = await response.json();
+        if (!isJsonObject(data) || typeof data.token !== "string") {
+          throw new Error("No conversation token received from API");
+        }
         conversationToken = data.token;
 
         if (!conversationToken) {

--- a/packages/client/src/utils/applyDelay.ts
+++ b/packages/client/src/utils/applyDelay.ts
@@ -17,6 +17,6 @@ export function resolveDelay(
 
 export async function applyDelay(delayMs: number) {
   if (delayMs > 0) {
-    await new Promise(resolve => setTimeout(resolve, delayMs));
+    await new Promise<void>(resolve => setTimeout(resolve, delayMs));
   }
 }

--- a/packages/client/src/utils/assert.ts
+++ b/packages/client/src/utils/assert.ts
@@ -1,0 +1,12 @@
+export function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function assertJsonObject(
+  value: unknown,
+  message = "Expected a JSON object"
+): asserts value is Record<string, unknown> {
+  if (!isJsonObject(value)) {
+    throw new Error(message);
+  }
+}

--- a/packages/client/src/utils/errors.ts
+++ b/packages/client/src/utils/errors.ts
@@ -1,13 +1,15 @@
+export function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
 export async function extractApiErrorMessage(
   response: Response
 ): Promise<string> {
   try {
-    const body = (await response.json()) as Record<string, unknown> | null;
-    const rawDetail = body?.detail;
-    const detail =
-      rawDetail != null && typeof rawDetail === "object"
-        ? (rawDetail as Record<string, unknown>).message
-        : rawDetail;
+    const body: unknown = await response.json();
+    if (!isJsonObject(body)) return response.statusText || "Unknown error";
+    const rawDetail = body.detail;
+    const detail = isJsonObject(rawDetail) ? rawDetail.message : rawDetail;
     if (typeof detail === "string") {
       return detail;
     }

--- a/packages/client/src/utils/errors.ts
+++ b/packages/client/src/utils/errors.ts
@@ -2,8 +2,12 @@ export async function extractApiErrorMessage(
   response: Response
 ): Promise<string> {
   try {
-    const body = await response.json();
-    const detail = body?.detail?.message ?? body?.detail;
+    const body = (await response.json()) as Record<string, unknown> | null;
+    const rawDetail = body?.detail;
+    const detail =
+      rawDetail != null && typeof rawDetail === "object"
+        ? (rawDetail as Record<string, unknown>).message
+        : rawDetail;
     if (typeof detail === "string") {
       return detail;
     }

--- a/packages/client/src/utils/errors.ts
+++ b/packages/client/src/utils/errors.ts
@@ -1,6 +1,4 @@
-export function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === "object" && !Array.isArray(value);
-}
+import { isJsonObject } from "./assert.js";
 
 export async function extractApiErrorMessage(
   response: Response

--- a/packages/client/src/utils/mergeOptions.ts
+++ b/packages/client/src/utils/mergeOptions.ts
@@ -1,6 +1,4 @@
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+import { isJsonObject as isPlainObject } from "./assert.js";
 
 function deepMerge<T extends Record<string, unknown>>(
   ...objects: Partial<T>[]


### PR DESCRIPTION
## Summary

- Declares a minimal `AnalyserNode` interface in `runtime.ts` for the deprecated `getAnalyser()` return type in `InputController`/`OutputController`
- Adds type assertions for `response.json()` calls in `BaseConversation` and `errors.ts` (returns `unknown` without DOM lib)
- Fixes `Promise<void>` typing in `applyDelay` to match the `setTimeout` callback signature
- Fixes pre-existing `Function` type lint error in `WebRTCConnection.test.ts`

After this change, `tsconfig.common.json` (without DOM lib) compiles with **zero errors**, completing the DOM API isolation effort started in Phase 0.

## Test plan

- [x] `tsc -p tsconfig.common.json --noEmit` — 0 errors
- [x] `tsc -p tsconfig.web.json --noEmit` — 0 errors
- [x] `pnpm turbo build` — all packages pass
- [x] `pnpm turbo lint` — passes (pre-existing test failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily TypeScript type-safety/ambient type additions and tighter JSON parsing guards, with minimal behavioral change limited to clearer errors on unexpected API responses.
> 
> **Overview**
> Finishes isolating DOM-specific types so `tsconfig.common.json` can compile without the DOM lib by adding a minimal `AnalyserNode` declaration in `runtime.ts` for deprecated `getAnalyser()` return types.
> 
> Hardens a few `response.json()` call sites (`BaseConversation.uploadFile`, `extractApiErrorMessage`, and `WebRTCConnection` token fetch) by treating JSON as `unknown` and validating object shape via a new `utils/assert.ts` helper, and reuses that helper in `mergeOptions`.
> 
> Cleans up remaining type errors by tightening promise typing in `applyDelay` and replacing `Function` with a typed callback signature in `WebRTCConnection.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33563143bf0dd3fb8eceae33780736efc4f3d3d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->