### PR TITLE
[Widget] Don't merge agent text segments split by a tool call

### DIFF
--- a/.changeset/tidy-tools-merge.md
+++ b/.changeset/tidy-tools-merge.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix transcript rendering for turns that interleave text and tool calls: keep text segments split by a tool call as separate bubbles, and show the tool status badge only once per turn

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -283,6 +283,28 @@ describe("buildDisplayTranscript", () => {
       const result = build(input, { showAgentStatus: false });
       expect(result[0]).not.toHaveProperty("toolStatus");
     });
+
+    it("attaches status to only the first bubble of a text → tool → text turn", () => {
+      // Two non-empty segments share the turn's eventId and stay as separate
+      // bubbles. The tool status attaches to the first (triggering) bubble only,
+      // so the badge is not duplicated across both.
+      const input = [
+        msg("agent", "Running the tool now.", { eventId: 2 }),
+        toolReq(2),
+        toolRes(2),
+        msg("agent", "Tool completed successfully", { eventId: 2 }),
+      ];
+      const result = build(input, { showAgentStatus: true });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        message: "Running the tool now.",
+        toolStatus: "success",
+      });
+      expect(result[1]).toMatchObject({
+        message: "Tool completed successfully",
+      });
+      expect(result[1]).not.toHaveProperty("toolStatus");
+    });
   });
 
   describe("transcript filtering", () => {

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -171,6 +171,39 @@ describe("buildDisplayTranscript", () => {
         expect(result[i]).toMatchObject(exp);
       });
     });
+
+    it("does not merge agent text segments separated by a tool call", () => {
+      // text > tool > text within the same turn (shared eventId). The two text
+      // segments are distinct bubbles and must both survive — the tool call
+      // between them prevents the same-eventId merge.
+      const input = [
+        msg("agent", "before tool", { eventId: 2 }),
+        toolReq(2),
+        toolRes(2),
+        msg("agent", "after tool", { eventId: 2 }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ message: "before tool" });
+      expect(result[1]).toMatchObject({ message: "after tool" });
+    });
+
+    it("still merges a streamed partial into its finalized message after a tool", () => {
+      // The first segment ends, a tool runs, then a new segment streams a
+      // partial and finalizes. The partial/full pair (no tool between them)
+      // still collapses to the finalized message.
+      const input = [
+        msg("agent", "before tool", { eventId: 2 }),
+        toolReq(3),
+        toolRes(3),
+        msg("agent", "partial", { eventId: 3 }),
+        msg("agent", "full", { eventId: 3 }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ message: "before tool" });
+      expect(result[1]).toMatchObject({ message: "full" });
+    });
   });
 
   describe("tool status", () => {

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -172,10 +172,10 @@ describe("buildDisplayTranscript", () => {
       });
     });
 
