### PR TITLE
Expose Unity upload file helper

### DIFF
--- a/.changeset/expose-unity-upload-file.md
+++ b/.changeset/expose-unity-upload-file.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Expose the file upload helper from the internal Unity entrypoint.

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -5,8 +5,7 @@ import type {
   SessionConfig,
   FormatConfig,
 } from "./utils/BaseConnection.js";
-import { assertJsonObject } from "./utils/assert.js";
-import { extractApiErrorMessage } from "./utils/errors.js";
+import { uploadFile, type UploadFileResult } from "./utils/uploadFile.js";
 import type { Conversation } from "./index.js";
 import type {
   AgentAudioEvent,
@@ -34,7 +33,6 @@ import type {
 import type { InputConfig } from "./InputController.js";
 import type { OutputConfig } from "./OutputController.js";
 
-const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
 const END_CALL_DETAILS: DisconnectionDetails = {
   reason: "agent",
   context: { type: "end_call", reason: "Agent ended the call" },
@@ -42,6 +40,7 @@ const END_CALL_DETAILS: DisconnectionDetails = {
 
 export type { Role, Mode, Status, Callbacks } from "./types.js";
 export { CALLBACK_KEYS } from "./types.js";
+export type { UploadFileResult } from "./utils/uploadFile.js";
 
 /** Allows self-hosting the worklets to avoid whitelisting blob: and data: in the CSP script-src  */
 export type AudioWorkletConfig = {
@@ -82,10 +81,6 @@ export type PartialOptions = SessionConfig &
 export type MultimodalMessageInput = {
   text?: string;
   fileId?: string;
-};
-
-export type UploadFileResult = {
-  fileId: string;
 };
 
 export type ClientToolsConfig = {
@@ -659,34 +654,10 @@ export abstract class BaseConversation {
   }
 
   public async uploadFile(file: Blob): Promise<UploadFileResult> {
-    const origin = (this.options.origin ?? HTTPS_API_ORIGIN)
-      .replace(/^wss:\/\//, "https://")
-      .replace(/^ws:\/\//, "http://");
-
-    const filename =
-      "name" in file && typeof file.name === "string"
-        ? file.name
-        : `upload.${(file.type || "image/png").split("/").pop()?.split("+")[0]}`;
-
-    const body = new FormData();
-    body.append("file", file, filename);
-
-    const response = await fetch(
-      `${origin}/v1/convai/conversations/${this.connection.conversationId}/files`,
-      { method: "POST", body }
-    );
-
-    if (!response.ok) {
-      const message = await extractApiErrorMessage(response);
-      throw new Error(`Upload failed: ${response.status} ${message}`);
-    }
-
-    const result: unknown = await response.json();
-    assertJsonObject(result, "Upload response is not a JSON object");
-    const { file_id } = result;
-    if (typeof file_id !== "string" || !file_id) {
-      throw new Error("Upload response is missing a valid file_id");
-    }
-    return { fileId: file_id };
+    return uploadFile({
+      conversationId: this.connection.conversationId,
+      origin: this.options.origin,
+      file,
+    });
   }
 }

--- a/packages/client/src/internal/unity.test.ts
+++ b/packages/client/src/internal/unity.test.ts
@@ -49,6 +49,7 @@ describe("@elevenlabs/client/internal/unity", () => {
       connectionFactory,
       webSocketConnection,
       webRTCConnection,
+      uploadFile,
       audioUnlock,
       webAudioAdapter,
     ] = await Promise.all([
@@ -56,6 +57,7 @@ describe("@elevenlabs/client/internal/unity", () => {
       import("../utils/ConnectionFactory.js"),
       import("../utils/WebSocketConnection.js"),
       import("../utils/WebRTCConnection.js"),
+      import("../utils/uploadFile.js"),
       import("../platform/web/audioUnlock.js"),
       import("../platform/web/webAudioAdapter.js"),
     ]);
@@ -65,6 +67,7 @@ describe("@elevenlabs/client/internal/unity", () => {
       webSocketConnection.WebSocketConnection
     );
     expect(unity.WebRTCConnection).toBe(webRTCConnection.WebRTCConnection);
+    expect(unity.uploadFile).toBe(uploadFile.uploadFile);
     expect(unity.installIosAudioUnlockListener).toBe(
       audioUnlock.installIosAudioUnlockListener
     );

--- a/packages/client/src/internal/unity.ts
+++ b/packages/client/src/internal/unity.ts
@@ -48,6 +48,7 @@ export { WebAudioAdapter } from "../platform/web/webAudioAdapter.js";
 export { createConnection } from "../utils/ConnectionFactory.js";
 export { WebSocketConnection } from "../utils/WebSocketConnection.js";
 export { WebRTCConnection } from "../utils/WebRTCConnection.js";
+export { uploadFile } from "../utils/uploadFile.js";
 
 // I/O ↔ connection wiring primitives.  Unity's audio-glue.ts composes
 // these (plus a Unity-local audio-payload-stripping wrapper) into its own

--- a/packages/client/src/utils/uploadFile.test.ts
+++ b/packages/client/src/utils/uploadFile.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { uploadFile } from "./uploadFile.js";
+
+describe("uploadFile", () => {
+  let fetchSpy: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function mockFetchSuccess() {
+    fetchSpy = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ file_id: "test-file-id" }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+  }
+
+  function getUploadedFilename(): string {
+    const formData = fetchSpy.mock.calls[0]![1]!.body as FormData;
+    return (formData.get("file") as File).name;
+  }
+
+  it("uploads to the conversation files endpoint", async () => {
+    mockFetchSuccess();
+
+    await expect(
+      uploadFile({
+        conversationId: "conversation-123",
+        origin: "https://api.example.com",
+        file: new Blob(["test"]),
+      })
+    ).resolves.toEqual({ fileId: "test-file-id" });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/v1/convai/conversations/conversation-123/files",
+      {
+        method: "POST",
+        body: expect.any(FormData),
+      }
+    );
+  });
+
+  it("uses the provided filename override", async () => {
+    mockFetchSuccess();
+
+    await uploadFile({
+      conversationId: "conversation-123",
+      file: new Blob(["test"], { type: "application/pdf" }),
+      filename: "attachment.pdf",
+    });
+
+    expect(getUploadedFilename()).toBe("attachment.pdf");
+  });
+});

--- a/packages/client/src/utils/uploadFile.ts
+++ b/packages/client/src/utils/uploadFile.ts
@@ -1,0 +1,53 @@
+import { assertJsonObject } from "./assert.js";
+import { extractApiErrorMessage } from "./errors.js";
+
+const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
+
+export type UploadFileArgs = {
+  conversationId: string;
+  origin?: string;
+  file: Blob;
+  filename?: string;
+};
+
+export type UploadFileResult = {
+  fileId: string;
+};
+
+export async function uploadFile({
+  conversationId,
+  origin: rawOrigin,
+  file,
+  filename: filenameOverride,
+}: UploadFileArgs): Promise<UploadFileResult> {
+  const origin = (rawOrigin ?? HTTPS_API_ORIGIN)
+    .replace(/^wss:\/\//, "https://")
+    .replace(/^ws:\/\//, "http://");
+
+  const filename =
+    filenameOverride ??
+    ("name" in file && typeof file.name === "string"
+      ? file.name
+      : `upload.${(file.type || "image/png").split("/").pop()?.split("+")[0]}`);
+
+  const body = new FormData();
+  body.append("file", file, filename);
+
+  const response = await fetch(
+    `${origin}/v1/convai/conversations/${conversationId}/files`,
+    { method: "POST", body }
+  );
+
+  if (!response.ok) {
+    const message = await extractApiErrorMessage(response);
+    throw new Error(`Upload failed: ${response.status} ${message}`);
+  }
+
+  const result: unknown = await response.json();
+  assertJsonObject(result, "Upload response is not a JSON object");
+  const { file_id } = result;
+  if (typeof file_id !== "string" || !file_id) {
+    throw new Error("Upload response is missing a valid file_id");
+  }
+  return { fileId: file_id };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extract `BaseConversation.uploadFile` into a shared helper.
- Re-export `uploadFile` from `@elevenlabs/client/internal/unity`.
- Add focused tests and a patch changeset for `@elevenlabs/client`.

## Testing
- `pnpm --filter @elevenlabs/client exec vitest run --browser.headless src/BaseConversation.test.ts src/utils/uploadFile.test.ts src/internal/unity.test.ts`
- `pnpm --filter @elevenlabs/client build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cdc7141-ffeb-4077-a1e3-ffe1dea60553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cdc7141-ffeb-4077-a1e3-ffe1dea60553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

