### PR TITLE
Expose internal unity connection exports

### DIFF
--- a/.changeset/quiet-unity-bundles.md
+++ b/.changeset/quiet-unity-bundles.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Expose the remaining Unity bridge connection exports from `@elevenlabs/client/internal/unity` so consumers can avoid importing the browser entrypoint.

--- a/agents.md
+++ b/agents.md
@@ -25,3 +25,21 @@ pnpm exec vitest --browser.headless src/conversation/ConversationClientTools.tes
 ```
 
 Always pass `--browser.headless` to avoid launching a visible browser window.
+
+## Changesets
+
+When changing a published package in a way that should trigger a release, add a
+Changeset in `.changeset/` before committing. Include every affected package and
+the appropriate bump type (`patch`, `minor`, or `major`) with a concise summary
+that can be used in the changelog.
+
+Use `pnpm run changeset` when interactive prompts are practical. Otherwise,
+write the Changeset file directly using the standard frontmatter format:
+
+```md
+---
+"@elevenlabs/client": patch
+---
+
+Describe the user-visible package change.
+```

--- a/packages/client/src/internal/unity.test.ts
+++ b/packages/client/src/internal/unity.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ConnectionType,
+  DisconnectionDetails,
+  FormatConfig,
+  IncomingSocketEvent,
+  InputConfig,
+  OutputConfig,
+  SessionConfig,
+} from "./unity.js";
+
+type UnityTypeSurface = {
+  connectionType: ConnectionType;
+  disconnectionDetails: DisconnectionDetails;
+  formatConfig: FormatConfig;
+  incomingSocketEvent: IncomingSocketEvent;
+  inputConfig: InputConfig;
+  outputConfig: OutputConfig;
+  sessionConfig: SessionConfig;
+};
+
+void (null as unknown as UnityTypeSurface);
+
+describe("@elevenlabs/client/internal/unity", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("loads without browser globals", async () => {
+    vi.stubGlobal("navigator", undefined);
+    vi.stubGlobal("document", undefined);
+
+    await expect(
+      import(`./unity.js?no-browser-globals=${Date.now()}`)
+    ).resolves.toEqual(
+      expect.objectContaining({
+        WebSocketConnection: expect.any(Function),
+        WebRTCConnection: expect.any(Function),
+        createConnection: expect.any(Function),
+        installIosAudioUnlockListener: expect.any(Function),
+        WebAudioAdapter: expect.any(Function),
+      })
+    );
+  });
+
+  it("re-exports runtime values from side-effect-free leaf modules", async () => {
+    const [
+      unity,
+      connectionFactory,
+      webSocketConnection,
+      webRTCConnection,
+      audioUnlock,
+      webAudioAdapter,
+    ] = await Promise.all([
+      import("./unity.js"),
+      import("../utils/ConnectionFactory.js"),
+      import("../utils/WebSocketConnection.js"),
+      import("../utils/WebRTCConnection.js"),
+      import("../platform/web/audioUnlock.js"),
+      import("../platform/web/webAudioAdapter.js"),
+    ]);
+
+    expect(unity.createConnection).toBe(connectionFactory.createConnection);
+    expect(unity.WebSocketConnection).toBe(
+      webSocketConnection.WebSocketConnection
+    );
+    expect(unity.WebRTCConnection).toBe(webRTCConnection.WebRTCConnection);
+    expect(unity.installIosAudioUnlockListener).toBe(
+      audioUnlock.installIosAudioUnlockListener
+    );
+    expect(unity.WebAudioAdapter).toBe(webAudioAdapter.WebAudioAdapter);
+  });
+});

--- a/packages/client/src/internal/unity.test.ts
+++ b/packages/client/src/internal/unity.test.ts
@@ -32,9 +32,7 @@ describe("@elevenlabs/client/internal/unity", () => {
     vi.stubGlobal("navigator", undefined);
     vi.stubGlobal("document", undefined);
 
-    await expect(
-      import(`./unity.js?no-browser-globals=${Date.now()}`)
-    ).resolves.toEqual(
+    await expect(import("./unity.js")).resolves.toEqual(
       expect.objectContaining({
         WebSocketConnection: expect.any(Function),
         WebRTCConnection: expect.any(Function),

--- a/packages/client/src/internal/unity.ts
+++ b/packages/client/src/internal/unity.ts
@@ -41,6 +41,13 @@
 // (Unity calls .create() on these from its JS factory glue.)
 export { MediaDeviceInput } from "../platform/web/input.js";
 export { MediaDeviceOutput } from "../platform/web/output.js";
+export { WebAudioAdapter } from "../platform/web/webAudioAdapter.js";
+
+// Connection primitives Unity may compose directly without importing the public
+// browser entrypoint and triggering its module-init side effects.
+export { createConnection } from "../utils/ConnectionFactory.js";
+export { WebSocketConnection } from "../utils/WebSocketConnection.js";
+export { WebRTCConnection } from "../utils/WebRTCConnection.js";
 
 // I/O ↔ connection wiring primitives.  Unity's audio-glue.ts composes
 // these (plus a Unity-local audio-payload-stripping wrapper) into its own
@@ -51,6 +58,10 @@ export { attachConnectionToOutput } from "../utils/attachConnectionToOutput.js";
 // v0.3: Unity-routed audio adapter slot.  Already exported from ./internal —
 // re-exported here so all Unity-consumed symbols live behind one import.
 export { setWebRTCAudioAdapterFactory } from "../WebRTCAudioAdapter.js";
+
+// Callable web platform setup hook. Export the function itself so Unity hosts
+// decide whether and when to install the browser-specific gesture listener.
+export { installIosAudioUnlockListener } from "../platform/web/audioUnlock.js";
 
 // ── Types only (erased at compile time, never reach the consumer's bundle) ────
 
@@ -63,6 +74,17 @@ export type {
 // Named convenience aliases for the MediaDevice* config shapes.
 export type { MediaDeviceInputConfig } from "../platform/web/input.js";
 export type { MediaDeviceOutputConfig } from "../platform/web/output.js";
+
+// Public configuration/event shapes needed when Unity composes connections.
+export type { InputConfig } from "../InputController.js";
+export type { OutputConfig } from "../OutputController.js";
+export type {
+  ConnectionType,
+  DisconnectionDetails,
+  FormatConfig,
+  SessionConfig,
+} from "../utils/BaseConnection.js";
+export type { IncomingSocketEvent } from "../utils/events.js";
 
 // WebRTCConnection's config type under a stable, descriptive name.
 export type { WebRTCConnectionConfig } from "../utils/WebRTCConnection.js";

--- a/packages/client/tsconfig.test.json
+++ b/packages/client/tsconfig.test.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "./tsconfig.web.json"
+    },
+    {
+      "path": "./tsconfig.internal-unity.json"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Re-export the remaining connection runtime surface from `@elevenlabs/client/internal/unity`
- Expose web platform setup hooks/classes without importing the browser entrypoint
- Add regression coverage that imports the Unity entrypoint without browser globals
- Reference the internal-unity TypeScript project from the client test project
- Add a patch changeset for `@elevenlabs/client`
- Update `agents.md` to remind agents to add Changesets for release-triggering package changes

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @elevenlabs/client generate-version && pnpm --filter @elevenlabs/types build`
- `pnpm --dir packages/client exec vitest run --project "Unit tests" src/internal/unity.test.ts`
- `pnpm --filter @elevenlabs/client build:esm`
- `pnpm --filter @elevenlabs/client lint:prettier`
- `pnpm --filter @elevenlabs/client lint:es`
- `pnpm exec prettier --check agents.md .changeset/quiet-unity-bundles.md`

## Notes
- The full pre-commit lint hook previously failed before scoped validation because `@elevenlabs/types` runs `node ./scripts/generate-all-types.ts` under Node v22.14.0, while the repository declares `node >=24.0.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f1be0fa-27b4-4a65-8e8c-f300439cbe31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f1be0fa-27b4-4a65-8e8c-f300439cbe31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

