### PR TITLE
[Agents] Fix iOS first-message audio drop on WebSocket voice sessions

### DIFF
--- a/.changeset/fix-ios-first-message-audio.md
+++ b/.changeset/fix-ios-first-message-audio.md
@@ -1,0 +1,16 @@
+---
+"@elevenlabs/client": patch
+---
+
+Fix iOS Safari dropping the first message's audio on WebSocket voice sessions.
+
+iOS Safari blocks `HTMLAudioElement` autoplay (including elements fed by `MediaStreamDestination`) when the underlying `AudioContext` wasn't started synchronously inside a user gesture, and additionally needs the audio element to have an explicit `play()` call against a non-empty playback graph. The web setup chain awaits `getUserMedia`, the connection handshake, and the audio worklet load before `MediaDeviceOutput` would have created its `AudioContext`, so by then the gesture is already consumed. The first agent message would arrive into a suspended context and never play; subsequent messages worked because the mic capture had reactivated iOS's audio session by then.
+
+The fix has two parts:
+
+- On import, the web entry point installs capture-phase `touchstart`/`touchend`/`click` listeners on `document`. The first user interaction creates and unlocks an `AudioContext` (silent `BufferSource.start(0)` + `resume()`) and stashes it for the next session. The stash auto-discards after 30s if no session starts. Capture-phase is needed because the convai widget awaits a terms-modal promise between the user's tap and `Conversation.startSession`, which would otherwise consume the gesture before any session code runs.
+- After the worklet is wired up, `MediaDeviceOutput` on iOS posts ~100ms of silence to the worklet and explicitly calls `audioElement.play()` to prime the MediaStream → HTMLAudioElement pipeline.
+
+Non-iOS is unchanged: it still lazily creates the context with the requested sample-rate constraint and does not register the document listeners.
+
+WebRTC voice sessions are unaffected by this change.

--- a/packages/client/src/platform/web/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/web/VoiceSessionSetup.ts
@@ -14,6 +14,10 @@ import { attachConnectionToOutput } from "../../utils/attachConnectionToOutput.j
 import { createConnection } from "../../utils/ConnectionFactory.js";
 import { applyDelay, resolveDelay } from "../../utils/applyDelay.js";
 import { isAndroidDevice, isIosDevice } from "./compatibility.js";