-    it("does not merge agent text segments separated by a tool call", () => {
-      // text > tool > text within the same turn (shared eventId). The two text
-      // segments are distinct bubbles and must both survive — the tool call
-      // between them prevents the same-eventId merge.
+    it("does not merge non-empty agent text segments separated by a tool call", () => {
+      // text > tool > text within the same turn (shared eventId). Both text
+      // segments have real content, so the second must not overwrite the first —
+      // a tool call separated them and the previous message is non-empty.
       const input = [
         msg("agent", "before tool", { eventId: 2 }),
         toolReq(2),
@@ -186,6 +186,21 @@ describe("buildDisplayTranscript", () => {
       expect(result).toHaveLength(2);
       expect(result[0]).toMatchObject({ message: "before tool" });
       expect(result[1]).toMatchObject({ message: "after tool" });
+    });
+
+    it("merges empty placeholders into the final message across tool calls", () => {
+      // The streamed flow brackets tool calls with empty placeholders, all
+      // sharing the turn's eventId. These collapse into the single real message —
+      // an empty previous message is folded in even across a tool.
+      const input = [
+        msg("agent", "", { eventId: 2 }),
+        toolReq(2),
+        toolRes(2),
+        msg("agent", "Done", { eventId: 2 }),
+      ];
+      const result = build(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ message: "Done" });
     });
 
     it("still merges a streamed partial into its finalized message after a tool", () => {

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -141,8 +141,8 @@ export function buildDisplayTranscript(
     // The one case we must NOT collapse: a non-empty text segment followed by a
     // tool call and then more text (text → tool → text). Overwriting the first
     // would lose it. So refuse to merge only when a tool separated the two AND
-    // the previous message already has real content; empty placeholders still
-    // merge freely across tools.
+    // the previous message already has real content; empty placeholders (incl.
+    // whitespace-only) still merge freely across tools.
     const prev = result[result.length - 1];
     if (
       entry.type === "message" &&
@@ -150,7 +150,7 @@ export function buildDisplayTranscript(
       prev?.type === "message" &&
       prev.eventId === entry.eventId &&
       prev.role === entry.role &&
-      (!toolBetween || !prev.message)
+      (!toolBetween || !prev.message.trim())
     ) {
       result[result.length - 1] = entry;
       continue;

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -160,8 +160,14 @@ export function buildDisplayTranscript(
     toolBetween = false;
   }
 
-  // Attach tool status to agent messages
+  // Attach tool status to agent messages. A turn (eventId) may now render as
+  // several bubbles (text → tool → text), so attach the status to only the first
+  // agent bubble of the turn — the one that triggered the tool. This keeps a
+  // single status badge and keeps it stable: it appears under the triggering
+  // message during loading instead of jumping to a later bubble when post-tool
+  // text arrives.
   if (config.showAgentStatus) {
+    const statusAttached = new Set<number>();
     for (let i = 0; i < result.length; i++) {
       const entry = result[i];
       if (
@@ -170,6 +176,7 @@ export function buildDisplayTranscript(
         entry.eventId == null
       )
         continue;
+      if (statusAttached.has(entry.eventId)) continue;
       const status = toolStatuses.get(entry.eventId);
       if (!status) continue;
 
@@ -180,6 +187,7 @@ export function buildDisplayTranscript(
             ? ToolCallStatus.ERROR
             : ToolCallStatus.SUCCESS;
       result[i] = { ...entry, toolStatus };
+      statusAttached.add(entry.eventId);
     }
   }
 

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -101,13 +101,21 @@ export function buildDisplayTranscript(
     }
   }
 
+  // Tracks whether a tool entry appeared since the last emitted message. Used to
+  // avoid merging two agent text segments of the same turn that are separated by
+  // a tool call — they share an eventId but are distinct bubbles, not a
+  // streamed-partial/finalized pair.
+  let toolBetween = false;
+
   for (const entry of entries) {
     // Skip tool entries (consumed into status)
     if (
       entry.type === "agent_tool_request" ||
       entry.type === "agent_tool_response"
-    )
+    ) {
+      toolBetween = true;
       continue;
+    }
 
     // Skip empty agent messages unless they have a tool status to display
     if (
@@ -126,9 +134,12 @@ export function buildDisplayTranscript(
     if (!config.transcriptEnabled && entry.type === "message" && !entry.isText)
       continue;
 
-    // Group consecutive messages with same eventId + role
+    // Group consecutive messages with same eventId + role (collapses a streamed
+    // partial into its finalized message). Skip when a tool call separated them —
+    // those are distinct text segments of the same turn and must stay separate.
     const prev = result[result.length - 1];
     if (
+      !toolBetween &&
       entry.type === "message" &&
       entry.eventId != null &&
       prev?.type === "message" &&
@@ -140,6 +151,7 @@ export function buildDisplayTranscript(
     }
 
     result.push(entry);
+    toolBetween = false;
   }
 
   // Attach tool status to agent messages

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -101,10 +101,7 @@ export function buildDisplayTranscript(
     }
   }
 
-  // Tracks whether a tool entry appeared since the last emitted message. Used to
-  // protect a non-empty text segment that is followed by a tool call and then
-  // more text (text → tool → text): those are distinct bubbles of the same turn
-  // and must not be collapsed into one.
+  // Whether a tool entry appeared since the last emitted message.
   let toolBetween = false;
 
   for (const entry of entries) {
@@ -134,15 +131,9 @@ export function buildDisplayTranscript(
     if (!config.transcriptEnabled && entry.type === "message" && !entry.isText)
       continue;
 
-    // Group consecutive messages with same eventId + role. This collapses a
-    // streamed partial into its finalized message, and folds the empty
-    // placeholders that bracket tool calls into the turn's real message.
-    //
-    // The one case we must NOT collapse: a non-empty text segment followed by a
-    // tool call and then more text (text → tool → text). Overwriting the first
-    // would lose it. So refuse to merge only when a tool separated the two AND
-    // the previous message already has real content; empty placeholders (incl.
-    // whitespace-only) still merge freely across tools.
+    // Merge same-eventId+role messages (collapses streamed partials and empty
+    // placeholders into the final message). Don't merge text → tool → text:
+    // a tool split two non-empty segments, so they stay distinct bubbles.
     const prev = result[result.length - 1];
     if (
       entry.type === "message" &&
@@ -160,12 +151,8 @@ export function buildDisplayTranscript(
     toolBetween = false;
   }
 
-  // Attach tool status to agent messages. A turn (eventId) may now render as
-  // several bubbles (text → tool → text), so attach the status to only the first
-  // agent bubble of the turn — the one that triggered the tool. This keeps a
-  // single status badge and keeps it stable: it appears under the triggering
-  // message during loading instead of jumping to a later bubble when post-tool
-  // text arrives.
+  // Attach tool status to the first agent bubble of each turn only — a turn can
+  // render as several bubbles, but the badge should appear once.
   if (config.showAgentStatus) {
     const statusAttached = new Set<number>();
     for (let i = 0; i < result.length; i++) {

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -102,9 +102,9 @@ export function buildDisplayTranscript(
   }
 
   // Tracks whether a tool entry appeared since the last emitted message. Used to
-  // avoid merging two agent text segments of the same turn that are separated by
-  // a tool call — they share an eventId but are distinct bubbles, not a
-  // streamed-partial/finalized pair.
+  // protect a non-empty text segment that is followed by a tool call and then
+  // more text (text → tool → text): those are distinct bubbles of the same turn
+  // and must not be collapsed into one.
   let toolBetween = false;
 
   for (const entry of entries) {
@@ -134,17 +134,23 @@ export function buildDisplayTranscript(
     if (!config.transcriptEnabled && entry.type === "message" && !entry.isText)
       continue;
 
-    // Group consecutive messages with same eventId + role (collapses a streamed
-    // partial into its finalized message). Skip when a tool call separated them —
-    // those are distinct text segments of the same turn and must stay separate.
+    // Group consecutive messages with same eventId + role. This collapses a
+    // streamed partial into its finalized message, and folds the empty
+    // placeholders that bracket tool calls into the turn's real message.
+    //
+    // The one case we must NOT collapse: a non-empty text segment followed by a
+    // tool call and then more text (text → tool → text). Overwriting the first
+    // would lose it. So refuse to merge only when a tool separated the two AND
+    // the previous message already has real content; empty placeholders still
+    // merge freely across tools.
     const prev = result[result.length - 1];
     if (
-      !toolBetween &&
       entry.type === "message" &&
       entry.eventId != null &&
       prev?.type === "message" &&
       prev.eventId === entry.eventId &&
-      prev.role === entry.role
+      prev.role === entry.role &&
+      (!toolBetween || !prev.message)
     ) {
       result[result.length - 1] = entry;
       continue;


### PR DESCRIPTION
## Summary
Fixes a bug where two agent text segments in the same turn, separated by a tool call (text → tool → text), would collapse into one — the second text bubble overwrote the first in the rendered transcript.

## Root cause
`buildDisplayTranscript` merges consecutive messages that share an `eventId` + role, to collapse a streamed partial into its finalized version. But tool entries are skipped during result building, so two distinct agent text segments separated by a tool call appear "consecutive" — and since all segments in a turn share one `eventId`, the second segment overwrote the first.

This is a pre-existing bug from #528 (2026-02-24). It became visible once `agent_chat_response_part` streaming was re-enabled for voice sessions, which routes voice agent text through `eventId`-tagged rows.

## Fix
Track whether a tool entry appeared since the last emitted message (`toolBetween`). Skip the same-`eventId` merge when a tool call separated the two messages — those are distinct bubbles, not a partial/final pair. The streamed-partial/final collapse is unchanged.

## Test plan
- [x] New unit tests in `display-transcript.test.ts`:
  - text → tool → text segments stay as two separate bubbles
  - a streamed partial/final pair (no tool between) still collapses to the final message

BEFORE:

https://github.com/user-attachments/assets/e109f00d-f9bb-42ef-bb95-1cbc1c9eecd1


AFTER:

https://github.com/user-attachments/assets/36ef1212-4767-4ddc-b5c1-824ae012795a


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to convai widget transcript display logic with added unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **transcript rendering** when a single agent turn interleaves **text → tool → text** with the same `eventId`. Those segments no longer collapse into one bubble (where the later text overwrote the earlier).
> 
> `buildDisplayTranscript` tracks whether a **tool request/response** sat between consecutive messages (`toolBetween`). Same-`eventId` merges still collapse streamed partials and empty placeholders, but merges are skipped when a tool separated two **non-empty** text segments. Empty placeholders before/after tools still fold into the final message.
> 
> With **agent tool status** enabled, the tool badge attaches to the **first** agent bubble for that turn only, so multi-bubble turns do not duplicate the status badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8baeba9491fe07e46b86cab62d19994a6ecbaab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->