### PR TITLE
Configurable audio input chunk length and default 25ms instead of 100ms

### DIFF
--- a/.changeset/reduce-audio-chunk-length-10ms.md
+++ b/.changeset/reduce-audio-chunk-length-10ms.md
@@ -1,6 +1,6 @@
 ---
-"@elevenlabs/client": patch
+"@elevenlabs/client": minor
 "@elevenlabs/react": patch
 ---
 
-Reduce audio input chunk length from 100ms to 10ms for lower latency.
+Make microphone input chunk duration configurable via `inputChunkDurationMs` (default 25ms).

--- a/.changeset/reduce-audio-chunk-length-10ms.md
+++ b/.changeset/reduce-audio-chunk-length-10ms.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react": patch
+---
+
+Reduce audio input chunk length from 100ms to 10ms for lower latency.

--- a/packages/client/src/InputController.ts
+++ b/packages/client/src/InputController.ts
@@ -1,5 +1,8 @@
 import type { FormatConfig } from "./utils/BaseConnection.js";
 
+/** Default microphone audio chunk duration sent to the agent (WebSocket path). */
+export const DEFAULT_INPUT_CHUNK_DURATION_MS = 25;
+
 export type InputDeviceConfig = {
   inputDeviceId?: string;
   preferHeadphonesForIosDevices?: boolean;
@@ -7,6 +10,11 @@ export type InputDeviceConfig = {
 
 export type InputConfig = InputDeviceConfig & {
   onError?(message: string, context?: unknown): void;
+  /**
+   * Duration of each microphone audio chunk sent to the agent, in milliseconds.
+   * Only applies to the WebSocket input path (AudioWorklet). Default: 25.
+   */
+  inputChunkDurationMs?: number;
 };
 
 export type InputMessageEvent = MessageEvent<[Uint8Array, number]>;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -23,6 +23,7 @@ export type {
   InputDeviceConfig,
   InputConfig,
 } from "./InputController.js";
+export { DEFAULT_INPUT_CHUNK_DURATION_MS } from "./InputController.js";
 export type {
   OutputController,
   OutputDeviceConfig,

--- a/packages/client/src/platform/web/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/web/VoiceSessionSetup.ts
@@ -51,6 +51,7 @@ async function setupWebSocketIO(
       ...connection.inputFormat,
       preferHeadphonesForIosDevices: options.preferHeadphonesForIosDevices,
       inputDeviceId: options.inputDeviceId,
+      inputChunkDurationMs: options.inputChunkDurationMs,
       workletPaths: options.workletPaths,
       libsampleratePath: options.libsampleratePath,
     }),

--- a/packages/client/src/platform/web/input.ts
+++ b/packages/client/src/platform/web/input.ts
@@ -3,12 +3,13 @@ import type { FormatConfig } from "../../utils/BaseConnection.js";
 import { isIosDevice } from "./compatibility.js";
 import type { AudioWorkletConfig } from "../../BaseConversation.js";
 import { addLibsamplerateModule } from "./addLibsamplerateModule.js";
-import type {
-  InputController,
-  InputDeviceConfig,
-  InputConfig,
-  InputEventTarget,
-  InputListener,
+import {
+  DEFAULT_INPUT_CHUNK_DURATION_MS,
+  type InputController,
+  type InputDeviceConfig,
+  type InputConfig,
+  type InputEventTarget,
+  type InputListener,
 } from "../../InputController.js";
 import {
   createAnalyserVolumeProvider,
@@ -33,6 +34,7 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
     workletPaths,
     libsampleratePath,
     onError,
+    inputChunkDurationMs = DEFAULT_INPUT_CHUNK_DURATION_MS,
   }: FormatConfig &
     InputConfig &
     AudioWorkletConfig): Promise<MediaDeviceInput> {
@@ -89,7 +91,12 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
 
       const source = context.createMediaStreamSource(inputStream);
       const worklet = new AudioWorkletNode(context, "rawAudioProcessor");
-      worklet.port.postMessage({ type: "setFormat", format, sampleRate });
+      worklet.port.postMessage({
+        type: "setFormat",
+        format,
+        sampleRate,
+        chunkDurationMs: inputChunkDurationMs,
+      });
 
       source.connect(analyser);
       analyser.connect(worklet);
@@ -215,9 +222,10 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
       // Extract inputDeviceId from config
       const inputDeviceId = config?.inputDeviceId;
 
-      // Note: sampleRate, format, and preferHeadphonesForIosDevices cannot be
-      // changed on an existing input (would require recreating the AudioContext).
-      // These options are only used during initial MediaDeviceInput.create()
+      // Note: sampleRate, format, inputChunkDurationMs, and
+      // preferHeadphonesForIosDevices cannot be changed on an existing input
+      // (would require recreating the AudioContext). These options are only used
+      // during initial MediaDeviceInput.create()
 
       // Create new constraints with the specified device or use default
       const options: MediaTrackConstraints = {

--- a/packages/client/src/platform/web/rawAudioProcessor.generated.ts
+++ b/packages/client/src/platform/web/rawAudioProcessor.generated.ts
@@ -56,7 +56,7 @@ class RawAudioProcessor extends AudioWorkletProcessor {
         case "setFormat":
           this.isMuted = false;
           this.buffer = []; // Initialize an empty buffer
-          this.bufferSize = data.sampleRate / 10;
+          this.bufferSize = data.sampleRate / 100;
           this.format = data.format;
 
           if (globalThis.LibSampleRate && sampleRate !== data.sampleRate) {

--- a/packages/client/src/platform/web/rawAudioProcessor.generated.ts
+++ b/packages/client/src/platform/web/rawAudioProcessor.generated.ts
@@ -56,7 +56,11 @@ class RawAudioProcessor extends AudioWorkletProcessor {
         case "setFormat":
           this.isMuted = false;
           this.buffer = []; // Initialize an empty buffer
-          this.bufferSize = data.sampleRate / 100;
+          const chunkDurationMs = data.chunkDurationMs ?? 25;
+          this.bufferSize = Math.max(
+            1,
+            Math.round((data.sampleRate * chunkDurationMs) / 1000)
+          );
           this.format = data.format;
 
           if (globalThis.LibSampleRate && sampleRate !== data.sampleRate) {

--- a/packages/client/worklets/rawAudioProcessor.js
+++ b/packages/client/worklets/rawAudioProcessor.js
@@ -50,7 +50,7 @@ class RawAudioProcessor extends AudioWorkletProcessor {
         case "setFormat":
           this.isMuted = false;
           this.buffer = []; // Initialize an empty buffer
-          this.bufferSize = data.sampleRate / 10;
+          this.bufferSize = data.sampleRate / 100;
           this.format = data.format;
 
           if (globalThis.LibSampleRate && sampleRate !== data.sampleRate) {

--- a/packages/client/worklets/rawAudioProcessor.js
+++ b/packages/client/worklets/rawAudioProcessor.js
@@ -50,7 +50,11 @@ class RawAudioProcessor extends AudioWorkletProcessor {
         case "setFormat":
           this.isMuted = false;
           this.buffer = []; // Initialize an empty buffer
-          this.bufferSize = data.sampleRate / 100;
+          const chunkDurationMs = data.chunkDurationMs ?? 25;
+          this.bufferSize = Math.max(
+            1,
+            Math.round((data.sampleRate * chunkDurationMs) / 1000)
+          );
           this.format = data.format;
 
           if (globalThis.LibSampleRate && sampleRate !== data.sampleRate) {


### PR DESCRIPTION
Lower raw audio worklet buffer threshold to 25ms so mic chunks are sent to the agent more frequently for lower latency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time uplink buffering and message frequency on the WebSocket voice path; misconfigured values could affect latency or server load, but defaults are conservative and the option is create-time only.
> 
> **Overview**
> Adds **`inputChunkDurationMs`** on the WebSocket microphone path so callers can control how long each mic chunk is before it is sent to the agent (default **25ms**, exported as `DEFAULT_INPUT_CHUNK_DURATION_MS`).
> 
> The **raw audio AudioWorklet** no longer uses a fixed `sampleRate / 10` (~100ms) buffer; it sets `bufferSize` from `chunkDurationMs` (with a minimum of one sample). **`MediaDeviceInput`** and **`VoiceSessionSetup`** pass the option through on session setup; it cannot be changed after create without recreating the input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c01886741c20cb5598642670ec8a984b2627ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->