### PR TITLE
[Agents] hide terms & conditions when toplevel setting is disabled

### DIFF
--- a/.changeset/widget-terms-kill-switch.md
+++ b/.changeset/widget-terms-kill-switch.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Treat null top-level `terms_html`/`terms_text` as a kill switch for the T&C modal. Previously, agents with the dashboard "Enable terms & conditions" toggle off but stale per-language preset terms would still show the modal because the widget always preferred `language_presets[lang].terms_html`. Per-language presets are now only consulted as overrides when the feature is enabled at top level.

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -240,6 +240,10 @@ export function useLocalizedTerms() {
   const { language } = useLanguageConfig();
 
   return useComputed(() => {
+    if (config.value.terms_html == null && config.value.terms_text == null) {
+      return { terms_html: undefined, terms_text: undefined, terms_key: undefined };
+    }
+
     const languagePreset = config.value.language_presets?.[language.value.languageCode];
 
     return {

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -970,4 +970,27 @@ describe("elevenlabs-convai", () => {
       FingerprintJS.load = originalLoad;
     });
   });
+
+  describe("terms kill switch", () => {
+    it("should not show terms modal when top-level terms are null even if language presets are set", async () => {
+      setupWebComponent({
+        "agent-id": "terms_disabled_with_stale_presets",
+        variant: "compact",
+      });
+
+      const startButton = page.getByRole("button", { name: "Start a call" });
+      await startButton.click();
+
+      await expect
+        .element(page.getByText("Stale preset terms"))
+        .not.toBeInTheDocument();
+      await expect
+        .element(page.getByRole("button", { name: "Accept" }))
+        .not.toBeInTheDocument();
+
+      await expect
+        .element(page.getByText("Agent response"))
+        .toBeInTheDocument();
+    });
+  });
 });

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -978,9 +978,10 @@ describe("elevenlabs-convai", () => {
         variant: "compact",
       });
 
-      const startButton = page.getByRole("button", { name: "Start a call" });
-      await startButton.click();
-
+      // The mocked agent has `default_expanded: true`, so the widget opens
+      // the chat directly without a "Start a call" button. If the kill
+      // switch works, no terms modal blocks the conversation and the
+      // agent's first message renders.
       await expect
         .element(page.getByText("Stale preset terms"))
         .not.toBeInTheDocument();

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -75,6 +75,20 @@ export const AGENTS = {
       },
     },
   },
+  terms_disabled_with_stale_presets: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    default_expanded: true,
+    terms_html: undefined,
+    terms_text: undefined,
+    supported_language_overrides: ["en"],
+    language_presets: {
+      en: {
+        terms_html: "<p>Stale preset terms</p>",
+        terms_text: "Stale preset terms",
+      },
+    },
+  },
   markdown: {
     ...BASIC_CONFIG,
     text_only: true,

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -79,8 +79,11 @@ export const AGENTS = {
     ...BASIC_CONFIG,
     text_only: true,
     default_expanded: true,
-    terms_html: undefined,
-    terms_text: undefined,
+    // Production serialises the kill switch as `null`, not `undefined`.
+    // HttpResponse.json -> JSON.stringify strips `undefined`, so using
+    // `null` keeps the mock faithful to the wire payload.
+    terms_html: null,
+    terms_text: null,
     supported_language_overrides: ["en"],
     language_presets: {
       en: {

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -45,8 +45,8 @@ export interface WidgetConfig {
   } | null;
   language: Language;
   supported_language_overrides?: Language[];
-  terms_html?: string;
-  terms_text?: string;
+  terms_html?: string | null;
+  terms_text?: string | null;
   terms_key?: string;
   mic_muting_enabled: boolean;
   transcript_enabled: boolean;
@@ -63,8 +63,8 @@ export interface WidgetConfig {
       {
         text_contents?: Partial<TextContents>;
         first_message?: string;
-        terms_html?: string;
-        terms_text?: string;
+        terms_html?: string | null;
+        terms_text?: string | null;
         terms_key?: string;
       }
     >


### PR DESCRIPTION
## Why

The convai widget showed the terms & conditions modal even when an agent had T&C disabled in the dashboard. Repro: any agent where the dashboard "Enable terms & conditions" switch was turned off after previously being enabled — top-level `terms_html`/`terms_text` come through as `null`, but `language_presets[lang].terms_html` is left populated from before. Example payload (German preset still set):

```json
"terms_text": null,
"terms_html": null,
"language_presets": {
  "de": { "terms_html": "<h4>Geschäftsbedingungen</h4>…" },
  "en": { "terms_html": "<p>This service is provided…</p>" }
}
```

`useLocalizedTerms` resolved `languagePreset.terms_html ?? config.terms_html`, so the per-language preset always won and the T&C modal fired on every conversation start regardless of the dashboard toggle.

This PR makes the widget respect the top-level kill switch as the source of truth.

## What
- take Top-level fields as the source of truth, matching the dashboard's `LabelSwitch` which is bound to `widget.terms_text !== null`. 
- `useLocalizedTerms` short-circuits and returns `{ undefined, undefined, undefined }` when both top-level `terms_html` and `terms_text` are `null`/`undefined`. Per-language presets are only consulted as overrides when the feature is enabled at top level.
- Uses `== null` so `""` (the dashboard's freshly-toggled-on "enabled but empty" state) still falls through to the preset fallback — only an explicit `null` suppresses presets.


## Test

- New `terms_disabled_with_stale_presets` mock in `mocks/browser.ts` mirrors the bug shape: top-level terms unset, `en` preset populated.
- New `describe("terms kill switch")` in `index.test.ts` asserts the modal text and Accept button do not appear after clicking Start, and the agent's first message renders.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gating logic for the Terms & Conditions modal, which can affect when users are prompted to accept legal terms. Risk is moderate because it alters conversation start flow based on config nullability and preset overrides.
> 
> **Overview**
> Fixes a bug where the widget could still display the Terms & Conditions modal when the dashboard toggle was off by treating top-level `terms_html`/`terms_text` being `null` as an explicit kill switch in `useLocalizedTerms` (ignoring `language_presets` in that case).
> 
> Updates `WidgetConfig` types to allow `null` terms fields, adds an MSW mock agent with stale per-language terms, and adds a browser test asserting the modal and Accept button do not render when the kill switch is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64175e85c56a2a4d2c08b80dfbdd57010d42c7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->