### PR TITLE
Add changelog for external_agent_joint and agent_typing events, and typing indicator

### DIFF
--- a/.changeset/orange-wolves-rhyme.md
+++ b/.changeset/orange-wolves-rhyme.md
@@ -1,0 +1,11 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/convai-widget-core": minor
+---
+
+Add support for external_agent_joined and agent_typing events.
+
+These events are send when an external agent takes over from the ai agent,
+and when an agent is currently typing, respectively.
+
+Show an "Agent is typing ..." indicator when the external agent is typing.


### PR DESCRIPTION
Add changelog for external_agent_joint and agent_typing events, and typing indicator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changeset with no runtime code changes in this PR.
> 
> **Overview**
> Adds a **changeset** for minor releases of `@elevenlabs/client` and `@elevenlabs/convai-widget-core` that documents new conversation events and UI behavior.
> 
> The changelog describes **`external_agent_joined`** (handoff when a human/external agent replaces the AI) and **`agent_typing`** (typing state from the agent), plus an **“Agent is typing ...”** indicator in the widget when an external agent is typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8cc1f0b9a6cc20472ba62fd4899b5d1eec530e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->