### PR TITLE
[agents][feedback] allow sendFeedback to target a past message by event_id

### DIFF
--- a/.changeset/feedback-event-id.md
+++ b/.changeset/feedback-event-id.md
@@ -1,0 +1,8 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+---
+
+Allow `sendFeedback` to target a past message by `event_id`. `sendFeedback(like, eventId?)` now accepts an optional event id; when provided it rates that specific message, and when omitted it rates the latest agent turn.
+
+`canSendFeedback` now reflects whether the conversation is connected rather than whether the latest turn is unrated, so feedback can be sent for any message (including re-rating) while the session is live.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -22,14 +22,15 @@ class TestConversation extends BaseConversation {
   }
 
   public static create(
-    options: Partial<Options> & { origin?: string } = {}
+    options: Partial<Options> & { origin?: string } = {},
+    connection: BaseConnection = noopConnection
   ): TestConversation {
     const fullOptions = TestConversation.getFullOptions({
       agentId: "test-agent-id",
       connectionType: "webrtc",
       ...options,
     } as PartialOptions);
-    return new TestConversation(fullOptions, noopConnection);
+    return new TestConversation(fullOptions, connection);
   }
 
   constructor(options: Options, connection: BaseConnection) {
@@ -55,6 +56,19 @@ class TestConversation extends BaseConversation {
     event: Parameters<Parameters<BaseConnection["onMessage"]>[0]>[0]
   ) {
     return this["onMessage"](event);
+  }
+
+  public connect(currentEventId = 1) {
+    this.currentEventId = currentEventId;
+    this.markConnected();
+  }
+
+  public setStatus(status: Parameters<TestConversation["updateStatus"]>[0]) {
+    this.updateStatus(status);
+  }
+
+  public getCanSendFeedback() {
+    return this.canSendFeedback;
   }
 }
 
