### PR TITLE
[agents][feedback] allow sendFeedback to clear feedback by passing null

### DIFF
--- a/.changeset/nullable-feedback.md
+++ b/.changeset/nullable-feedback.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": minor
+---
+
+Allow `sendFeedback` to clear feedback by passing `null`. `sendFeedback(like, eventId?)` now accepts `null` as the first parameter; when passed it sends `score: null` to clear the feedback on that event, allowing users to remove their like/dislike rating.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -437,6 +437,32 @@ describe("BaseConversation", () => {
       });
     });
 
+    it("clears feedback when null is passed", () => {
+      const { conversation, sendMessage } = createWithSpy();
+      conversation.connect(5);
+
+      conversation.sendFeedback(null, 2);
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "feedback",
+        score: null,
+        event_id: 2,
+      });
+    });
+
+    it("clears feedback for the current turn when eventId is omitted", () => {
+      const { conversation, sendMessage } = createWithSpy();
+      conversation.connect(5);
+
+      conversation.sendFeedback(null);
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "feedback",
+        score: null,
+        event_id: 5,
+      });
+    });
+
     it("can send repeatedly while connected", () => {
       const { conversation, sendMessage } = createWithSpy();
       conversation.connect(5);

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -594,7 +594,7 @@ export abstract class BaseConversation {
   public abstract getInputVolume(): number;
   public abstract getOutputVolume(): number;
 
-  public sendFeedback(like: boolean, eventId?: number) {
+  public sendFeedback(like: boolean | null, eventId?: number) {
     if (!this.canSendFeedback) {
       console.warn("Cannot send feedback: the conversation is not connected.");
       return;
@@ -602,7 +602,7 @@ export abstract class BaseConversation {
 
     this.connection.sendMessage({
       type: "feedback",
-      score: like ? "like" : "dislike",
+      score: like === null ? null : like ? "like" : "dislike",
       event_id: eventId ?? this.currentEventId,
     });
   }

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -602,7 +602,7 @@ export abstract class BaseConversation {
 
     this.connection.sendMessage({
       type: "feedback",
-      score: like === null ? null : like ? "like" : "dislike",
+      score: like !== null ? (like ? "like" : "dislike") : null,
       event_id: eventId ?? this.currentEventId,
     });
   }

--- a/packages/react/src/conversation/ConversationFeedback.test.tsx
+++ b/packages/react/src/conversation/ConversationFeedback.test.tsx
@@ -125,6 +125,24 @@ describe("ConversationFeedback", () => {
     expect(mockConversation.sendFeedback).toHaveBeenCalledWith(true, 42);
   });
 
+  it("clears feedback when null is passed", async () => {
+    const mockConversation = createMockConversation();
+    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+
+    const { result } = renderHook(() => useTestHook(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    act(() => {
+      result.current.feedback.sendFeedback(null, 42);
+    });
+    expect(mockConversation.sendFeedback).toHaveBeenCalledWith(null, 42);
+  });
+
   it("composes with user-provided onCanSendFeedbackChange callback", async () => {
     const userOnCanSendFeedbackChange = vi.fn();
     const mockConversation = createMockConversation();

--- a/packages/react/src/conversation/ConversationFeedback.tsx
+++ b/packages/react/src/conversation/ConversationFeedback.tsx
@@ -12,7 +12,7 @@ import {
 
 export type ConversationFeedbackValue = {
   canSendFeedback: boolean;
-  sendFeedback: (like: boolean, eventId?: number) => void;
+  sendFeedback: (like: boolean | null, eventId?: number) => void;
 };
 
 const ConversationFeedbackContext =
@@ -40,7 +40,7 @@ export function ConversationFeedbackProvider({
   });
 
   const sendFeedback = useCallback(
-    (like: boolean, eventId?: number) => {
+    (like: boolean | null, eventId?: number) => {
       conversationRef.current?.sendFeedback(like, eventId);
     },
     [conversationRef]

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -24,10 +24,10 @@ export interface UserActivity {
 export interface UserFeedback {
   type: "feedback";
   event_id: number;
-  score: Score;
+  score: ScoreOneOf_0 | null;
 }
 
-export type Score = "like" | "dislike";
+export type ScoreOneOf_0 = "like" | "dislike";
 
 export interface ClientToolResult {
   type: "client_tool_result";
@@ -683,7 +683,7 @@ export interface UserActivityClientToOrchestratorEvent {
 export interface UserFeedbackClientToOrchestratorEvent {
   type: "feedback";
   event_id: number;
-  score: Score;
+  score: ScoreOneOf_0 | null;
 }
 
 export interface ClientToolResultClientToOrchestratorEvent {

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -486,11 +486,13 @@ components:
       description: Audio encoding format for user input
 
     FeedbackScore:
-      type: string
-      enum:
-        - like
-        - dislike
-      description: User's feedback score
+      oneOf:
+        - type: string
+          enum:
+            - like
+            - dislike
+        - type: "null"
+      description: User's feedback score. Pass null to clear the feedback.
 
     MCPIntegrationType:
       type: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is compliant with our asyncapi spec and backend supports it.

This allows clearing feedback on an event by passing `null` to `sendFeedback`.

https://github.com/elevenlabs/xi/pull/39197 is fully deployed

## Changes

- **`@elevenlabs/client`**: Updated `sendFeedback(like, eventId?)` to accept `boolean | null` as the first parameter. When `null` is passed, it sends `score: null` to clear the feedback on that event.

- **`@elevenlabs/react`**: Updated `useConversationFeedback` hook's `sendFeedback` to accept `null` values, forwarding them to the client.

- **`@elevenlabs/types`**: Updated AsyncAPI schema to make `FeedbackScore` nullable using `oneOf` with `null` type.

## Testing

Added tests for:
- Clearing feedback when `null` is passed with an explicit `eventId`
- Clearing feedback for the current turn when `eventId` is omitted
- React hook properly forwarding `null` to the client
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://eleven-labs-workspace.slack.com/archives/D094A2U16DS/p1782391113702989?thread_ts=1782391113.702989&cid=D094A2U16DS)

<div><a href="https://cursor.com/agents/bc-3452c6ef-0068-51a1-90b4-1dd2b38461db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3452c6ef-0068-51a1-90b4-1dd2b38461db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

