### PR TITLE
[Agents] Render markdown for agent responses blocked-then-released by guardrails

### DIFF
--- a/.changeset/green-guards-grin.md
+++ b/.changeset/green-guards-grin.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Render markdown for text-only agent responses that arrive without streaming parts.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -296,7 +296,7 @@ function useConversationSetup() {
                   type: "message",
                   role,
                   message,
-                  isText: false,
+                  isText: conversationTextOnly.peek() === true,
                   conversationIndex: conversationIndex.peek(),
                   eventId: event_id,
                 },

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -465,6 +465,25 @@ describe("elevenlabs-convai", () => {
   });
 
   describe("markdown link allowlist", () => {
+    it("should render links from bare text-only agent responses", async () => {
+      setupWebComponent({
+        "agent-id": "markdown_agent_response",
+        variant: "compact",
+      });
+
+      const textInput = page.getByRole("textbox", {
+        name: "Text message input",
+      });
+      await textInput.fill("Text message");
+      await userEvent.keyboard("{Enter}");
+
+      const link = page.getByRole("link", { name: "setup guide" });
+      await expect.element(link).toBeInTheDocument();
+      await expect
+        .element(link)
+        .toHaveAttribute("href", "https://example.com/setup");
+    });
+
     it("should allow widget domain by default when config omits allowlist", async () => {
       setupWebComponent({
         "agent-id": "markdown_default_domain",

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -153,6 +153,16 @@ const codeBlock = true;
     default_expanded: true,
     first_message: `[Relative link](/relative)`,
   },
+  markdown_agent_response: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+    markdown_link_allowed_hosts: [{ hostname: "*" }],
+    first_message: "Agent response",
+  },
   tool_call: {
     ...BASIC_CONFIG,
     text_only: true,
@@ -292,11 +302,15 @@ export const Worker = setupWorker(
         agentId !== "file_upload" &&
         agentId !== "no_file_upload"
       ) {
+        const agentResponse =
+          agentId === "markdown_agent_response"
+            ? "Read the [setup guide](https://example.com/setup)."
+            : "Another agent response";
         client.send(
           JSON.stringify({
             type: "agent_response",
             agent_response_event: {
-              agent_response: "Another agent response",
+              agent_response: agentResponse,
               event_id: 2,
             },
           })


### PR DESCRIPTION
Slack: https://eleven-labs-workspace.slack.com/archives/C08A0QJ8YQH/p1782793448912399
Linear: AP-2457
Zendesk: #623804

**Why:**
Markdown links in agent responses render as raw text in the widget when the Content guardrail runs in Blocking execution mode. With blocking guardrails, the server suppresses `agent_chat_response_part` streaming events and delivers the response only as a single final `agent_response` event. The widget appended such messages with `isText: false`, routing them to the plain-text voice-transcript rendering path instead of the markdown renderer.

**What:**
- Agent `agent_response` events that arrive without a preceding streaming part now set `isText` from the conversation's text-only state (same derivation as the streaming path), so they render through the markdown renderer in text conversations.
- Voice conversations are unchanged: `isText` stays false there, preserving plain transcript rendering.
- Side changes, both consequences of the corrected `isText`: bare text-only agent responses are no longer filtered out when `transcript_enabled` is false, and `strip_audio_tags` no longer applies to them (stripping is voice-only). Both now match the behavior of streamed text responses.

Test: browser test reproducing the blocking-guardrail event shape (bare `agent_response` with a markdown link, no `agent_chat_response_part` events) and asserting the link renders. Verified it fails without the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line transcript flag change in the widget with a targeted test; voice rendering is unchanged.
> 
> **Overview**
> Fixes **markdown links showing as raw text** when blocking guardrails deliver the agent reply only as a final `agent_response` (no `agent_chat_response_part` stream).
> 
> In `conversation.tsx`, non-streaming `onMessage` transcript entries no longer hard-code `isText: false`; they use **`conversationTextOnly === true`**, matching the streaming path so text chats route agent replies through the markdown renderer. Voice sessions stay `isText: false`.
> 
> Adds a browser test and MSW mock (`markdown_agent_response`) that simulates a bare markdown `agent_response` after user text input and asserts the link renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e097e2129e0625489745aa85bae21323b9ef736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->