### PR TITLE
[React Native] Add serverUrl param for in-VPC WebRTC deployments

### DIFF
--- a/examples/react-native-expo/.env.example
+++ b/examples/react-native-expo/.env.example
@@ -2,6 +2,7 @@
 EXPO_PUBLIC_AGENT_ID=
 
 # Optional: point to a self-hosted / in-VPC bridge instead of ElevenLabs cloud.
-# Sets both the token endpoint origin and the LiveKit server URL.
+# WebRTC-only: sets both the token endpoint origin and the LiveKit server URL.
+# Ignored for WebSocket sessions.
 # Example: EXPO_PUBLIC_SERVER_URL=https://bridge.vpc.example.com
 EXPO_PUBLIC_SERVER_URL=

--- a/examples/react-native-expo/.env.example
+++ b/examples/react-native-expo/.env.example
@@ -1,2 +1,7 @@
 # Set your ElevenLabs Agent ID here
 EXPO_PUBLIC_AGENT_ID=
+
+# Optional: point to a self-hosted / in-VPC bridge instead of ElevenLabs cloud.
+# Sets both the token endpoint origin and the LiveKit server URL.
+# Example: EXPO_PUBLIC_SERVER_URL=https://bridge.vpc.example.com
+EXPO_PUBLIC_SERVER_URL=

--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -58,6 +58,9 @@ const ConversationScreen = () => {
       connectionType,
       userId: "demo-user",
       textOnly: isTextOnly || undefined,
+      ...(process.env.EXPO_PUBLIC_SERVER_URL && {
+        serverUrl: process.env.EXPO_PUBLIC_SERVER_URL,
+      }),
     });
   };
 

