### PR TITLE
[Types] Add license to types package

### DIFF
--- a/.changeset/types-add-license-field.md
+++ b/.changeset/types-add-license-field.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/types": patch
+---
+
+Add `"license": "MIT"` field to package.json so license-checker tools no longer see an undefined license (#838).

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,7 @@
   "name": "@elevenlabs/types",
   "version": "0.14.0",
   "description": "AsyncAPI contracts and generated TypeScript types for ElevenLabs agent communication",
+  "license": "MIT",
   "type": "module",
   "types": "./dist/src/index.d.ts",
   "files": [


### PR DESCRIPTION
Fixes https://github.com/elevenlabs/packages/issues/838

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only package.json change with no runtime or API impact.
> 
> **Overview**
> Adds **`"license": "MIT"`** to `packages/types/package.json` so `@elevenlabs/types` matches the other published packages and license-checker tooling no longer reports an undefined license (fixes #838).
> 
> Includes a **patch** changeset for `@elevenlabs/types`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 676db6d7d280e58658fddecc5c481bd71bf986cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->