### PR TITLE
fix(types): correct PingEvent.ping_ms type to allow null values (#820)

### DIFF
--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -467,7 +467,7 @@ export interface Ping {
 
 export interface PingEvent {
   event_id: number;
-  ping_ms?: number;
+  ping_ms?: number | null;
 }
 
 export interface AsrInitiationMetadata {

--- a/packages/types/generated/types/incoming.ts
+++ b/packages/types/generated/types/incoming.ts
@@ -18,6 +18,7 @@ export type {
   McpConnectionStatusClientEvent,
   McpToolCallClientEvent,
   PartialTranscriptMessage,
+  Ping,
   PingEvent,
   ScribeAuthErrorMessage,
   ScribeChunkSizeExceededErrorMessage,

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -1132,8 +1132,9 @@ components:
         event_id:
           type: integer
         ping_ms:
-          type: integer
-          nullable: true
+          anyOf:
+            - type: integer
+            - type: "null"
           description: Estimated round-trip time in milliseconds
 
     ASRInitiationMetadataPayload:


### PR DESCRIPTION
## Summary

- `PingEvent.ping_ms` was typed as `number | undefined` but the ElevenLabs
  WebSocket API sends `null` when round-trip time is not yet measured,
  causing a type error at consumer call sites
- Root cause: `@asyncapi/modelina`'s TypeScriptGenerator silently ignores
  `nullable: true`; fix updates the schema to use the JSON Schema draft 7
  `anyOf` nullable pattern that modelina handles correctly
- `Ping` (the top-level `{ type: "ping", ping_event: PingEvent }` wrapper)
  was also missing from the `incoming.ts` barrel export

## Changes

- `packages/types/schemas/agent.asyncapi.yaml`: replace `nullable: true` with
  `anyOf: [{type: integer}, {type: "null"}]` on `PingData.ping_ms`
- `packages/types/generated/types/asyncapi-types.ts`: `ping_ms?: number` → `ping_ms?: number | null`
- `packages/types/generated/types/incoming.ts`: add `Ping` to barrel export

Fixes #820

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated type and schema-only changes for ping/latency fields; no runtime or security logic.
> 
> **Overview**
> Aligns generated **ping** WebSocket types with the API when round-trip time is not available yet.
> 
> `PingEvent.ping_ms` is now typed as `number | null` (not only optional `number`) so payloads that send `null` type-check at consumers. The AsyncAPI source for `PingData.ping_ms` switches from `nullable: true` to a JSON Schema **`anyOf`** (`integer` | `null`) so `@asyncapi/modelina` emits null correctly.
> 
> The **`Ping`** wrapper type is also added to the `incoming.ts` barrel export alongside `PingEvent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af774b3b0d57651d42a3a6b6ea105c319261113a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->