### PR TITLE
[types] Add changeset for PingEvent allowing null values

### DIFF
--- a/.changeset/cyan-baths-pull.md
+++ b/.changeset/cyan-baths-pull.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/types": minor
+---
+
+Allow null values for PingEvent

--- a/packages/types/generated/types/incoming.ts
+++ b/packages/types/generated/types/incoming.ts
@@ -20,7 +20,6 @@ export type {
   McpConnectionStatusClientEvent,
   McpToolCallClientEvent,
   PartialTranscriptMessage,
-  Ping,
   PingEvent,
   ScribeAuthErrorMessage,
   ScribeChunkSizeExceededErrorMessage,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small generated-types export tweak; possible compile breaks only if code imported Ping from incoming.ts, which is unlikely.
> 
> **Overview**
> Documents a **minor** `@elevenlabs/types` release for **`PingEvent`** payloads that may carry **`null`** (e.g. optional **`ping_ms`**), via a new changeset.
> 
> The **`incoming`** type barrel no longer re-exports the wrapper type **`Ping`**; it still exports **`PingEvent`**, so consumers importing incoming WebSocket payloads should use **`PingEvent`** (or import **`Ping`** from generated types elsewhere) instead of **`Ping`** from that barrel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6baf6df9f71d8e32b3697bb35648b1e7811b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->