### PR TITLE
docs(react-native-expo): document React Native Web support

### DIFF
--- a/examples/react-native-expo/README.md
+++ b/examples/react-native-expo/README.md
@@ -84,7 +84,13 @@ In the Extended Controls panel, enable "Virtual microphone uses host audio input
 
 ## Web
 
-Note that React Native Web is currently not supported. For web implementations please use the [ElevenLabs React SDK](https://elevenlabs.io/docs/conversational-ai/libraries/react).
+React Native Web is supported and has been since the v1 release of the SDK. You can run this example in the browser without a development build:
+
+```bash
+pnpm web
+```
+
+Or press `w` after starting the Expo dev server. Grant microphone permissions when prompted.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `examples/react-native-expo` README to reflect that React Native Web is supported (since the SDK v1 release), replacing the outdated note that directed users to the React SDK instead.

## Changes

- Replaced the "not supported" Web section with accurate documentation
- Added instructions for running the example in the browser via `pnpm web`

## Context

The example app already includes `react-native-web` and a `web` script in `package.json`. The SDK has supported web since v1 by re-exporting the conversation API without native side-effects.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2091c42d-1ad7-40b6-bf88-5c963ea71d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2091c42d-1ad7-40b6-bf88-5c963ea71d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

