### PR TITLE
Configure Cursor Cloud Node 24 environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:lts-krypton
+
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+RUN corepack enable \
+  && corepack prepare pnpm@10.28.1 --activate \
+  && node --version \
+  && pnpm --version

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "Node 24 Krypton",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "node --version && pnpm --version && pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Cursor Cloud environment configuration for Node.js lts/Krypton via `node:lts-krypton`
- Enable Corepack and activate `pnpm@10.28.1` in the environment image
- Run version checks before the frozen pnpm install during cloud environment setup

## Verification
- `node --version` in this already-running agent: `v22.14.0` (the new Cursor image applies to future sessions)
- `pnpm --version`: `10.28.1`
- `node -e "JSON.parse(require('fs').readFileSync('.cursor/environment.json', 'utf8'))"`
- `pnpm install --frozen-lockfile`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66f365c5-c92c-4670-9e06-83a315fca9c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66f365c5-c92c-4670-9e06-83a315fca9c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

