### PR TITLE
[Widget] Align trigger controls

### DIFF
--- a/.changeset/tidy-widgets-align.md
+++ b/.changeset/tidy-widgets-align.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix compact and full trigger control alignment.

--- a/packages/convai-widget-core/src/styles/index.css
+++ b/packages/convai-widget-core/src/styles/index.css
@@ -27,6 +27,10 @@
     sans-serif;
 
   scrollbar-color: #e5e7eb transparent;
+
+  button {
+    margin: 0;
+  }
 }
 
 @layer utilities {

--- a/packages/convai-widget-core/src/widget/FullExpandableTrigger.tsx
+++ b/packages/convai-widget-core/src/widget/FullExpandableTrigger.tsx
@@ -32,9 +32,9 @@ export function FullExpandableTrigger({
     >
       <SizeTransition
         visible={!expanded.value && isDisconnected.value}
-        className="p-1 !min-w-60"
+        className="p-1 w-full"
       >
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-60">
           <Avatar />
           <div className="text-sm max-w-64">{text.main_label}</div>
         </div>


### PR DESCRIPTION
## Summary
- Reset widget button margins so host/dev page button styles do not push compact controls off-center.
- Make the full trigger header fill the transition row and keep its minimum width on the actual header content.


## Test plan
- Verified compact and full trigger alignment in the local widget playground.
- Commit hook ran the workspace lint/build pipeline successfully.
- Focused browser Vitest did not run because the local Playwright Chromium binary is missing.

before

<img width="1102" height="1916" alt="CleanShot 2026-06-04 at 02 06 09@2x" src="https://github.com/user-attachments/assets/ad57e141-bf07-448c-a8f3-99d0d40f814b" />

after
<img width="1102" height="500" alt="CleanShot 2026-06-04 at 02 25 37@2x" src="https://github.com/user-attachments/assets/e508ecc7-f9e3-4525-a114-4663c17b795a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS and layout class tweaks in the widget package with no auth, data, or API changes.
> 
> **Overview**
> Fixes **compact and full** convai widget trigger alignment when embedded on pages that style `button` elements.
> 
> Widget host styles now **zero out button margins** inside `.dev-host` / `:host`, so inherited host CSS no longer shifts trigger controls off-center. For the **full** expandable trigger, the collapsed header row uses **`w-full`** on the size-transition wrapper while **`min-w-60`** moves to the inner avatar/label row so width constraints apply to the content, not the transition container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51fb5c928ab9ef41ed051ed950074586b99e2841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->