### PR TITLE
[Widget] Re-enable text streaming in voice sessions

### DIFF
--- a/.changeset/four-dingos-press.md
+++ b/.changeset/four-dingos-press.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Re-enable agent_chat_response_part streaming in voice sessions

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -280,7 +280,7 @@ function useConversationSetup() {
                     type: "message",
                     role: "agent",
                     message,
-                    isText: true,
+                    isText: conversationTextOnly.peek() === true,
                     conversationIndex: conversationIndex.peek(),
                     eventId: event_id,
                   };
@@ -325,7 +325,7 @@ function useConversationSetup() {
                     type: "message",
                     role: "agent",
                     message: "",
-                    isText: true,
+                    isText: conversationTextOnly.peek() === true,
                     conversationIndex: conversationIndex.peek(),
                     eventId: event_id,
                   },

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -81,33 +81,11 @@ export type TranscriptEntry =
       conversationIndex: number;
     };
 
-// Voice user transcripts can arrive after the agent response for the same
-// server turn. Insert those late user messages before the matching agent row;
-// keep local text/multimodal messages anchored by normal append order.
 function appendTranscriptMessage(
   entries: TranscriptEntry[],
   entry: Extract<TranscriptEntry, { type: "message" }>
 ): TranscriptEntry[] {
-  if (entry.role !== "user" || entry.eventId == null) {
-    return [...entries, entry];
-  }
-
-  const matchingAgentIndex = entries.findIndex(
-    candidate =>
-      candidate.type === "message" &&
-      candidate.role === "agent" &&
-      candidate.eventId === entry.eventId &&
-      candidate.conversationIndex === entry.conversationIndex
-  );
-  if (matchingAgentIndex === -1) {
-    return [...entries, entry];
-  }
-
-  return [
-    ...entries.slice(0, matchingAgentIndex),
-    entry,
-    ...entries.slice(matchingAgentIndex),
-  ];
+  return [...entries, entry];
 }
 
 export function ConversationProvider({ children }: ConversationProviderProps) {

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -81,13 +81,6 @@ export type TranscriptEntry =
       conversationIndex: number;
     };
 
-function appendTranscriptMessage(
-  entries: TranscriptEntry[],
-  entry: Extract<TranscriptEntry, { type: "message" }>
-): TranscriptEntry[] {
-  return [...entries, entry];
-}
-
 export function ConversationProvider({ children }: ConversationProviderProps) {
   const value = useConversationSetup();
 
@@ -297,14 +290,17 @@ function useConversationSetup() {
                 return;
               }
 
-              transcript.value = appendTranscriptMessage(transcript.peek(), {
-                type: "message",
-                role,
-                message,
-                isText: false,
-                conversationIndex: conversationIndex.peek(),
-                eventId: event_id,
-              });
+              transcript.value = [
+                ...transcript.peek(),
+                {
+                  type: "message",
+                  role,
+                  message,
+                  isText: false,
+                  conversationIndex: conversationIndex.peek(),
+                  eventId: event_id,
+                },
+              ];
             },
             onAgentChatResponsePart: ({ text, type, event_id }) => {
               if (

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -329,11 +329,11 @@ function useConversationSetup() {
               });
             },
             onAgentChatResponsePart: ({ text, type, event_id }) => {
-              if (conversationTextOnly.peek() !== true) {
-                return;
-              }
-
-              if (firstMessage.peek() && !receivedFirstMessageRef.current) {
+              if (
+                firstMessage.peek() &&
+                conversationTextOnly.peek() === true &&
+                !receivedFirstMessageRef.current
+              ) {
                 // Text mode is always started by the user sending a text message.
                 // We need to ignore the first agent message as it is immediately
                 // interrupted by the user input.


### PR DESCRIPTION
## Problem
PR #775 disabled `agent_chat_response_part` streaming for voice sessions because the backend was emitting these events eagerly from abandoned turns, making them unreliable. It also added an ordering hack in `appendTranscriptMessage` to insert late user transcripts before the matching agent response, because user transcripts could arrive after the agent response for the same turn.

## Fix
Two backend fixes have since removed the root causes:
- elevenlabs/xi#37097 gates `agent_chat_response_part` events on `turn_irreversible`, so they are only emitted once the turn is committed. The voice exclusion is no longer needed.
- elevenlabs/xi#38653 sends the user transcript before opening the gate, guaranteeing user transcripts always arrive before response parts. The ordering hack is no longer needed.

This restores the original behavior: the transcript streams in word-by-word as the agent responds in both voice and text-only sessions, with messages in the correct order.

## Changes
- Remove the early return in `onAgentChatResponsePart` that skipped all voice session events
- Restore the `conversationTextOnly` guard on the `firstMessage` skip (text-only-specific behavior that was previously made redundant by the early return)
- Remove the ordering hack in `appendTranscriptMessage` and inline the plain append at the call site (it can never trigger now that user transcripts arrive first)

## Test plan
[DONE] Local widget connected to prod server, voice + transcript enabled — verified user messages always appear above their matching agent response across multiple turns, and agent text streams in word-by-word.

## Dependency
[DONE] Requires elevenlabs/xi#37097 and elevenlabs/xi#38653 to be deployed (both merged), otherwise voice sessions may display partial text from abandoned turns or out-of-order messages.

## Why this is safe
Bugbot may flag the removal of the ordering logic in `appendTranscriptMessage` as a potential out-of-order risk. It is safe because the race it defended against no longer exists:

- The hack only triggered when a user transcript arrived **after** the matching agent response for the same turn.
- elevenlabs/xi#38653 moves `turn.turn_irreversible.set()` to run **after** `add_user_message`, so the backend now sends the user transcript before opening the gate that allows any `agent_chat_response_part` events through.
- Therefore, by the time agent response parts (or the final agent message) reach the client, the matching user transcript is already in the transcript. The `matchingAgentIndex` lookup would always return -1, i.e. the hack was already a no-op against the fixed backend.

Verified on prod (voice + transcript): user messages always render above their matching agent response across multiple turns.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Transcript order and partial text in voice depend on deployed backend turn-ordering fixes; wrong deployment could regress UX but does not touch auth or data handling.
> 
> **Overview**
> **Re-enables word-by-word agent transcript streaming in voice sessions** by processing `agent_chat_response_part` events again instead of ignoring them when the session is not text-only.
> 
> The **`appendTranscriptMessage` ordering helper is removed**; non-streaming messages are appended in arrival order, relying on backend guarantees that user transcripts arrive before agent response parts. **Text-only-only behavior is restored** for skipping the first agent stream when `firstMessage` is set, and streamed/final agent rows set **`isText` from `conversationTextOnly`** rather than always treating streams as text.
> 
> Patch changeset notes the streaming fix for `@elevenlabs/convai-widget-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1045aeae09c5360c500f110e54266762ddd1c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->