@@ -351,6 +365,101 @@ describe("BaseConversation", () => {
         reason: "error",
         message: "Maximum duration exceeded",
         context: { type: "max_duration_exceeded" },
+      });
+    });
+  });
+
+  describe("sendFeedback", () => {
+    function createWithSpy() {
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      const conversation = TestConversation.create({}, connection);
+      return { conversation, sendMessage };
+    }
+
+    it("warns and does not send when not connected", () => {
+      const { conversation, sendMessage } = createWithSpy();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      expect(conversation.getCanSendFeedback()).toBe(false);
+      conversation.sendFeedback(true);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("targets the current turn when eventId is omitted", () => {
+      const { conversation, sendMessage } = createWithSpy();
+      conversation.connect(5);
+
+      conversation.sendFeedback(true);
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "feedback",
+        score: "like",
+        event_id: 5,
+      });
+    });
+
+    it("advances the default target as agent responses arrive", async () => {
+      const { conversation, sendMessage } = createWithSpy();
+      conversation.connect();
+
+      await conversation.receiveMessage({
+        type: "agent_response",
+        agent_response_event: {
+          agent_response: "Hello there",
+          event_id: 7,
+        },
+      });
+      conversation.sendFeedback(true);
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "feedback",
+        score: "like",
+        event_id: 7,
+      });
+    });
+
+    it("targets an explicit past message", () => {
+      const { conversation, sendMessage } = createWithSpy();
+      conversation.connect(5);
+
+      conversation.sendFeedback(false, 2);
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "feedback",
+        score: "dislike",
+        event_id: 2,
+      });
+    });
+
+    it("can send repeatedly while connected", () => {
+      const { conversation, sendMessage } = createWithSpy();
+      conversation.connect(5);
+
+      conversation.sendFeedback(true, 2);
+      conversation.sendFeedback(true, 5);
+
+      expect(sendMessage).toHaveBeenCalledTimes(2);
+      expect(conversation.getCanSendFeedback()).toBe(true);
+    });
+
+    it("notifies onCanSendFeedbackChange on connect and disconnect", () => {
+      const onCanSendFeedbackChange = vi.fn();
+      const conversation = TestConversation.create({ onCanSendFeedbackChange });
+
+      conversation.connect(1);
+      expect(onCanSendFeedbackChange).toHaveBeenLastCalledWith({
+        canSendFeedback: true,
+      });
+
+      conversation.setStatus("disconnected");
+      expect(onCanSendFeedbackChange).toHaveBeenLastCalledWith({
+        canSendFeedback: false,
       });
     });
   });

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -118,7 +118,6 @@ export abstract class BaseConversation {
   protected status: Status = "connecting";
   protected volume = 1;
   protected currentEventId = 1;
-  protected lastFeedbackEventId = 0;
   protected canSendFeedback = false;
 
   protected static getFullOptions(partialOptions: PartialOptions): Options {
@@ -196,11 +195,12 @@ export abstract class BaseConversation {
       if (this.options.onStatusChange) {
         this.options.onStatusChange({ status });
       }
+      this.updateCanSendFeedback();
     }
   }
 
   protected updateCanSendFeedback() {
-    const canSendFeedback = this.currentEventId !== this.lastFeedbackEventId;
+    const canSendFeedback = this.status === "connected";
     if (this.canSendFeedback !== canSendFeedback) {
       this.canSendFeedback = canSendFeedback;
       if (this.options.onCanSendFeedbackChange) {
@@ -222,6 +222,7 @@ export abstract class BaseConversation {
   }
 
   protected handleAgentResponse(event: AgentResponseEvent) {
+    this.currentEventId = event.agent_response_event.event_id;
     if (this.options.onMessage) {
       this.options.onMessage({
         source: "ai",
@@ -593,23 +594,17 @@ export abstract class BaseConversation {
   public abstract getInputVolume(): number;
   public abstract getOutputVolume(): number;
 
-  public sendFeedback(like: boolean) {
+  public sendFeedback(like: boolean, eventId?: number) {
     if (!this.canSendFeedback) {
-      console.warn(
-        this.lastFeedbackEventId === 0
-          ? "Cannot send feedback: the conversation has not started yet."
-          : "Cannot send feedback: feedback has already been sent for the current response."
-      );
+      console.warn("Cannot send feedback: the conversation is not connected.");
       return;
     }
 
     this.connection.sendMessage({
       type: "feedback",
       score: like ? "like" : "dislike",
-      event_id: this.currentEventId,
+      event_id: eventId ?? this.currentEventId,
     });
-    this.lastFeedbackEventId = this.currentEventId;
-    this.updateCanSendFeedback();
   }
 
   public sendContextualUpdate(text: string, options?: ContextualUpdateOptions) {

--- a/packages/react/src/conversation/ConversationFeedback.test.tsx
+++ b/packages/react/src/conversation/ConversationFeedback.test.tsx
@@ -32,11 +32,7 @@ function useTestHook() {
 
 function createWrapper(props: Record<string, unknown> = {}) {
   return function Wrapper({ children }: React.PropsWithChildren) {
-    return (
-      <ConversationProvider {...props}>
-        {children}
-      </ConversationProvider>
-    );
+    return <ConversationProvider {...props}>{children}</ConversationProvider>;
   };
 }
 
@@ -100,12 +96,33 @@ describe("ConversationFeedback", () => {
     act(() => {
       result.current.feedback.sendFeedback(true);
     });
-    expect(mockConversation.sendFeedback).toHaveBeenCalledWith(true);
+    expect(mockConversation.sendFeedback).toHaveBeenCalledWith(true, undefined);
 
     act(() => {
       result.current.feedback.sendFeedback(false);
     });
-    expect(mockConversation.sendFeedback).toHaveBeenCalledWith(false);
+    expect(mockConversation.sendFeedback).toHaveBeenCalledWith(
+      false,
+      undefined
+    );
+  });
+
+  it("forwards an explicit eventId to rate a past message", async () => {
+    const mockConversation = createMockConversation();
+    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+
+    const { result } = renderHook(() => useTestHook(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    act(() => {
+      result.current.feedback.sendFeedback(true, 42);
+    });
+    expect(mockConversation.sendFeedback).toHaveBeenCalledWith(true, 42);
   });
 
   it("composes with user-provided onCanSendFeedbackChange callback", async () => {

--- a/packages/react/src/conversation/ConversationFeedback.tsx
+++ b/packages/react/src/conversation/ConversationFeedback.tsx
@@ -5,11 +5,14 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useRawConversationRef, useRegisterCallbacks } from "./ConversationContext.js";
+import {
+  useRawConversationRef,
+  useRegisterCallbacks,
+} from "./ConversationContext.js";
 
 export type ConversationFeedbackValue = {
   canSendFeedback: boolean;
-  sendFeedback: (like: boolean) => void;
+  sendFeedback: (like: boolean, eventId?: number) => void;
 };
 
 const ConversationFeedbackContext =
@@ -36,9 +39,12 @@ export function ConversationFeedbackProvider({
     },
   });
 
-  const sendFeedback = useCallback((like: boolean) => {
-    conversationRef.current?.sendFeedback(like);
-  }, [conversationRef]);
+  const sendFeedback = useCallback(
+    (like: boolean, eventId?: number) => {
+      conversationRef.current?.sendFeedback(like, eventId);
+    },
+    [conversationRef]
+  );
 
   const value = useMemo<ConversationFeedbackValue>(
     () => ({


### PR DESCRIPTION
this is compliant with our asyncapi spec and backend supports it

this would unblock some work of mine in the xi repo that consumes the client and wants to send the event_id

### testing 
added a test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API and semantics of `canSendFeedback` change (always true when connected vs one-shot per turn); apps that hid feedback after the first like/dislike need to adjust UX, though behavior matches the async API and backend.
> 
> **Overview**
> **`sendFeedback`** now accepts an optional **`eventId`**: omit it to rate the latest agent turn (tracked via **`currentEventId`** on each **`agent_response`**), or pass an id to rate a specific past message. The wire payload still uses **`event_id`** on the feedback message.
> 
> **`canSendFeedback`** no longer blocks after one rating per turn. It is **`true` while the session is `connected`** (updated on status changes), so callers can rate any message or re-rate during a live conversation. One-feedback-per-turn tracking (**`lastFeedbackEventId`**) was removed.
> 
> **`@elevenlabs/react`** **`useConversationFeedback`** forwards the optional **`eventId`** to the client. Minor version bumps are noted in the changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58b3019b75693d2edc2055b0b36e84b84abd3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->