--- a/examples/react-native-expo/App.tsx
+++ b/examples/react-native-expo/App.tsx
@@ -58,9 +58,10 @@ const ConversationScreen = () => {
       connectionType,
       userId: "demo-user",
       textOnly: isTextOnly || undefined,
-      ...(process.env.EXPO_PUBLIC_SERVER_URL && {
-        serverUrl: process.env.EXPO_PUBLIC_SERVER_URL,
-      }),
+      ...(connectionType === "webrtc" &&
+        process.env.EXPO_PUBLIC_SERVER_URL && {
+          serverUrl: process.env.EXPO_PUBLIC_SERVER_URL,
+        }),
     });
   };
 

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -30,6 +30,15 @@ export type BaseSessionConfig = {
   origin?: string;
   authorization?: string;
   livekitUrl?: string;
+  /**
+   * Convenience URL for self-hosted / in-VPC WebRTC deployments. Derives both
+   * the token endpoint origin and the LiveKit WebSocket URL from a single base
+   * URL (e.g. `https://bridge.vpc.example.com` or `http://localhost:7880` for
+   * local dev). Explicit `origin` or `livekitUrl` values always take
+   * precedence. Only honoured by WebRTC connections; has no effect on WebSocket
+   * sessions.
+   */
+  serverUrl?: string;
   overrides?: {
     agent?: {
       prompt?: ConversationConfigOverrideAgentPrompt;

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -415,6 +415,27 @@ describe("WebRTCConnection", () => {
       );
     });
 
+    it("converts wss:// serverUrl to https:// for token and keeps wss:// for LiveKit", async () => {
+      const mockRoom = new Room() as any;
+      setupRoomEvents(mockRoom);
+      const fetchMock = mockTokenFetch();
+
+      await WebRTCConnection.create({
+        agentId: "test-agent",
+        serverUrl: "wss://bridge.vpc.example.com",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "https://bridge.vpc.example.com/v1/convai/conversation/token"
+        )
+      );
+      expect(mockRoom.connect).toHaveBeenCalledWith(
+        "wss://bridge.vpc.example.com",
+        "mock-livekit-token"
+      );
+    });
+
     it("explicit origin takes precedence over serverUrl for token fetch", async () => {
       const mockRoom = new Room() as any;
       setupRoomEvents(mockRoom);

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
 // Track mock calls using a global object that can be accessed after mocking
 const mockCalls = {
@@ -332,13 +332,11 @@ describe("WebRTCConnection", () => {
   });
 
   describe("serverUrl resolution", () => {
-    function setupRoomEvents(mockRoom: ReturnType<typeof Room>) {
-      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
-        (event: string, callback: () => void) => {
-          if (event === "connected") queueMicrotask(callback);
-        }
-      );
-      (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+    function setupRoomEvents(mockRoom: { on: Mock; once: Mock }) {
+      mockRoom.on.mockImplementation((event: string, callback: () => void) => {
+        if (event === "connected") queueMicrotask(callback);
+      });
+      mockRoom.once.mockImplementation(
         (event: string, callback: () => void) => {
           if (event === "signalConnected") queueMicrotask(callback);
         }

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -394,6 +394,27 @@ describe("WebRTCConnection", () => {
       );
     });
 
+    it("converts ws:// serverUrl to http:// for token and keeps ws:// for LiveKit", async () => {
+      const mockRoom = new Room() as any;
+      setupRoomEvents(mockRoom);
+      const fetchMock = mockTokenFetch();
+
+      await WebRTCConnection.create({
+        agentId: "test-agent",
+        serverUrl: "ws://localhost:7880",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "http://localhost:7880/v1/convai/conversation/token"
+        )
+      );
+      expect(mockRoom.connect).toHaveBeenCalledWith(
+        "ws://localhost:7880",
+        "mock-livekit-token"
+      );
+    });
+
     it("explicit origin takes precedence over serverUrl for token fetch", async () => {
       const mockRoom = new Room() as any;
       setupRoomEvents(mockRoom);

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -331,6 +331,110 @@ describe("WebRTCConnection", () => {
     });
   });
 
+  describe("serverUrl resolution", () => {
+    function setupRoomEvents(mockRoom: ReturnType<typeof Room>) {
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "connected") queueMicrotask(callback);
+        }
+      );
+      (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "signalConnected") queueMicrotask(callback);
+        }
+      );
+    }
+
+    function mockTokenFetch() {
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ token: "mock-livekit-token" }),
+      } as Response);
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
+    it("fetches token from serverUrl origin and connects LiveKit to wss equivalent", async () => {
+      const mockRoom = new Room() as any;
+      setupRoomEvents(mockRoom);
+      const fetchMock = mockTokenFetch();
+
+      await WebRTCConnection.create({
+        agentId: "test-agent",
+        serverUrl: "https://bridge.vpc.example.com",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "https://bridge.vpc.example.com/v1/convai/conversation/token"
+        )
+      );
+      expect(mockRoom.connect).toHaveBeenCalledWith(
+        "wss://bridge.vpc.example.com",
+        "mock-livekit-token"
+      );
+    });
+
+    it("converts http:// serverUrl to ws:// for LiveKit and keeps http:// for token", async () => {
+      const mockRoom = new Room() as any;
+      setupRoomEvents(mockRoom);
+      const fetchMock = mockTokenFetch();
+
+      await WebRTCConnection.create({
+        agentId: "test-agent",
+        serverUrl: "http://localhost:7880",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "http://localhost:7880/v1/convai/conversation/token"
+        )
+      );
+      expect(mockRoom.connect).toHaveBeenCalledWith(
+        "ws://localhost:7880",
+        "mock-livekit-token"
+      );
+    });
+
+    it("explicit origin takes precedence over serverUrl for token fetch", async () => {
+      const mockRoom = new Room() as any;
+      setupRoomEvents(mockRoom);
+      const fetchMock = mockTokenFetch();
+
+      await WebRTCConnection.create({
+        agentId: "test-agent",
+        serverUrl: "https://bridge.vpc.example.com",
+        origin: "https://custom-origin.example.com",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "https://custom-origin.example.com/v1/convai/conversation/token"
+        )
+      );
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("bridge.vpc.example.com")
+      );
+    });
+
+    it("explicit livekitUrl takes precedence over serverUrl for LiveKit connection", async () => {
+      const mockRoom = new Room() as any;
+      setupRoomEvents(mockRoom);
+      mockTokenFetch();
+
+      await WebRTCConnection.create({
+        agentId: "test-agent",
+        serverUrl: "https://bridge.vpc.example.com",
+        livekitUrl: "wss://custom-livekit.example.com",
+      });
+
+      expect(mockRoom.connect).toHaveBeenCalledWith(
+        "wss://custom-livekit.example.com",
+        "mock-livekit-token"
+      );
+    });
+  });
+
   it.each([
     { textOnly: true, shouldEnableMic: false },
     { textOnly: false, shouldEnableMic: true },

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -41,9 +41,14 @@ const DEFAULT_LIVEKIT_WS_URL = "wss://livekit.rtc.elevenlabs.io";
 const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
 const AUDIO_VOLUME_THRESHOLD = 0.01;
 
-// Convert WSS origin to HTTPS for API calls
+// Convert WS(S) origin to HTTP(S) for API calls
 function convertWssToHttps(origin: string): string {
-  return origin.replace(/^wss:\/\//, "https://");
+  return origin.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+}
+
+// Convert HTTP(S) URL to WS(S) for LiveKit connections
+function convertToWss(url: string): string {
+  return url.replace(/^https:\/\//, "wss://").replace(/^http:\/\//, "ws://");
 }
 
 export type ConnectionConfig = SessionConfig & {
@@ -230,6 +235,17 @@ export class WebRTCConnection extends BaseConnection {
   ): Promise<WebRTCConnection> {
     let conversationToken: string;
 
+    // serverUrl is a convenience that derives both the token origin and LiveKit
+    // URL from one base URL. Explicit origin/livekitUrl always take precedence.
+    const resolvedOrigin =
+      config.origin ??
+      (config.serverUrl != null
+        ? convertWssToHttps(config.serverUrl)
+        : undefined);
+    const resolvedLivekitUrl =
+      config.livekitUrl ??
+      (config.serverUrl != null ? convertToWss(config.serverUrl) : undefined);
+
     // Handle different authentication scenarios
     if ("conversationToken" in config && config.conversationToken) {
       // Direct token provided
@@ -238,7 +254,7 @@ export class WebRTCConnection extends BaseConnection {
       // Agent ID provided - fetch token from API
       try {
         const { name: source, version } = sourceInfo;
-        const configOrigin = config.origin ?? HTTPS_API_ORIGIN;
+        const configOrigin = resolvedOrigin ?? HTTPS_API_ORIGIN;
         const origin = convertWssToHttps(configOrigin); //origin is wss, not https
         let url = `${origin}/v1/convai/conversation/token?agent_id=${config.agentId}&source=${source}&version=${version}`;
         if (config.environment) {
@@ -300,7 +316,7 @@ export class WebRTCConnection extends BaseConnection {
       );
 
       // Use configurable LiveKit URL or default if not provided
-      const livekitUrl = config.livekitUrl || DEFAULT_LIVEKIT_WS_URL;
+      const livekitUrl = resolvedLivekitUrl ?? DEFAULT_LIVEKIT_WS_URL;
 
       // Enable microphone on SignalConnected (before room.connect resolves).
       // The server may wait for the client to publish audio before fully

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -41,11 +41,6 @@ const DEFAULT_LIVEKIT_WS_URL = "wss://livekit.rtc.elevenlabs.io";
 const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
 const AUDIO_VOLUME_THRESHOLD = 0.01;
 
-// Convert WSS origin to HTTPS for API calls
-function convertWssToHttps(origin: string): string {
-  return origin.replace(/^wss:\/\//, "https://");
-}
-
 // Convert HTTP(S) URL to WS(S) for LiveKit connections
 function convertToWss(url: string): string {
   return url.replace(/^https:\/\//, "wss://").replace(/^http:\/\//, "ws://");

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -244,10 +244,10 @@ export class WebRTCConnection extends BaseConnection {
     // URL from one base URL. Explicit origin/livekitUrl always take precedence.
     const resolvedOrigin =
       config.origin ??
-      (config.serverUrl != null ? convertToHttps(config.serverUrl) : undefined);
+      (config.serverUrl ? convertToHttps(config.serverUrl) : undefined);
     const resolvedLivekitUrl =
       config.livekitUrl ??
-      (config.serverUrl != null ? convertToWss(config.serverUrl) : undefined);
+      (config.serverUrl ? convertToWss(config.serverUrl) : undefined);
 
     // Handle different authentication scenarios
     if ("conversationToken" in config && config.conversationToken) {

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -258,7 +258,7 @@ export class WebRTCConnection extends BaseConnection {
       try {
         const { name: source, version } = sourceInfo;
         const configOrigin = resolvedOrigin ?? HTTPS_API_ORIGIN;
-        const origin = convertWssToHttps(configOrigin); //origin is wss, not https
+        const origin = convertToHttps(configOrigin); // normalize ws(s):// and http(s):// to http(s):// for token fetch
         let url = `${origin}/v1/convai/conversation/token?agent_id=${config.agentId}&source=${source}&version=${version}`;
         if (config.environment) {
           url += `&environment=${encodeURIComponent(config.environment)}`;

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -51,6 +51,11 @@ function convertToWss(url: string): string {
   return url.replace(/^https:\/\//, "wss://").replace(/^http:\/\//, "ws://");
 }
 
+// Convert any WS(S) or HTTP(S) URL to HTTP(S) for API calls
+function convertToHttps(url: string): string {
+  return url.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+}
+
 export type ConnectionConfig = SessionConfig & {
   onDebug?: (info: unknown) => void;
 };
@@ -239,9 +244,7 @@ export class WebRTCConnection extends BaseConnection {
     // URL from one base URL. Explicit origin/livekitUrl always take precedence.
     const resolvedOrigin =
       config.origin ??
-      (config.serverUrl != null
-        ? convertWssToHttps(config.serverUrl)
-        : undefined);
+      (config.serverUrl != null ? convertToHttps(config.serverUrl) : undefined);
     const resolvedLivekitUrl =
       config.livekitUrl ??
       (config.serverUrl != null ? convertToWss(config.serverUrl) : undefined);
@@ -316,7 +319,7 @@ export class WebRTCConnection extends BaseConnection {
       );
 
       // Use configurable LiveKit URL or default if not provided
-      const livekitUrl = resolvedLivekitUrl ?? DEFAULT_LIVEKIT_WS_URL;
+      const livekitUrl = resolvedLivekitUrl || DEFAULT_LIVEKIT_WS_URL;
 
       // Enable microphone on SignalConnected (before room.connect resolves).
       // The server may wait for the client to publish audio before fully

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -41,9 +41,9 @@ const DEFAULT_LIVEKIT_WS_URL = "wss://livekit.rtc.elevenlabs.io";
 const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
 const AUDIO_VOLUME_THRESHOLD = 0.01;
 
-// Convert WS(S) origin to HTTP(S) for API calls
+// Convert WSS origin to HTTPS for API calls
 function convertWssToHttps(origin: string): string {
-  return origin.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+  return origin.replace(/^wss:\/\//, "https://");
 }
 
 // Convert HTTP(S) URL to WS(S) for LiveKit connections


### PR DESCRIPTION
## Summary

Adds a serverUrl param to the SDK — point it at your bridge (e.g. "https://bridge.vpc.example.com") and it derives both the token fetch and LiveKit URL automatically. Can proceed in parallel with WebRTC <> WebSockets bridge; Pelago will need this published before deploying the bridge in their VPC.

- Adds `serverUrl?: string` to `BaseSessionConfig` — a single URL that simultaneously configures the token-fetch origin and the LiveKit WebSocket URL for self-hosted / in-VPC bridges
- `WebRTCConnection.create()` derives `resolvedOrigin` (HTTP/HTTPS) and `resolvedLivekitUrl` (WS/WSS) from `serverUrl` via symmetric helpers `convertToHttps` / `convertToWss`; explicit `origin` / `livekitUrl` always take precedence
- Handles all four input protocols: `https://` → `wss://`, `http://` → `ws://`, `wss://` → `https://` (token) + pass-through (LiveKit), `ws://` → `http://` (token) + pass-through (LiveKit)
- Updates `examples/react-native-expo/App.tsx` to pick up `EXPO_PUBLIC_SERVER_URL` so VPC deployments can be tested without code changes
- Documents in JSDoc that `serverUrl` is WebRTC-only (WebSocket sessions use `origin` directly)

## Motivation

Pelago Health (in-VPC customer) uses the React Native SDK with a self-hosted LiveKit bridge. Previously they had to configure `origin` (token endpoint) and `livekitUrl` (LiveKit WS URL) separately. `serverUrl` derives both from one base URL.

## Test plan

**Automated (CI) — all passing:**
- [x] `https://` serverUrl → token fetched from `https://`, LiveKit connects to `wss://`
- [x] `http://` serverUrl → token fetched from `http://`, LiveKit connects to `ws://`
- [x] `ws://` serverUrl → token fetched from `http://` (not a broken `ws://` fetch URL), LiveKit connects to `ws://`
- [x] Explicit `origin` overrides `serverUrl` for token fetch
- [x] Explicit `livekitUrl` overrides `serverUrl` for LiveKit connection

**Manual — no regression:**
- [x] Run Expo example app without `EXPO_PUBLIC_SERVER_URL` set → cloud session connects as before

**VPC E2E — deferred to Step 3 (requires bridge from Step 2):**
- [ ] Set `EXPO_PUBLIC_SERVER_URL=https://<bridge-host>`, confirm token fetched from that origin and LiveKit connects to `wss://<bridge-host>`

## Plan

This is Step 1 of 3 for WebRTC / React Native in-VPC support (customer: Pelago Health).

**Step 1 — this PR:** Add `serverUrl` to the SDK so the React Native app can point at a self-hosted LiveKit bridge.

**Step 2 — extend the SIP bridge for WebRTC:**
- Add a `/v1/convai/conversation/token` HTTP endpoint to `elevenlabs-agents-on-prem-sip-connector` so the SDK can mint LiveKit JWTs
- Make agent config dynamic from LiveKit room metadata (Pelago has 4+ agents; the current bridge uses a single static `AGENT_CONFIG`)
- One shared bridge instance handles all agents via per-session dynamic variables in the system prompt

**Step 3 — Pelago E2E:**
- Publish updated SDK package
- Pelago integrates `serverUrl` pointing at their EC2 bridge
- End-to-end call test: mobile app → LiveKit bridge (EC2) → VPC orchestrator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebRTC connection URL resolution and token fetch origins; mistakes could misroute VPC traffic, though defaults and explicit overrides preserve existing cloud behavior.
> 
> **Overview**
> Adds optional **`serverUrl`** on session config so WebRTC clients can target a **self-hosted / in-VPC bridge** with one base URL instead of setting **`origin`** and **`livekitUrl`** separately.
> 
> **`WebRTCConnection.create()`** now resolves token HTTP(S) origin and LiveKit WS(S) URL from `serverUrl` via **`convertToHttps`** / **`convertToWss`**, with explicit **`origin`** / **`livekitUrl`** still winning. Token fetch normalization covers **http(s) and ws(s)** inputs (replacing the older wss→https-only helper).
> 
> The **React Native Expo** example documents **`EXPO_PUBLIC_SERVER_URL`** and passes **`serverUrl`** into **`startSession`** only for **WebRTC**. New unit tests lock in protocol mapping and override precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d8081c0905ab8d02c4e984336a0522328988aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->