+import {
+  discardStashedAudioContext,
+  takeUnlockedAudioContext,
+} from "./audioUnlock.js";
 
 function detectPlatform(): "android" | "ios" | "default" {
   if (isAndroidDevice()) return "android";
@@ -39,7 +43,8 @@ async function requestWakeLock(): Promise<WakeLockSentinel | null> {
  */
 async function setupWebSocketIO(
   options: Options,
-  connection: WebSocketConnection
+  connection: WebSocketConnection,
+  audioContext: AudioContext | null
 ): Promise<Omit<VoiceSessionSetupResult, "connection">> {
   const [input, output] = await Promise.all([
     MediaDeviceInput.create({
@@ -53,6 +58,7 @@ async function setupWebSocketIO(
       ...connection.outputFormat,
       outputDeviceId: options.outputDeviceId,
       workletPaths: options.workletPaths,
+      audioContext: audioContext ?? undefined,
     }),
   ]);
 
@@ -81,6 +87,7 @@ export async function webSessionSetup(
   const useWakeLock = options.useWakeLock ?? true;
   let wakeLock: WakeLockSentinel | null = null;
   let preliminaryInputStream: MediaStream | null = null;
+  let unlockedAudioContext: AudioContext | null = null;
 
   try {
     if (useWakeLock) {
@@ -101,14 +108,23 @@ export async function webSessionSetup(
     let result: VoiceSessionSetupResult;
     try {
       if (connection instanceof WebSocketConnection) {
+        unlockedAudioContext = takeUnlockedAudioContext();
         result = {
           connection,
-          ...(await setupWebSocketIO(options, connection)),
+          ...(await setupWebSocketIO(
+            options,
+            connection,
+            unlockedAudioContext
+          )),
         };
+        // Ownership transferred to MediaDeviceOutput.
+        unlockedAudioContext = null;
       } else {
         result = setupWebRTCSession(connection);
       }
     } catch (ioError) {
+      await unlockedAudioContext?.close().catch(() => {});
+      unlockedAudioContext = null;
       connection.close();
       throw ioError;
     }
@@ -167,6 +183,7 @@ export async function webSessionSetup(
       await wakeLock?.release();
       wakeLock = null;
     } catch (_e) {}
+    discardStashedAudioContext();
     throw error;
   }
 }

--- a/packages/client/src/platform/web/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/web/VoiceSessionSetup.ts
@@ -120,6 +120,9 @@ export async function webSessionSetup(
         // Ownership transferred to MediaDeviceOutput.
         unlockedAudioContext = null;
       } else {
+        // WebRTC doesn't use the unlocked context — discard the stash so it
+        // doesn't sit until the TTL fires.
+        discardStashedAudioContext();
         result = setupWebRTCSession(connection);
       }
     } catch (ioError) {

--- a/packages/client/src/platform/web/audioUnlock.test.ts
+++ b/packages/client/src/platform/web/audioUnlock.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./compatibility.js", () => ({
+  isIosDevice: vi.fn(() => true),
+}));
+
+import { isIosDevice } from "./compatibility.js";
+import {
+  discardStashedAudioContext,
+  installIosAudioUnlockListener,
+  takeUnlockedAudioContext,
+  unlockIosAudioForSession,
+} from "./audioUnlock.js";
+
+describe("unlockIosAudioForSession", () => {
+  beforeEach(() => {
+    vi.mocked(isIosDevice).mockReturnValue(true);
+    vi.stubGlobal(
+      "AudioContext",
+      vi.fn(function MockAudioContext(this: {
+        createBuffer: ReturnType<typeof vi.fn>;
+        createBufferSource: ReturnType<typeof vi.fn>;
+        destination: object;
+        resume: ReturnType<typeof vi.fn>;
+        close: ReturnType<typeof vi.fn>;
+      }) {
+        this.createBuffer = vi.fn(() => ({}));
+        this.createBufferSource = vi.fn(() => ({
+          buffer: null,
+          connect: vi.fn(),
+          start: vi.fn(),
+        }));
+        this.destination = {};
+        this.resume = vi.fn().mockResolvedValue(undefined);
+        this.close = vi.fn().mockResolvedValue(undefined);
+      })
+    );
+  });
+
+  afterEach(() => {
+    discardStashedAudioContext();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null from take when not on iOS", () => {
+    vi.mocked(isIosDevice).mockReturnValue(false);
+
+    unlockIosAudioForSession();
+
+    expect(takeUnlockedAudioContext()).toBeNull();
+  });
+
+  it("stashes an AudioContext on iOS until taken", () => {
+    unlockIosAudioForSession();
+    const ctx = takeUnlockedAudioContext();
+
+    expect(ctx).not.toBeNull();
+    expect(takeUnlockedAudioContext()).toBeNull();
+  });
+
+  it("does not stash a second context when called twice", () => {
+    unlockIosAudioForSession();
+    unlockIosAudioForSession();
+
+    expect(takeUnlockedAudioContext()).not.toBeNull();
+    expect(takeUnlockedAudioContext()).toBeNull();
+  });
+
+  it("discardStashedAudioContext clears an untaken stash", () => {
+    unlockIosAudioForSession();
+
+    discardStashedAudioContext();
+
+    expect(takeUnlockedAudioContext()).toBeNull();
+  });
+});
+
+describe("installIosAudioUnlockListener", () => {
+  beforeEach(() => {
+    vi.mocked(isIosDevice).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registers capture-phase gesture listeners on iOS", () => {
+    const addEventListener = vi.fn();
+    vi.stubGlobal("document", { addEventListener });
+
+    installIosAudioUnlockListener();
+
+    expect(addEventListener).toHaveBeenCalledTimes(3);
+    expect(addEventListener).toHaveBeenCalledWith(
+      "touchstart",
+      expect.any(Function),
+      true
+    );
+  });
+});

--- a/packages/client/src/platform/web/audioUnlock.ts
+++ b/packages/client/src/platform/web/audioUnlock.ts
@@ -1,0 +1,87 @@
+import { isIosDevice } from "./compatibility.js";
+
+const STASH_TTL_MS = 30_000;
+const UNLOCK_EVENTS = ["touchstart", "touchend", "click"] as const;
+
+let stashedAudioContext: AudioContext | null = null;
+let discardTimer: ReturnType<typeof setTimeout> | null = null;
+let unlockListenerInstalled = false;
+
+function unlockAudioContext(ctx: AudioContext): void {
+  const buffer = ctx.createBuffer(1, 1, 22050);
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(ctx.destination);
+  source.start(0);
+  void ctx.resume().catch(() => {});
+}
+
+function scheduleStashDiscard(): void {
+  if (discardTimer) {
+    clearTimeout(discardTimer);
+  }
+  discardTimer = setTimeout(() => {
+    discardTimer = null;
+    discardStashedAudioContext();
+  }, STASH_TTL_MS);
+}
+
+function clearStashDiscardTimer(): void {
+  if (!discardTimer) {
+    return;
+  }
+  clearTimeout(discardTimer);
+  discardTimer = null;
+}
+
+/** Unlock iOS audio during a user gesture. No-op on non-iOS. */
+export function unlockIosAudioForSession(): void {
+  if (!isIosDevice() || stashedAudioContext) {
+    return;
+  }
+
+  const ctx = new AudioContext();
+  unlockAudioContext(ctx);
+  stashedAudioContext = ctx;
+  scheduleStashDiscard();
+}
+
+/**
+ * Listen for the first user interaction on the page and unlock iOS audio in
+ * the capture phase, before application click handlers run. Covers callers
+ * (such as the convai widget) that `await` before `Conversation.startSession`.
+ */
+export function installIosAudioUnlockListener(): void {
+  if (
+    !isIosDevice() ||
+    unlockListenerInstalled ||
+    typeof document === "undefined"
+  ) {
+    return;
+  }
+
+  unlockListenerInstalled = true;
+  const onUserGesture = () => {
+    unlockIosAudioForSession();
+  };
+
+  for (const event of UNLOCK_EVENTS) {
+    document.addEventListener(event, onUserGesture, true);
+  }
+}
+
+export function takeUnlockedAudioContext(): AudioContext | null {
+  const ctx = stashedAudioContext;
+  stashedAudioContext = null;
+  clearStashDiscardTimer();
+  return ctx;
+}
+
+export function discardStashedAudioContext(): void {
+  if (!stashedAudioContext) {
+    return;
+  }
+  void stashedAudioContext.close().catch(() => {});
+  stashedAudioContext = null;
+  clearStashDiscardTimer();
+}

--- a/packages/client/src/platform/web/index.ts
+++ b/packages/client/src/platform/web/index.ts
@@ -1,6 +1,13 @@
 // Side-effect: registers the web voice session setup strategy
 import "./VoiceSessionSetup.js";
 
+// Side-effect: arms iOS audio unlock on first user gesture (no-op on other
+// platforms). Needed because the convai widget awaits other promises (terms
+// modal etc.) between the user's tap and Conversation.startSession, by which
+// point the gesture has been consumed.
+import { installIosAudioUnlockListener } from "./audioUnlock.js";
+installIosAudioUnlockListener();
+
 // Side-effect: registers the web audio adapter for WebRTC connections
 import { setWebRTCAudioAdapterFactory } from "../../WebRTCAudioAdapter.js";
 import { WebAudioAdapter } from "./webAudioAdapter.js";

--- a/packages/client/src/platform/web/output.ts
+++ b/packages/client/src/platform/web/output.ts
@@ -13,6 +13,38 @@ import {
   createAnalyserVolumeProvider,
   type VolumeProvider,
 } from "./volumeProvider.js";
+import { isIosDevice } from "./compatibility.js";
+
+function maybePrimeIosPlayback({
+  sampleRate,
+  format,
+  worklet,
+  audioElement,
+}: {
+  sampleRate: number;
+  format: FormatConfig["format"];
+  worklet: AudioWorkletNode;
+  audioElement: HTMLAudioElement;
+}): void {
+  if (!isIosDevice()) {
+    return;
+  }
+
+  // ~100ms of silence is enough to flush the worklet → MediaStream → audio
+  // element pipeline so iOS treats the element as "playing media" and won't
+  // stall the first real audio chunk.
+  const PRIME_DURATION_MS = 100;
+  const primeFrameCount = Math.floor((sampleRate * PRIME_DURATION_MS) / 1000);
+  const silentBuffer =
+    format === "ulaw"
+      ? new Uint8Array(primeFrameCount)
+      : new Int16Array(primeFrameCount);
+  worklet.port.postMessage({
+    type: "buffer",
+    buffer: silentBuffer.buffer,
+  });
+  void audioElement.play().catch(() => {});
+}
 
 export class MediaDeviceOutput
   implements OutputController, PlaybackEventTarget
@@ -23,17 +55,22 @@ export class MediaDeviceOutput
     outputDeviceId,
     workletPaths,
     libsampleratePath,
+    audioContext,
   }: FormatConfig &
     OutputConfig &
-    AudioWorkletConfig): Promise<MediaDeviceOutput> {
-    let context: AudioContext | null = null;
+    AudioWorkletConfig & {
+      audioContext?: AudioContext;
+    }): Promise<MediaDeviceOutput> {
+    let context: AudioContext | null = audioContext ?? null;
     let audioElement: HTMLAudioElement | null = null;
     try {
       const supportsSampleRateConstraint =
         navigator.mediaDevices.getSupportedConstraints().sampleRate;
-      context = new AudioContext(
-        supportsSampleRateConstraint ? { sampleRate } : {}
-      );
+      if (!context) {
+        context = new AudioContext(
+          supportsSampleRateConstraint ? { sampleRate } : {}
+        );
+      }
 
       const analyser = context.createAnalyser();
       const gain = context.createGain();
@@ -71,6 +108,8 @@ export class MediaDeviceOutput
       worklet.connect(gain);
 
       await context.resume();
+
+      maybePrimeIosPlayback({ sampleRate, format, worklet, audioElement });
 
       // Set initial output device if provided
       if (outputDeviceId && audioElement.setSinkId) {

--- a/packages/client/src/platform/web/output.ts
+++ b/packages/client/src/platform/web/output.ts
@@ -35,9 +35,13 @@ function maybePrimeIosPlayback({
   // stall the first real audio chunk.
   const PRIME_DURATION_MS = 100;
   const primeFrameCount = Math.floor((sampleRate * PRIME_DURATION_MS) / 1000);
+  // μ-law silence is 0xFF, not 0x00. The worklet decodes 0x00 to ~-32124
+  // (near full-scale negative DC), which would emit a loud pop instead of
+  // priming with silence. PCM silence is plain zero, so the zero-filled
+  // Int16Array is correct as-is.
   const silentBuffer =
     format === "ulaw"
-      ? new Uint8Array(primeFrameCount)
+      ? new Uint8Array(primeFrameCount).fill(0xff)
       : new Int16Array(primeFrameCount);
   worklet.port.postMessage({
     type: "buffer",

--- a/packages/client/src/utils/WebSocketConnection.test.ts
+++ b/packages/client/src/utils/WebSocketConnection.test.ts
@@ -125,4 +125,47 @@ describe("WebSocketConnection", () => {
       vi.useRealTimers();
     });
   });
+
+  it("buffers audio events until a listener is attached", async () => {
+    const connection = await createConnection();
+    const listener = vi.fn();
+
+    emit("message", {
+      data: JSON.stringify({
+        type: "audio",
+        audio_event: {
+          audio_base_64: "dGVzdA==",
+          event_id: 1,
+        },
+      }),
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+
+    connection.addListener(listener);
+
+    expect(listener).toHaveBeenCalledWith({
+      audio_base_64: "dGVzdA==",
+    });
+  });
+
+  it("clears buffered audio when the connection closes", async () => {
+    const connection = await createConnection();
+    const listener = vi.fn();
+
+    emit("message", {
+      data: JSON.stringify({
+        type: "audio",
+        audio_event: {
+          audio_base_64: "dGVzdA==",
+          event_id: 1,
+        },
+      }),
+    });
+
+    connection.close();
+    connection.addListener(listener);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
 });

--- a/packages/client/src/utils/WebSocketConnection.ts
+++ b/packages/client/src/utils/WebSocketConnection.ts
@@ -13,7 +13,11 @@ import {
 } from "./events.js";
 import { constructOverrides } from "./overrides.js";
 import { SessionConnectionError } from "./errors.js";
-import type { OutputEventTarget, OutputListener } from "../OutputController.js";
+import type {
+  OutputEventTarget,
+  OutputListener,
+  OutputAudioEvent,
+} from "../OutputController.js";
 
 const MAIN_PROTOCOL = "convai";
 const WSS_API_ORIGIN = "wss://api.elevenlabs.io";
@@ -28,6 +32,7 @@ export class WebSocketConnection
   public readonly outputFormat: FormatConfig;
 
   private outputListeners: Set<OutputListener> = new Set();
+  private pendingAudioEvents: OutputAudioEvent[] = [];
 
   private constructor(
     private readonly socket: WebSocket,
@@ -213,6 +218,7 @@ export class WebSocketConnection
   }
 
   public close() {
+    this.pendingAudioEvents = [];
     this.socket.close(1000, "User ended conversation");
   }
 
@@ -221,7 +227,16 @@ export class WebSocketConnection
   }
 
   public addListener(listener: OutputListener): void {
+    const hadListeners = this.outputListeners.size > 0;
     this.outputListeners.add(listener);
+    if (hadListeners || this.pendingAudioEvents.length === 0) {
+      return;
+    }
+    const pending = this.pendingAudioEvents;
+    this.pendingAudioEvents = [];
+    for (const event of pending) {
+      listener(event);
+    }
   }
 
   public removeListener(listener: OutputListener): void {
@@ -236,6 +251,10 @@ export class WebSocketConnection
       const audioEvent = {
         audio_base_64: parsedEvent.audio_event.audio_base_64,
       };
+      if (this.outputListeners.size === 0) {
+        this.pendingAudioEvents.push(audioEvent);
+        return;
+      }
       this.outputListeners.forEach(listener => listener(audioEvent));
     }
   }


### PR DESCRIPTION
## Why

On iOS, the widget's first agent message plays no audio — the transcript appears but nothing is heard. Subsequent messages work normally.

Two race conditions in the setup chain line up on the first message:

1. **The AudioContext is created several `await`s after the user tap** (mic permission, WebSocket handshake, worklet load). iOS Safari requires audio to start as a direct result of a user gesture, so by the time the context exists the gesture has expired and iOS keeps it suspended — the audio element fed by it stays silent.
2. **First audio chunks can arrive before any listener is attached.** `WebSocketConnection` could receive the first agent audio events between the connection opening and `attachConnectionToOutput` wiring up the output. Those chunks were silently dropped.

Once the user speaks back, iOS reactivates the audio session for the mic capture, which also resumes playback — which is why later messages were fine.

## What

- New `platform/web/audioUnlock.ts`: at module import on iOS, install capture-phase `touchstart` / `touchend` / `click` listeners on `document`. The first user interaction creates and unlocks an `AudioContext` (silent `BufferSource.start(0)` + `resume()`) and stashes it for up to 30s so the next session can claim it.
- `webSessionSetup` takes the stashed context on the WebSocket path and hands ownership to `MediaDeviceOutput`. WebRTC / error paths discard it.
- `MediaDeviceOutput.create` accepts an optional pre-created `audioContext`. After the worklet is connected, on iOS it posts ~100ms of silence and calls `audioElement.play()` explicitly so the MediaStream → audio element pipeline is recognised as actively playing media.
- `WebSocketConnection` now buffers audio events when no listener is attached and drains them to the first listener that arrives. Cleared on close.

Non-iOS and WebRTC voice sessions are unchanged.

## Test

- Manually verified on iOS Safari

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes web audio initialization and event buffering logic in the WebSocket voice path, which can affect playback timing and resource cleanup across browsers.
> 
> **Overview**
> Fixes iOS Safari dropping the first agent audio in WebSocket voice sessions by **pre-unlocking and reusing an `AudioContext` created during the first user gesture** and passing it into `MediaDeviceOutput` during `webSessionSetup`.
> 
> On iOS, `MediaDeviceOutput` now **primes playback** after the worklet is ready by posting ~100ms of silence (format-aware, including μ-law) and explicitly calling `audioElement.play()`. `WebSocketConnection` now **buffers incoming audio events until an output listener is attached** (and clears the buffer on `close()`), preventing early audio chunks from being lost. Non-iOS and WebRTC paths are intended to be unchanged, and the release is documented as a patch via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4c9e440de2fb7bf47afc63e0254549a4b5f203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->