### PR TITLE
feat(client): add `@elevenlabs/client/internal/unity` sub-path export for Unity SDK WebGL bridge

### DIFF
--- a/.changeset/client-internal-unity-export.md
+++ b/.changeset/client-internal-unity-export.md
@@ -1,0 +1,8 @@
+---
+"@elevenlabs/client": minor
+---
+
+Add `@elevenlabs/client/internal/unity` sub-path export for the Unity SDK's WebGL bridge.
+
+- New `./internal/unity` entrypoint exposing `MediaDeviceInput`, `MediaDeviceOutput`, `attachInputToConnection`, `attachConnectionToOutput`, and `setWebRTCAudioAdapterFactory` as runtime values, plus `WebRTCAudioAdapter`, `AnalysisResult`, `MediaDeviceInputConfig`, `MediaDeviceOutputConfig`, and `WebRTCConnectionConfig` as type-only exports.
+- New named type aliases `MediaDeviceInputConfig`, `MediaDeviceOutputConfig`, and `WebRTCConnectionConfig` (the last replaces the previous `ConnectionConfig`, which is kept as a deprecated alias).

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -58,11 +58,11 @@ For the full API reference including connection types, client tools, conversatio
 
 ## Entrypoints
 
-| Path                                | Stability             |
-| ----------------------------------- | --------------------- |
-| `@elevenlabs/client`                | Public, semver-stable |
-| `@elevenlabs/client/internal`       | No semver guarantees  |
-| `@elevenlabs/client/internal/unity` | No semver guarantees  |
+| Path                                | Stability                      |
+| ----------------------------------- | ------------------------------ |
+| `@elevenlabs/client`                | Public, semver-stable          |
+| `@elevenlabs/client/internal`       | Internal, no semver guarantees |
+| `@elevenlabs/client/internal/unity` | Internal, no semver guarantees |
 
 ## Development
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -48,6 +48,29 @@ await conversation.endSession();
 
 For the full API reference including connection types, client tools, conversation overrides, and more, see the [JavaScript SDK documentation](https://elevenlabs.io/docs/eleven-agents/libraries/java-script).
 
+## Entrypoints
+
+| Path | Stability | Audience |
+|---|---|---|
+| `@elevenlabs/client` | Public, semver-stable | All users |
+| `@elevenlabs/client/internal` | No semver guarantees | SDK internals + advanced consumers |
+| `@elevenlabs/client/internal/unity` | No semver guarantees | The [ElevenLabs Unity SDK](https://github.com/elevenlabs/unity)'s WebGL bridge |
+
+### `@elevenlabs/client/internal/unity`
+
+This sub-path exports a curated set of low-level primitives consumed by the
+Unity SDK's WebGL bridge.  It is **not intended for general use** — the surface
+may change in any release without a major-version bump.
+
+The Unity bridge bypasses `Conversation` / `VoiceConversation` entirely and
+drives three smaller objects directly (`WebSocketConnection` /
+`WebRTCConnection`, `MediaDeviceInput`, `MediaDeviceOutput`).  This entrypoint
+exposes exactly what the bridge needs without pulling unrelated SDK code into a
+size-sensitive WebGL bundle.
+
+See [Plan B](https://github.com/elevenlabs/unity/blob/main/Docs~/plans/plan-b.md)
+for the full rationale and the corresponding Unity-side cleanup steps.
+
 ## Development
 
 Please refer to the README.md file in the root of this repository.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -29,13 +29,21 @@ const conversation = await Conversation.startSession({
   onDisconnect: () => {
     console.log("Disconnected");
   },
-  onMessage: (message) => {
+  onMessage: message => {
     console.log("Message:", message);
   },
-  onAgentResponseCorrection: ({ original_agent_response, corrected_agent_response }) => {
-    console.log("Agent response corrected:", original_agent_response, "->", corrected_agent_response);
+  onAgentResponseCorrection: ({
+    original_agent_response,
+    corrected_agent_response,
+  }) => {
+    console.log(
+      "Agent response corrected:",
+      original_agent_response,
+      "->",
+      corrected_agent_response
+    );
   },
-  onError: (message) => {
+  onError: message => {
     console.error("Error:", message);
   },
 });
@@ -50,26 +58,15 @@ For the full API reference including connection types, client tools, conversatio
 
 ## Entrypoints
 
-| Path | Stability | Audience |
-|---|---|---|
-| `@elevenlabs/client` | Public, semver-stable | All users |
-| `@elevenlabs/client/internal` | No semver guarantees | SDK internals + advanced consumers |
-| `@elevenlabs/client/internal/unity` | No semver guarantees | The [ElevenLabs Unity SDK](https://github.com/elevenlabs/unity)'s WebGL bridge |
+| Path                                | Stability             | Audience                                                                       |
+| ----------------------------------- | --------------------- | ------------------------------------------------------------------------------ |
+| `@elevenlabs/client`                | Public, semver-stable | All users                                                                      |
+| `@elevenlabs/client/internal`       | No semver guarantees  | SDK internals + advanced consumers                                             |
+| `@elevenlabs/client/internal/unity` | No semver guarantees  | The [ElevenLabs Unity SDK](https://github.com/elevenlabs/unity)'s WebGL bridge |
 
 ### `@elevenlabs/client/internal/unity`
 
-This sub-path exports a curated set of low-level primitives consumed by the
-Unity SDK's WebGL bridge.  It is **not intended for general use** — the surface
-may change in any release without a major-version bump.
-
-The Unity bridge bypasses `Conversation` / `VoiceConversation` entirely and
-drives three smaller objects directly (`WebSocketConnection` /
-`WebRTCConnection`, `MediaDeviceInput`, `MediaDeviceOutput`).  This entrypoint
-exposes exactly what the bridge needs without pulling unrelated SDK code into a
-size-sensitive WebGL bundle.
-
-See [Plan B](https://github.com/elevenlabs/unity/blob/main/Docs~/plans/plan-b.md)
-for the full rationale and the corresponding Unity-side cleanup steps.
+Low-level primitives used by the [ElevenLabs Unity SDK](https://github.com/elevenlabs/unity)'s WebGL bridge. **Not intended for general use.**
 
 ## Development
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -58,15 +58,11 @@ For the full API reference including connection types, client tools, conversatio
 
 ## Entrypoints
 
-| Path                                | Stability             | Audience                                                                       |
-| ----------------------------------- | --------------------- | ------------------------------------------------------------------------------ |
-| `@elevenlabs/client`                | Public, semver-stable | All users                                                                      |
-| `@elevenlabs/client/internal`       | No semver guarantees  | SDK internals + advanced consumers                                             |
-| `@elevenlabs/client/internal/unity` | No semver guarantees  | The [ElevenLabs Unity SDK](https://github.com/elevenlabs/unity)'s WebGL bridge |
-
-### `@elevenlabs/client/internal/unity`
-
-Low-level primitives used by the [ElevenLabs Unity SDK](https://github.com/elevenlabs/unity)'s WebGL bridge. **Not intended for general use.**
+| Path                                | Stability             |
+| ----------------------------------- | --------------------- |
+| `@elevenlabs/client`                | Public, semver-stable |
+| `@elevenlabs/client/internal`       | No semver guarantees  |
+| `@elevenlabs/client/internal/unity` | No semver guarantees  |
 
 ## Development
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,10 +12,7 @@
       "default": "./dist/index.js"
     },
     "./internal": "./dist/internal.js",
-    "./internal/unity": {
-      "types": "./dist/internal/unity.d.ts",
-      "default": "./dist/internal/unity.js"
-    }
+    "./internal/unity": "./dist/internal/unity.js"
   },
   "scripts": {
     "generate-version": "node ../../scripts/generate-version.mjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,11 @@
       "browser": "./dist/platform/web/index.js",
       "default": "./dist/index.js"
     },
-    "./internal": "./dist/internal.js"
+    "./internal": "./dist/internal.js",
+    "./internal/unity": {
+      "types": "./dist/internal/unity.d.ts",
+      "default": "./dist/internal/unity.js"
+    }
   },
   "scripts": {
     "generate-version": "node ../../scripts/generate-version.mjs",

--- a/packages/client/src/internal/unity.ts
+++ b/packages/client/src/internal/unity.ts
@@ -1,0 +1,79 @@
+/**
+ * @internal
+ *
+ * `@elevenlabs/client/internal/unity`
+ *
+ * A curated, low-level surface of `@elevenlabs/client` shaped to the needs of
+ * the [ElevenLabs Unity SDK](https://github.com/elevenlabs/unity)'s WebGL
+ * bridge.
+ *
+ * ## Stability contract
+ *
+ * This entrypoint carries **no semver guarantees**.  It is stable only for the
+ * Unity SDK's own use.  Any external consumer must accept that additions,
+ * removals, or renames may happen in any release without a major-version bump.
+ *
+ * ## Why it exists
+ *
+ * On WebGL the Unity SDK's C# `Conversation` type delegates to this library
+ * via an Emscripten jslib bridge.  The bridge bypasses `Conversation` /
+ * `VoiceConversation` entirely and drives three smaller objects directly:
+ *
+ * ```
+ * C# Conversation
+ *   ├── IConnection           → wraps WebSocketConnection / WebRTCConnection
+ *   ├── IInputController      → wraps MediaDeviceInput
+ *   └── IOutputController     → wraps MediaDeviceOutput
+ * ```
+ *
+ * The concrete platform classes (`MediaDeviceInput`, `MediaDeviceOutput`) and
+ * the audio-wiring helpers (`attachInputToConnection`,
+ * `attachConnectionToOutput`) are not exposed on the public `.` entrypoint
+ * because they are too low-level for general consumers.  This sub-path
+ * collects exactly the symbols the Unity bridge needs behind one stable import,
+ * without pulling any unrelated SDK code into a size-sensitive WebGL bundle.
+ *
+ * ## How to evolve it
+ *
+ * - **Additions** — safe; add them here and mirror in `elevenlabs/unity`.
+ * - **Removals / renames** — require a coordinated change with
+ *   `elevenlabs/unity` (see the cleanup checklist in Plan B).
+ * - **Sibling consumers** — add a parallel sub-path
+ *   (`./internal/react-native`, `./internal/godot`, etc.) following the same
+ *   pattern.
+ *
+ * Plan B (the Unity SDK plan this entrypoint serves):
+ * https://github.com/elevenlabs/unity/blob/main/Docs~/plans/plan-b.md
+ */
+
+// ── Runtime values ────────────────────────────────────────────────────────────
+
+// Concrete platform classes the Unity bridge instantiates from C#.
+// (Unity calls .create() on these from its JS factory glue.)
+export { MediaDeviceInput } from "../platform/web/input.js";
+export { MediaDeviceOutput } from "../platform/web/output.js";
+
+// I/O ↔ connection wiring primitives.  Unity's audio-glue.ts composes
+// these (plus a Unity-local audio-payload-stripping wrapper) into its own
+// `attachDefaultAudio` factory — the SDK does not ship that composition.
+export { attachInputToConnection } from "../utils/attachInputToConnection.js";
+export { attachConnectionToOutput } from "../utils/attachConnectionToOutput.js";
+
+// v0.3: Unity-routed audio adapter slot.  Already exported from ./internal —
+// re-exported here so all Unity-consumed symbols live behind one import.
+export { setWebRTCAudioAdapterFactory } from "../WebRTCAudioAdapter.js";
+
+// ── Types only (erased at compile time, never reach the consumer's bundle) ────
+
+// Adapter slot's interface + result shape.  v0.3 Unity-routed audio.
+export type {
+  WebRTCAudioAdapter,
+  AnalysisResult,
+} from "../WebRTCAudioAdapter.js";
+
+// Named convenience aliases for the MediaDevice* config shapes.
+export type { MediaDeviceInputConfig } from "../platform/web/input.js";
+export type { MediaDeviceOutputConfig } from "../platform/web/output.js";
+
+// WebRTCConnection's config type under a stable, descriptive name.
+export type { WebRTCConnectionConfig } from "../utils/WebRTCConnection.js";

--- a/packages/client/src/internal/unity.ts
+++ b/packages/client/src/internal/unity.ts
@@ -33,17 +33,6 @@
  * collects exactly the symbols the Unity bridge needs behind one stable import,
  * without pulling any unrelated SDK code into a size-sensitive WebGL bundle.
  *
- * ## How to evolve it
- *
- * - **Additions** — safe; add them here and mirror in `elevenlabs/unity`.
- * - **Removals / renames** — require a coordinated change with
- *   `elevenlabs/unity` (see the cleanup checklist in Plan B).
- * - **Sibling consumers** — add a parallel sub-path
- *   (`./internal/react-native`, `./internal/godot`, etc.) following the same
- *   pattern.
- *
- * Plan B (the Unity SDK plan this entrypoint serves):
- * https://github.com/elevenlabs/unity/blob/main/Docs~/plans/plan-b.md
  */
 
 // ── Runtime values ────────────────────────────────────────────────────────────

--- a/packages/client/src/platform/web/input.ts
+++ b/packages/client/src/platform/web/input.ts
@@ -25,6 +25,10 @@ const defaultConstraints = {
   channelCount: { ideal: 1 },
 };
 
+export type MediaDeviceInputConfig = FormatConfig &
+  InputConfig &
+  AudioWorkletConfig;
+
 export class MediaDeviceInput implements InputController, InputEventTarget {
   public static async create({
     sampleRate,
@@ -35,9 +39,7 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
     libsampleratePath,
     onError,
     inputChunkDurationMs = DEFAULT_INPUT_CHUNK_DURATION_MS,
-  }: FormatConfig &
-    InputConfig &
-    AudioWorkletConfig): Promise<MediaDeviceInput> {
+  }: MediaDeviceInputConfig): Promise<MediaDeviceInput> {
     let context: AudioContext | null = null;
     let inputStream: MediaStream | null = null;
 

--- a/packages/client/src/platform/web/output.ts
+++ b/packages/client/src/platform/web/output.ts
@@ -50,6 +50,12 @@ function maybePrimeIosPlayback({
   void audioElement.play().catch(() => {});
 }
 
+export type MediaDeviceOutputConfig = FormatConfig &
+  OutputConfig &
+  AudioWorkletConfig & {
+    audioContext?: AudioContext;
+  };
+
 export class MediaDeviceOutput
   implements OutputController, PlaybackEventTarget
 {
@@ -60,11 +66,7 @@ export class MediaDeviceOutput
     workletPaths,
     libsampleratePath,
     audioContext,
-  }: FormatConfig &
-    OutputConfig &
-    AudioWorkletConfig & {
-      audioContext?: AudioContext;
-    }): Promise<MediaDeviceOutput> {
+  }: MediaDeviceOutputConfig): Promise<MediaDeviceOutput> {
     let context: AudioContext | null = audioContext ?? null;
     let audioElement: HTMLAudioElement | null = null;
     try {

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -46,9 +46,12 @@ function convertWssToHttps(origin: string): string {
   return origin.replace(/^wss:\/\//, "https://");
 }
 
-export type ConnectionConfig = SessionConfig & {
+export type WebRTCConnectionConfig = SessionConfig & {
   onDebug?: (info: unknown) => void;
 };
+
+/** @deprecated Use {@link WebRTCConnectionConfig} instead. */
+export type ConnectionConfig = WebRTCConnectionConfig;
 
 export class WebRTCConnection extends BaseConnection {
   public conversationId: string;
@@ -226,7 +229,7 @@ export class WebRTCConnection extends BaseConnection {
   }
 
   public static async create(
-    config: ConnectionConfig
+    config: WebRTCConnectionConfig
   ): Promise<WebRTCConnection> {
     let conversationToken: string;
 

--- a/packages/client/tsconfig.internal-unity.json
+++ b/packages/client/tsconfig.internal-unity.json
@@ -2,18 +2,21 @@
   "compilerOptions": {
     "composite": true,
     "strict": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
+    "outDir": "./dist/internal",
+    "rootDir": "./src/internal",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "skipLibCheck": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**", "src/platform/web/**", "src/internal/**"]
+  "include": ["src/internal/**/*.ts"],
+  "references": [
+    { "path": "./tsconfig.common.json" },
+    { "path": "./tsconfig.web.json" }
+  ]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./tsconfig.web.json"
     },
     {
+      "path": "./tsconfig.internal-unity.json"
+    },
+    {
       "path": "./tsconfig.test.json"
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exposes everything the Unity SDK's WebGL jslib bridge needs from `@elevenlabs/client` across all phases of [Plan B](https://github.com/elevenlabs/unity/blob/main/Docs~/plans/plan-b.md). One PR, one bump, then no more "expose this please" round-trips.

**Pure surface change — no new runtime behavior.**

---

## Changes

### 1. New `./internal/unity` sub-path export (`package.json`)

```jsonc
"./internal/unity": {
  "types":   "./dist/internal/unity.d.ts",
  "default": "./dist/internal/unity.js"
}
```

### 2. New `src/internal/unity.ts` entrypoint

Aggregates exactly the symbols the Unity bridge consumes — no speculative surface:

| Symbol | Kind | Source |
|---|---|---|
| `MediaDeviceInput` | class (runtime) | `platform/web/input.ts` |
| `MediaDeviceOutput` | class (runtime) | `platform/web/output.ts` |
| `attachInputToConnection` | function (runtime) | `utils/attachInputToConnection.ts` |
| `attachConnectionToOutput` | function (runtime) | `utils/attachConnectionToOutput.ts` |
| `setWebRTCAudioAdapterFactory` | function (runtime) | `WebRTCAudioAdapter.ts` |
| `WebRTCAudioAdapter` | type | `WebRTCAudioAdapter.ts` |
| `AnalysisResult` | type | `WebRTCAudioAdapter.ts` |
| `MediaDeviceInputConfig` | type | `platform/web/input.ts` (new alias) |
| `MediaDeviceOutputConfig` | type | `platform/web/output.ts` (new alias) |
| `WebRTCConnectionConfig` | type | `utils/WebRTCConnection.ts` (new alias) |

The module has no top-level side effects and is fully tree-shakable.

### 3. Three new named config-type aliases

Promotes anonymous intersection types to named, exported types — no runtime changes:

- **`MediaDeviceInputConfig`** = `FormatConfig & InputConfig & AudioWorkletConfig` (in `platform/web/input.ts`)
- **`MediaDeviceOutputConfig`** = `FormatConfig & OutputConfig & AudioWorkletConfig & { audioContext? }` (in `platform/web/output.ts`)
- **`WebRTCConnectionConfig`** = `SessionConfig & { onDebug? }` — renamed from `ConnectionConfig` with a `@deprecated` alias kept for backward compat (in `utils/WebRTCConnection.ts`)

### 4. Build system: `tsconfig.internal-unity.json`

New TypeScript project config that compiles `src/internal/unity.ts` to `dist/internal/unity.{js,d.ts}`:
- Inherits base settings from `tsconfig.common.json`
- Adds `"lib": ["ES2022", "DOM"]` (needed for web-platform re-exports)
- References both `tsconfig.common.json` and `tsconfig.web.json`
- `tsconfig.common.json` updated to exclude `src/internal/**` (avoids double-compilation)
- Root `tsconfig.json` updated to include the new project reference

### 5. README documentation

Added an "Entrypoints" section listing all three sub-paths with stability and audience notes, plus a brief description of why `./internal/unity` exists.

---

## Acceptance criteria verification

- [x] All 10 symbols importable from `@elevenlabs/client/internal/unity`
- [x] `tsc --build` succeeds (module resolution `nodenext`)
- [x] `dist/internal/unity.ts` has no top-level side effects
- [x] README entrypoints table added; maintainer-facing note in `src/internal/unity.ts` JSDoc header
- [x] All 124 existing tests pass

---

## What does NOT change

The `./internal` export, `Conversation` / `VoiceConversation` / `TextConversation`, `WebSocketConnection`, `WebRTCConnection`, `createConnection`, and all other currently-public symbols are untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac6dc780-a2f9-4ae8-bc85-45433b52ce1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac6dc780-a2f9-4ae8-bc85-45433b52ce1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

