### PR TITLE
feat(client): add ASR keywords override to session config

### DIFF
--- a/.changeset/asr-keywords-override.md
+++ b/.changeset/asr-keywords-override.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/types": minor
+---
+
+Add `overrides.asr.keywords` support to the browser client so per-conversation ASR keyword biasing can be sent via `conversation_initiation_client_data`.

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -42,6 +42,10 @@ export type BaseSessionConfig = {
       stability?: number;
       similarityBoost?: number;
     };
+    asr?: {
+      /** Keywords to boost ASR prediction probability for this conversation. */
+      keywords?: string[];
+    };
     conversation?: {
       textOnly?: boolean;
     };

--- a/packages/client/src/utils/overrides.test.ts
+++ b/packages/client/src/utils/overrides.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { constructOverrides } from "./overrides.js";
+
+describe("constructOverrides", () => {
+  it("includes asr keywords in conversation_config_override", () => {
+    const event = constructOverrides({
+      agentId: "agent_123",
+      overrides: {
+        asr: {
+          keywords: ["Cvent", "registration"],
+        },
+      },
+    });
+
+    expect(event.conversation_config_override?.asr?.keywords).toEqual([
+      "Cvent",
+      "registration",
+    ]);
+  });
+
+  it("omits asr keywords when not provided", () => {
+    const event = constructOverrides({
+      agentId: "agent_123",
+      overrides: {
+        agent: {
+          firstMessage: "Hello",
+        },
+      },
+    });
+
+    expect(event.conversation_config_override?.asr?.keywords).toBeUndefined();
+  });
+});

--- a/packages/client/src/utils/overrides.test.ts
+++ b/packages/client/src/utils/overrides.test.ts
@@ -19,7 +19,7 @@ describe("constructOverrides", () => {
     ]);
   });
 
-  it("omits asr keywords when not provided", () => {
+  it("omits asr when keywords are not provided", () => {
     const event = constructOverrides({
       agentId: "agent_123",
       overrides: {
@@ -29,6 +29,19 @@ describe("constructOverrides", () => {
       },
     });
 
-    expect(event.conversation_config_override?.asr?.keywords).toBeUndefined();
+    expect(event.conversation_config_override?.asr).toBeUndefined();
+  });
+
+  it("includes asr with an empty keywords array when explicitly provided", () => {
+    const event = constructOverrides({
+      agentId: "agent_123",
+      overrides: {
+        asr: {
+          keywords: [],
+        },
+      },
+    });
+
+    expect(event.conversation_config_override?.asr?.keywords).toEqual([]);
   });
 });

--- a/packages/client/src/utils/overrides.ts
+++ b/packages/client/src/utils/overrides.ts
@@ -25,9 +25,9 @@ export function constructOverrides(
         stability: config.overrides.tts?.stability,
         similarity_boost: config.overrides.tts?.similarityBoost,
       },
-      asr: {
-        keywords: config.overrides.asr?.keywords,
-      },
+      ...(config.overrides.asr?.keywords !== undefined
+        ? { asr: { keywords: config.overrides.asr.keywords } }
+        : {}),
       conversation: {
         text_only: config.overrides.conversation?.textOnly,
       },

--- a/packages/client/src/utils/overrides.ts
+++ b/packages/client/src/utils/overrides.ts
@@ -25,6 +25,9 @@ export function constructOverrides(
         stability: config.overrides.tts?.stability,
         similarity_boost: config.overrides.tts?.similarityBoost,
       },
+      asr: {
+        keywords: config.overrides.asr?.keywords,
+      },
       conversation: {
         text_only: config.overrides.conversation?.textOnly,
       },

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -60,6 +60,7 @@ export interface ConversationInitiation {
 
 export interface ConversationConfigOverride {
   agent?: ConversationConfigOverrideAgent;
+  asr?: ConversationConfigOverrideAsr;
   tts?: ConversationConfigOverrideTts;
   conversation?: ConversationConfigOverrideConversation;
 }
@@ -148,6 +149,10 @@ export type ConversationConfigOverrideAgentLanguage =
 export interface ConversationConfigOverrideAgentPrompt {
   prompt?: string;
   llm?: string;
+}
+
+export interface ConversationConfigOverrideAsr {
+  keywords?: string[];
 }
 
 export interface ConversationConfigOverrideTts {

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -1286,10 +1286,23 @@ components:
       properties:
         agent:
           $ref: "#/components/schemas/AgentConfigOverride"
+        asr:
+          $ref: "#/components/schemas/ASRConversationalConfigOverride"
         tts:
           $ref: "#/components/schemas/TTSConversationalConfigOverride"
         conversation:
           $ref: "#/components/schemas/ConversationConfigOverride"
+
+    ASRConversationalConfigOverride:
+      type: object
+      description: Automatic speech recognition configuration overrides
+      properties:
+        keywords:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: Keywords to boost prediction probability for
 
     AgentConfigOverride:
       type: object


### PR DESCRIPTION
## Summary
- Add `overrides.asr.keywords` to `@elevenlabs/client` `SessionConfig` so browser SDK users can send per-conversation ASR keyword biasing via `conversation_initiation_client_data`.
- Extend the AsyncAPI schema and generated `@elevenlabs/types` `ConversationConfigOverride` with `asr.keywords`.
- Forward the override in `constructOverrides()` and add unit tests.

## Usage
```ts
await Conversation.startSession({
  agentId: "your-agent-id",
  overrides: {
    asr: {
      keywords: ["Cvent", "registration"],
    },
  },
});
```

**Note:** The agent must permit `asr.keywords` overrides in its security/override settings (off by default). The backend silently ignores this override when not permitted.

## Test plan
- [x] `pnpm exec vitest run src/utils/overrides.test.ts --browser.headless` in `packages/client`
- [x] Pre-commit turbo lint/build passed locally
- [ ] Verify with an agent that has `asr.keywords` override enabled


Made with [Cursor](https://cursor.com)