### PR TITLE
Add agent Vitest docs and Claude format hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -r -I {} pnpm exec prettier --write \"{}\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | xargs -r -I {} pnpm exec prettier --write \"{}\""
+            "command": "FILE=$(jq -r '.tool_input.file_path // empty') && [ -n \"$FILE\" ] && pnpm exec prettier --write \"$FILE\""
           }
         ]
       }

--- a/agents.md
+++ b/agents.md
@@ -2,26 +2,26 @@
 
 ## Running package tests with Vitest
 
-Run Vitest in headless mode for individual packages by using `vitest run` from the package that owns the tests.
+Run Vitest for individual packages from the package that owns the tests.
 
 ```sh
 cd packages/client
-pnpm exec vitest run
+pnpm exec vitest --browser.headless
 ```
 
 You can also run a single package from the repo root with a workspace filter:
 
 ```sh
-pnpm --filter @elevenlabs/client exec vitest run
-pnpm --filter @elevenlabs/react exec vitest run
-pnpm --filter @elevenlabs/convai-widget-core exec vitest run
+pnpm --filter @elevenlabs/client exec vitest --browser.headless
+pnpm --filter @elevenlabs/react exec vitest --browser.headless
+pnpm --filter @elevenlabs/convai-widget-core exec vitest --browser.headless
 ```
 
-To run a single test file headlessly, pass the file path after `run`:
+To run a single test file, pass the file path after `run`:
 
 ```sh
 cd packages/react
-pnpm exec vitest run src/conversation/ConversationClientTools.test.tsx
+pnpm exec vitest --browser.headless src/conversation/ConversationClientTools.test.tsx
 ```
 
-Prefer `vitest run` over the package `test` script when working as an agent so Vitest does not enter watch mode.
+Always pass `--browser.headless` to avoid launching a visible browser window.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,27 @@
+# Agent instructions
+
+## Running package tests with Vitest
+
+Run Vitest in headless mode for individual packages by using `vitest run` from the package that owns the tests.
+
+```sh
+cd packages/client
+pnpm exec vitest run
+```
+
+You can also run a single package from the repo root with a workspace filter:
+
+```sh
+pnpm --filter @elevenlabs/client exec vitest run
+pnpm --filter @elevenlabs/react exec vitest run
+pnpm --filter @elevenlabs/convai-widget-core exec vitest run
+```
+
+To run a single test file headlessly, pass the file path after `run`:
+
+```sh
+cd packages/react
+pnpm exec vitest run src/conversation/ConversationClientTools.test.tsx
+```
+
+Prefer `vitest run` over the package `test` script when working as an agent so Vitest does not enter watch mode.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `agents.md` with package-local Vitest headless test commands.
- Add a repo-scoped Claude Code hook that runs `pnpm exec prettier --write` after Claude writes or edits a file.

## Testing
- `pnpm exec prettier --write agents.md .claude/settings.json`
- `printf '%s' '{"tool_input":{"file_path":"agents.md"}}' | jq -r '.tool_input.file_path // empty' | xargs -r -I {} pnpm exec prettier --write "{}"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6ef0c87-4fea-4ece-bee5-1ee12e4fbf6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ef0c87-4fea-4ece-bee5-1ee12e4fbf6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

