### PR TITLE
feat(scribe): add includeLanguageDetection option to realtime transcription

### DIFF
--- a/.changeset/scribe-language-detection.md
+++ b/.changeset/scribe-language-detection.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+---
+
+Expose includeLanguageDetection for realtime Scribe sessions, including React useScribe support for requesting and reading detected language metadata.

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -237,6 +237,25 @@ describe("Scribe", () => {
       server.close();
     });
 
+    it("builds URI with includeLanguageDetection", () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&include_language_detection=true"
+      );
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+        includeLanguageDetection: true,
+      });
+
+      expect(connection).toBeDefined();
+
+      connection.close();
+      server.close();
+    });
+
     it("accepts valid parameter values", () => {
       const server = new Server(
         "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&vad_silence_threshold_secs=1.5&vad_threshold=0.5&min_speech_duration_ms=100&min_silence_duration_ms=200"

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -67,6 +67,11 @@ interface BaseOptions {
    */
   includeTimestamps?: boolean;
   /**
+   * Whether to include detected language information in the transcription results.
+   * @default false
+   */
+  includeLanguageDetection?: boolean;
+  /**
    * List of keyterms to bias the model towards.
    * Maximum 50 keyterms, each up to 20 characters.
    */
@@ -180,6 +185,12 @@ export class ScribeRealtime {
       params.append(
         "include_timestamps",
         options.includeTimestamps ? "true" : "false"
+      );
+    }
+    if (options.includeLanguageDetection !== undefined) {
+      params.append(
+        "include_language_detection",
+        options.includeLanguageDetection ? "true" : "false"
       );
     }
     if (options.keyterms !== undefined) {

--- a/packages/react/src/scribe.test.tsx
+++ b/packages/react/src/scribe.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Scribe } from "@elevenlabs/client";
+import { AudioFormat, Scribe } from "@elevenlabs/client";
 import type { RealtimeConnection } from "@elevenlabs/client";
 import { useScribe } from "./scribe.js";
 
@@ -49,6 +49,27 @@ describe("useScribe", () => {
         microphone: expect.objectContaining({
           deviceId,
         }),
+      })
+    );
+  });
+
+  it("passes language detection through to the client", async () => {
+    const { result } = renderHook(() =>
+      useScribe({ includeLanguageDetection: true })
+    );
+
+    await act(async () => {
+      await result.current.connect({
+        token: "test-token",
+        modelId: "scribe_v2_realtime",
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+      });
+    });
+
+    expect(Scribe.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeLanguageDetection: true,
       })
     );
   });

--- a/packages/react/src/scribe.ts
+++ b/packages/react/src/scribe.ts
@@ -50,6 +50,8 @@ export interface TranscriptSegment {
   text: string;
   timestamp: number;
   isFinal: boolean;
+  /** Detected language code (only present when includeLanguageDetection is enabled) */
+  languageCode?: string;
   /** Word-level timestamps (only present when includeTimestamps is enabled) */
   words?: WordTimestamp[];
 }
@@ -60,6 +62,7 @@ export interface ScribeCallbacks {
   onCommittedTranscript?: (data: { text: string }) => void;
   onCommittedTranscriptWithTimestamps?: (data: {
     text: string;
+    language_code?: string;
     words?: WordTimestamp[];
   }) => void;
   /** Called for any error (also called when specific error callbacks fire) */
@@ -107,6 +110,8 @@ export interface ScribeHookOptions extends ScribeCallbacks {
 
   // Include timestamps
   includeTimestamps?: boolean;
+  /** Include detected language information in transcription results */
+  includeLanguageDetection?: boolean;
 
   // Keyterms and verbatim control
   keyterms?: string[];
@@ -189,6 +194,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
 
     // Timestamps
     includeTimestamps: defaultIncludeTimestamps,
+    includeLanguageDetection: defaultIncludeLanguageDetection,
 
     // Keyterms and verbatim control
     keyterms: defaultKeyterms,
@@ -249,6 +255,9 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
             runtimeOptions.onCommittedTranscriptWithTimestamps ||
             onCommittedTranscriptWithTimestamps
           );
+        const includeLanguageDetection =
+          runtimeOptions.includeLanguageDetection ??
+          defaultIncludeLanguageDetection;
 
         if (microphone) {
           // Microphone mode
@@ -272,6 +281,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
             noVerbatim: runtimeOptions.noVerbatim ?? defaultNoVerbatim,
             microphone,
             includeTimestamps,
+            includeLanguageDetection,
           } as MicrophoneOptions);
         } else if (audioFormat && sampleRate) {
           // Manual audio mode
@@ -294,6 +304,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
             keyterms: runtimeOptions.keyterms || defaultKeyterms,
             noVerbatim: runtimeOptions.noVerbatim ?? defaultNoVerbatim,
             includeTimestamps,
+            includeLanguageDetection,
             audioFormat,
             sampleRate,
           } as AudioOptions);
@@ -340,6 +351,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
               text: message.text,
               timestamp: Date.now(),
               isFinal: true,
+              languageCode: message.language_code,
               words: message.words,
             };
             setCommittedTranscripts(prev => [...prev, segment]);
@@ -477,6 +489,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
       defaultAudioFormat,
       defaultSampleRate,
       defaultIncludeTimestamps,
+      defaultIncludeLanguageDetection,
       defaultKeyterms,
       defaultNoVerbatim,
       onSessionStarted,


### PR DESCRIPTION
## Summary

Adds an opt-in `includeLanguageDetection` option to `Scribe.connect()` for realtime speech-to-text, mirroring the existing `includeTimestamps` option.

When set, the client appends `include_language_detection` to the realtime STT WebSocket query parameters, asking the server to return the detected language. The detected language is surfaced as `language_code` on the `committed_transcript_with_timestamps` message (the field already exists in the schema). Defaults to `false`.

## Motivation

Consumers that want the detected language of a transcript currently have no way to request it from the realtime client — `language_code` comes back `null` because the client never asks the server to run detection. This adds the missing opt-in, following the established `includeTimestamps` pattern.

## Testing

- `vitest run src/scribe/scribe.test.ts` — all scribe tests pass, including the new case.
- `tsc --build` — clean compile.
- Verified end-to-end against a real consumer: with `includeLanguageDetection: true`, the realtime session returns a populated `language_code` on `committed_transcript_with_timestamps` (it was `null` without the flag).

## Notes

The option is opt-in and defaults to `false`, so existing behavior is unchanged for callers that don't set it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in API and query-parameter wiring only; default behavior is unchanged and changes are covered by unit tests.
> 
> **Overview**
> Adds an opt-in **`includeLanguageDetection`** flag for realtime Scribe, following the same pattern as **`includeTimestamps`**.
> 
> When enabled, **`Scribe.connect()`** sends `include_language_detection=true` on the STT WebSocket URL so the server can return detected language. **`useScribe`** accepts the option at hook or connect time, forwards it to the client in both microphone and manual audio modes, and maps **`language_code`** from `committed_transcript_with_timestamps` into **`TranscriptSegment.languageCode`** and the timestamp callback payload.
> 
> The flag defaults to off, so existing callers are unchanged. Minor bumps are recorded for **`@elevenlabs/client`** and **`@elevenlabs/react`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4daa26e921417b1048d78fdc4e6288fe89d74b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->