### PR TITLE
[Agents] Extract widget transcript ingestion into a pure reducer

### DIFF
--- a/.changeset/olive-papers-tell.md
+++ b/.changeset/olive-papers-tell.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Extract transcript ingestion into a pure reducer; no behavior change.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -1,10 +1,4 @@
-import {
-  Conversation,
-  Mode,
-  Role,
-  SessionConfig,
-  Status,
-} from "@elevenlabs/client";
+import { Conversation, Mode, SessionConfig, Status } from "@elevenlabs/client";
 import {
   computed,
   signal,
@@ -18,10 +12,24 @@ import { useSessionConfig } from "./session-config";
 import FingerprintJS from "@fingerprintjs/fingerprintjs";
 
 import { useContextSafely } from "../utils/useContextSafely";
+import {
+  applyTranscriptEvent,
+  createIngestState,
+  type TranscriptIngestContext,
+  type TranscriptIngestEvent,
+  type TranscriptIngestState,
+  type TranscriptEntry,
+  type TranscriptFileInput,
+} from "../utils/transcript-events";
 import { useTerms } from "./terms";
 import { useFirstMessage, useWidgetConfig } from "./widget-config";
 import { ConversationMode } from "./conversation-mode";
 import { useShadowHost } from "./shadow-host";
+
+export type {
+  TranscriptEntry,
+  TranscriptFileInput,
+} from "../utils/transcript-events";
 
 type ConversationSetup = ReturnType<typeof useConversationSetup>;
 
@@ -32,54 +40,6 @@ export const ConversationContext = createContext<ConversationSetup | null>(
 interface ConversationProviderProps {
   children: ComponentChildren;
 }
-
-/** File metadata stored alongside a user message in the local transcript. */
-export type TranscriptFileInput = {
-  fileName: string;
-  mimeType: string;
-  previewUrl: string | null;
-};
-
-export type TranscriptEntry =
-  | {
-      type: "message";
-      role: Role;
-      message: string;
-      isText: boolean;
-      conversationIndex: number;
-      eventId?: number;
-      fileInput?: TranscriptFileInput | null;
-    }
-  | {
-      type: "agent_tool_request";
-      toolName: string;
-      toolCallId: string;
-      eventId: number;
-      conversationIndex: number;
-    }
-  | {
-      type: "agent_tool_response";
-      toolCallId: string;
-      eventId: number;
-      isError: boolean;
-      conversationIndex: number;
-    }
-  | {
-      type: "disconnection";
-      role: Role;
-      message?: undefined;
-      conversationIndex: number;
-    }
-  | {
-      type: "error";
-      message: string;
-      conversationIndex: number;
-    }
-  | {
-      type: "mode_toggle";
-      mode: ConversationMode;
-      conversationIndex: number;
-    };
 
 export function ConversationProvider({ children }: ConversationProviderProps) {
   const value = useConversationSetup();
@@ -121,9 +81,7 @@ export function useCallButtonDisabled() {
 function useConversationSetup() {
   const conversationRef = useRef<Conversation | null>(null);
   const lockRef = useRef<Promise<Conversation> | null>(null);
-  const receivedFirstMessageRef = useRef(false);
-  const streamingMessageIndexRef = useRef<number | null>(null);
-  const isReceivingStreamRef = useRef(false);
+  const ingestStateRef = useRef<TranscriptIngestState>(createIngestState());
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shadowHost = useShadowHost();
 
@@ -174,6 +132,32 @@ function useConversationSetup() {
           isAgentTyping.value = false;
         }, durationMs);
       }
+    };
+
+    const ingestContext = (): TranscriptIngestContext => ({
+      isTextConversation: conversationTextOnly.peek() === true,
+      conversationIndex: conversationIndex.peek(),
+      suppressFirstAgentMessage:
+        !!firstMessage.peek() && conversationTextOnly.peek() === true,
+    });
+
+    // The only mutation path for the transcript: runs the pure ingest reducer
+    // and mirrors the resulting entries into the transcript signal. Returns
+    // whether the event was accepted (not dropped by first-message suppression).
+    const dispatchTranscriptEvent = (event: TranscriptIngestEvent): boolean => {
+      const result = applyTranscriptEvent(
+        ingestStateRef.current,
+        event,
+        ingestContext()
+      );
+      ingestStateRef.current = result.state;
+      transcript.value = result.state.entries;
+      return result.accepted;
+    };
+
+    const resetIngestState = () => {
+      ingestStateRef.current = createIngestState();
+      transcript.value = ingestStateRef.current.entries;
     };
 
     return {
@@ -230,17 +214,13 @@ function useConversationSetup() {
         }
 
         conversationTextOnly.value = processedConfig.textOnly ?? false;
-        transcript.value = initialMessage
-          ? [
-              {
-                type: "message",
-                role: "user",
-                message: initialMessage,
-                isText: true,
-                conversationIndex: conversationIndex.peek(),
-              },
-            ]
-          : [];
+        resetIngestState();
+        if (initialMessage) {
+          dispatchTranscriptEvent({
+            type: "user_message",
+            message: initialMessage,
+          });
+        }
 
         try {
           lockRef.current = Conversation.startSession({
@@ -255,122 +235,42 @@ function useConversationSetup() {
               canSendFeedback.value = props.canSendFeedback;
             },
             onMessage: ({ role, message, event_id }) => {
-              if (
-                firstMessage.peek() &&
-                conversationTextOnly.peek() === true &&
-                role === "agent" &&
-                !receivedFirstMessageRef.current
-              ) {
-                receivedFirstMessageRef.current = true;
-                // Text mode is always started by the user sending a text message.
-                // We need to ignore the first agent message as it is immediately
-                // interrupted by the user input.
-                return;
-              } else if (role === "agent") {
-                receivedFirstMessageRef.current = true;
+              const accepted = dispatchTranscriptEvent({
+                type: "message",
+                role,
+                message,
+                eventId: event_id,
+              });
+              if (accepted && role === "agent") {
                 setAgentTyping(false);
               }
-
-              if (role === "agent" && isReceivingStreamRef.current) {
-                const streamingIndex = streamingMessageIndexRef.current;
-                if (streamingIndex !== null) {
-                  const currentTranscript = transcript.peek();
-                  const updatedTranscript = [...currentTranscript];
-                  updatedTranscript[streamingIndex] = {
-                    type: "message",
-                    role: "agent",
-                    message,
-                    isText: conversationTextOnly.peek() === true,
-                    conversationIndex: conversationIndex.peek(),
-                    eventId: event_id,
-                  };
-                  transcript.value = updatedTranscript;
-                }
-                isReceivingStreamRef.current = false;
-                return;
-              }
-
-              transcript.value = [
-                ...transcript.peek(),
-                {
-                  type: "message",
-                  role,
-                  message,
-                  isText: conversationTextOnly.peek() === true,
-                  conversationIndex: conversationIndex.peek(),
-                  eventId: event_id,
-                },
-              ];
             },
             onAgentChatResponsePart: ({ text, type, event_id }) => {
-              if (
-                firstMessage.peek() &&
-                conversationTextOnly.peek() === true &&
-                !receivedFirstMessageRef.current
-              ) {
-                // Text mode is always started by the user sending a text message.
-                // We need to ignore the first agent message as it is immediately
-                // interrupted by the user input.
-                return;
-              }
-              setAgentTyping(false);
-
-              if (type === "start") {
-                isReceivingStreamRef.current = true;
-                const currentTranscript = transcript.peek();
-                streamingMessageIndexRef.current = currentTranscript.length;
-                transcript.value = [
-                  ...currentTranscript,
-                  {
-                    type: "message",
-                    role: "agent",
-                    message: "",
-                    isText: conversationTextOnly.peek() === true,
-                    conversationIndex: conversationIndex.peek(),
-                    eventId: event_id,
-                  },
-                ];
-              } else if (type === "delta") {
-                const streamingIndex = streamingMessageIndexRef.current;
-                if (streamingIndex !== null && text) {
-                  const currentTranscript = transcript.peek();
-                  const entry = currentTranscript[streamingIndex];
-                  if (entry.type === "message") {
-                    const updatedTranscript = [...currentTranscript];
-                    updatedTranscript[streamingIndex] = {
-                      ...entry,
-                      message: entry.message + text,
-                    };
-                    transcript.value = updatedTranscript;
-                  }
-                }
-              } else if (type === "stop") {
-                streamingMessageIndexRef.current = null;
+              const accepted = dispatchTranscriptEvent({
+                type: "response_part",
+                part: type,
+                text,
+                eventId: event_id,
+              });
+              if (accepted) {
+                setAgentTyping(false);
               }
             },
             onAgentToolRequest: ({ tool_call_id, tool_name, event_id }) => {
-              transcript.value = [
-                ...transcript.peek(),
-                {
-                  type: "agent_tool_request",
-                  toolName: tool_name,
-                  toolCallId: tool_call_id,
-                  eventId: event_id,
-                  conversationIndex: conversationIndex.peek(),
-                },
-              ];
+              dispatchTranscriptEvent({
+                type: "tool_request",
+                toolName: tool_name,
+                toolCallId: tool_call_id,
+                eventId: event_id,
+              });
             },
             onAgentToolResponse: ({ tool_call_id, is_error, event_id }) => {
-              transcript.value = [
-                ...transcript.peek(),
-                {
-                  type: "agent_tool_response",
-                  toolCallId: tool_call_id,
-                  eventId: event_id,
-                  isError: is_error,
-                  conversationIndex: conversationIndex.peek(),
-                },
-              ];
+              dispatchTranscriptEvent({
+                type: "tool_response",
+                toolCallId: tool_call_id,
+                isError: is_error,
+                eventId: event_id,
+              });
             },
             onAgentTyping: ({ is_typing, duration_ms }) => {
               setAgentTyping(is_typing, duration_ms);
@@ -379,27 +279,18 @@ function useConversationSetup() {
               isExternalAgentMode.value = true;
             },
             onDisconnect: details => {
-              receivedFirstMessageRef.current = false;
               conversationTextOnly.value = null;
-              streamingMessageIndexRef.current = null;
-              isReceivingStreamRef.current = false;
               clearTypingTimer();
               isAgentTyping.value = false;
               isExternalAgentMode.value = false;
-              transcript.value = [
-                ...transcript.peek(),
+              dispatchTranscriptEvent(
                 details.reason === "error"
-                  ? {
-                      type: "error",
-                      message: details.message,
-                      conversationIndex: conversationIndex.peek(),
-                    }
+                  ? { type: "error", message: details.message }
                   : {
                       type: "disconnection",
                       role: details.reason === "user" ? "user" : "agent",
-                      conversationIndex: conversationIndex.peek(),
-                    },
-              ];
+                    }
+              );
               conversationIndex.value++;
               if (details.reason === "error") {
                 error.value = details.message;
@@ -430,14 +321,7 @@ function useConversationSetup() {
             message = e.message || message;
           }
           error.value = message;
-          transcript.value = [
-            ...transcript.value,
-            {
-              type: "error",
-              message,
-              conversationIndex: conversationIndex.peek(),
-            },
-          ];
+          dispatchTranscriptEvent({ type: "error", message });
         } finally {
           lockRef.current = null;
         }
@@ -464,16 +348,7 @@ function useConversationSetup() {
       },
       sendUserMessage: (text: string) => {
         conversationRef.current?.sendUserMessage(text);
-        transcript.value = [
-          ...transcript.value,
-          {
-            type: "message",
-            role: "user",
-            message: text,
-            isText: true,
-            conversationIndex: conversationIndex.peek(),
-          },
-        ];
+        dispatchTranscriptEvent({ type: "user_message", message: text });
       },
       sendMultimodalMessage: (input: {
         text?: string;
@@ -485,17 +360,11 @@ function useConversationSetup() {
           text: trimmed || undefined,
           fileId,
         });
-        transcript.value = [
-          ...transcript.value,
-          {
-            type: "message",
-            role: "user",
-            message: trimmed,
-            isText: true,
-            conversationIndex: conversationIndex.peek(),
-            fileInput,
-          },
-        ];
+        dispatchTranscriptEvent({
+          type: "user_message",
+          message: trimmed,
+          fileInput,
+        });
       },
       sendUserActivity: () => {
         conversationRef.current?.sendUserActivity();
@@ -506,14 +375,7 @@ function useConversationSetup() {
       addModeToggleEntry: (mode: ConversationMode) => {
         // Only add entry if conversation is active
         if (!conversationRef.current?.isOpen()) return;
-        transcript.value = [
-          ...transcript.value,
-          {
-            type: "mode_toggle",
-            mode,
-            conversationIndex: conversationIndex.peek(),
-          },
-        ];
+        dispatchTranscriptEvent({ type: "mode_toggle", mode });
       },
     };
   }, [config]);

--- a/packages/convai-widget-core/src/utils/transcript-events.test.ts
+++ b/packages/convai-widget-core/src/utils/transcript-events.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTranscriptEvent,
+  createIngestState,
+  type TranscriptEntry,
+  type TranscriptIngestContext,
+  type TranscriptIngestEvent,
+  type TranscriptIngestState,
+} from "./transcript-events";
+
+const voiceContext: TranscriptIngestContext = {
+  isTextConversation: false,
+  conversationIndex: 0,
+  suppressFirstAgentMessage: false,
+};
+
+const textContext: TranscriptIngestContext = {
+  ...voiceContext,
+  isTextConversation: true,
+};
+
+const suppressedTextContext: TranscriptIngestContext = {
+  ...textContext,
+  suppressFirstAgentMessage: true,
+};
+
+/** Run a sequence of events through the reducer and return the final state. */
+function run(
+  events: TranscriptIngestEvent[],
+  context: TranscriptIngestContext = voiceContext,
+  state: TranscriptIngestState = createIngestState()
+): TranscriptIngestState {
+  return events.reduce(
+    (current, event) => applyTranscriptEvent(current, event, context).state,
+    state
+  );
+}
+
+function agentMessage(
+  message: string,
+  eventId?: number
+): TranscriptIngestEvent {
+  return { type: "message", role: "agent", message, eventId };
+}
+
+function part(
+  partType: "start" | "delta" | "stop",
+  text = "",
+  eventId?: number
+): TranscriptIngestEvent {
+  return { type: "response_part", part: partType, text, eventId };
+}
+
+describe("applyTranscriptEvent", () => {
+  describe("message isText derivation", () => {
+    it.each<{
+      description: string;
+      context: TranscriptIngestContext;
+      event: TranscriptIngestEvent;
+      expected: Partial<Extract<TranscriptEntry, { type: "message" }>>;
+    }>([
+      {
+        description: "agent message in a voice conversation is not text",
+        context: voiceContext,
+        event: agentMessage("Hello", 1),
+        expected: {
+          role: "agent",
+          message: "Hello",
+          isText: false,
+          eventId: 1,
+        },
+      },
+      {
+        description:
+          "agent message in a text conversation is text (blocking-guardrail shape)",
+        context: textContext,
+        event: agentMessage("See the [guide](https://example.com)", 1),
+        expected: { role: "agent", isText: true },
+      },
+      {
+        description: "user voice transcript is not text",
+        context: voiceContext,
+        event: { type: "message", role: "user", message: "Hi", eventId: 2 },
+        expected: { role: "user", message: "Hi", isText: false },
+      },
+      {
+        description: "local user message is always text",
+        context: voiceContext,
+        event: { type: "user_message", message: "typed" },
+        expected: { role: "user", message: "typed", isText: true },
+      },
+    ])("$description", ({ context, event, expected }) => {
+      const state = run([event], context);
+      expect(state.entries).toHaveLength(1);
+      expect(state.entries[0]).toMatchObject(expected);
+    });
+  });
+
+  describe("first-agent-message suppression", () => {
+    it("drops the first agent message and reports it as not accepted", () => {
+      const result = applyTranscriptEvent(
+        createIngestState(),
+        agentMessage("interrupted first message"),
+        suppressedTextContext
+      );
+      expect(result.accepted).toBe(false);
+      expect(result.state.entries).toEqual([]);
+      expect(result.state.receivedFirstAgentMessage).toBe(true);
+    });
+
+    it("accepts the second agent message", () => {
+      const state = run(
+        [agentMessage("first"), agentMessage("second")],
+        suppressedTextContext
+      );
+      expect(state.entries).toHaveLength(1);
+      expect(state.entries[0]).toMatchObject({ message: "second" });
+    });
+
+    it("does not suppress user messages", () => {
+      const result = applyTranscriptEvent(
+        createIngestState(),
+        { type: "message", role: "user", message: "hi" },
+        suppressedTextContext
+      );
+      expect(result.accepted).toBe(true);
+      expect(result.state.entries).toHaveLength(1);
+      expect(result.state.receivedFirstAgentMessage).toBe(false);
+    });
+
+    it("ignores response parts before the first agent message without consuming the suppression", () => {
+      const state = run(
+        [part("start", "", 1), part("delta", "chunk", 1)],
+        suppressedTextContext
+      );
+      expect(state.entries).toEqual([]);
+      expect(state.receivedFirstAgentMessage).toBe(false);
+      expect(state.isReceivingStream).toBe(false);
+    });
+
+    it("does not suppress when the context flag is off", () => {
+      const state = run([agentMessage("first")], textContext);
+      expect(state.entries).toHaveLength(1);
+    });
+  });
+
+  describe("streaming response parts", () => {
+    it("start appends an empty agent entry and begins the stream", () => {
+      const state = run([part("start", "", 5)], textContext);
+      expect(state.entries).toHaveLength(1);
+      expect(state.entries[0]).toMatchObject({
+        role: "agent",
+        message: "",
+        isText: true,
+        eventId: 5,
+      });
+      expect(state.streamingEntryIndex).toBe(0);
+      expect(state.isReceivingStream).toBe(true);
+    });
+
+    it("deltas accumulate into the streamed entry", () => {
+      const state = run(
+        [part("start", "", 5), part("delta", "Hel", 5), part("delta", "lo", 5)],
+        textContext
+      );
+      expect(state.entries[0]).toMatchObject({ message: "Hello" });
+    });
+
+    it.each<{ description: string; events: TranscriptIngestEvent[] }>([
+      {
+        description: "delta without an active stream is a no-op",
+        events: [part("delta", "orphan", 5)],
+      },
+      {
+        description: "empty delta text is a no-op",
+        events: [part("start", "", 5), part("delta", "", 5)],
+      },
+    ])("$description", ({ events }) => {
+      const state = run(events, textContext);
+      const messages = state.entries.filter(e => e.type === "message");
+      expect(messages.every(e => e.message === "")).toBe(true);
+    });
+
+    it("stop ends delta accumulation but keeps the stream open for the final message", () => {
+      const state = run(
+        [part("start", "", 5), part("stop", "", 5)],
+        textContext
+      );
+      expect(state.streamingEntryIndex).toBe(null);
+      expect(state.isReceivingStream).toBe(true);
+    });
+  });
+
+  describe("stream finalization by the full message", () => {
+    it("replaces the streamed entry with the final message", () => {
+      const state = run(
+        [
+          part("start", "", 5),
+          part("delta", "Hel", 5),
+          agentMessage("Hello there", 5),
+        ],
+        textContext
+      );
+      expect(state.entries).toHaveLength(1);
+      expect(state.entries[0]).toMatchObject({
+        message: "Hello there",
+        isText: true,
+        eventId: 5,
+      });
+      expect(state.isReceivingStream).toBe(false);
+    });
+
+    it("replaces the streamed entry when the final message arrives before stop (server order)", () => {
+      const state = run(
+        [
+          part("start", "", 5),
+          agentMessage("Hello there", 5),
+          part("stop", "", 5),
+        ],
+        textContext
+      );
+      expect(state.entries).toHaveLength(1);
+      expect(state.entries[0]).toMatchObject({ message: "Hello there" });
+      expect(state.streamingEntryIndex).toBe(null);
+      expect(state.isReceivingStream).toBe(false);
+    });
+
+    it("drops the final message when the stream already stopped, keeping the streamed entry", () => {
+      const state = run(
+        [
+          part("start", "", 5),
+          part("delta", "Hello", 5),
+          part("stop", "", 5),
+          agentMessage("Hello", 5),
+        ],
+        textContext
+      );
+      expect(state.entries).toHaveLength(1);
+      expect(state.entries[0]).toMatchObject({ message: "Hello" });
+      expect(state.isReceivingStream).toBe(false);
+    });
+
+    it("appends instead of replacing once the previous stream was finalized", () => {
+      const state = run(
+        [
+          part("start", "", 5),
+          agentMessage("first", 5),
+          part("stop", "", 5),
+          agentMessage("second", 6),
+        ],
+        textContext
+      );
+      expect(state.entries).toHaveLength(2);
+      expect(state.entries[1]).toMatchObject({ message: "second" });
+    });
+  });
+
+  describe("tool and local events", () => {
+    it("appends tool request and response entries", () => {
+      const state = run([
+        {
+          type: "tool_request",
+          toolName: "search",
+          toolCallId: "c1",
+          eventId: 3,
+        },
+        { type: "tool_response", toolCallId: "c1", isError: true, eventId: 3 },
+      ]);
+      expect(state.entries).toEqual([
+        {
+          type: "agent_tool_request",
+          toolName: "search",
+          toolCallId: "c1",
+          eventId: 3,
+          conversationIndex: 0,
+        },
+        {
+          type: "agent_tool_response",
+          toolCallId: "c1",
+          isError: true,
+          eventId: 3,
+          conversationIndex: 0,
+        },
+      ]);
+    });
+
+    it("attaches fileInput to user messages only when provided", () => {
+      const fileInput = {
+        fileName: "doc.pdf",
+        mimeType: "application/pdf",
+        previewUrl: null,
+      };
+      const state = run([
+        { type: "user_message", message: "with file", fileInput },
+        { type: "user_message", message: "without file" },
+      ]);
+      expect(state.entries[0]).toMatchObject({ fileInput });
+      expect(state.entries[1]).not.toHaveProperty("fileInput");
+    });
+
+    it("appends mode toggle entries", () => {
+      const state = run([{ type: "mode_toggle", mode: "text" }]);
+      expect(state.entries[0]).toEqual({
+        type: "mode_toggle",
+        mode: "text",
+        conversationIndex: 0,
+      });
+    });
+
+    it("stamps entries with the context conversationIndex", () => {
+      const state = run([agentMessage("hi")], {
+        ...voiceContext,
+        conversationIndex: 2,
+      });
+      expect(state.entries[0]).toMatchObject({ conversationIndex: 2 });
+    });
+  });
+
+  describe("disconnection and error", () => {
+    it.each<{
+      description: string;
+      event: TranscriptIngestEvent;
+      expected: Partial<TranscriptEntry>;
+    }>([
+      {
+        description: "disconnection appends an entry with the ending role",
+        event: { type: "disconnection", role: "user" },
+        expected: { type: "disconnection", role: "user" },
+      },
+      {
+        description: "error appends an error entry",
+        event: { type: "error", message: "boom" },
+        expected: { type: "error", message: "boom" },
+      },
+    ])("$description", ({ event, expected }) => {
+      const state = run(
+        [
+          agentMessage("first"),
+          part("start", "", 5),
+          part("delta", "in flight", 5),
+          event,
+        ],
+        textContext
+      );
+      expect(state.entries[state.entries.length - 1]).toMatchObject(expected);
+      // Ingest bookkeeping resets so the next session starts clean.
+      expect(state.streamingEntryIndex).toBe(null);
+      expect(state.isReceivingStream).toBe(false);
+      expect(state.receivedFirstAgentMessage).toBe(false);
+    });
+  });
+});

--- a/packages/convai-widget-core/src/utils/transcript-events.ts
+++ b/packages/convai-widget-core/src/utils/transcript-events.ts
@@ -1,0 +1,317 @@
+import type { Role } from "@elevenlabs/client";
+import type { ConversationMode } from "../contexts/conversation-mode";
+
+/** File metadata stored alongside a user message in the local transcript. */
+export type TranscriptFileInput = {
+  fileName: string;
+  mimeType: string;
+  previewUrl: string | null;
+};
+
+export type TranscriptEntry =
+  | {
+      type: "message";
+      role: Role;
+      message: string;
+      isText: boolean;
+      conversationIndex: number;
+      eventId?: number;
+      fileInput?: TranscriptFileInput | null;
+    }
+  | {
+      type: "agent_tool_request";
+      toolName: string;
+      toolCallId: string;
+      eventId: number;
+      conversationIndex: number;
+    }
+  | {
+      type: "agent_tool_response";
+      toolCallId: string;
+      eventId: number;
+      isError: boolean;
+      conversationIndex: number;
+    }
+  | {
+      type: "disconnection";
+      role: Role;
+      message?: undefined;
+      conversationIndex: number;
+    }
+  | {
+      type: "error";
+      message: string;
+      conversationIndex: number;
+    }
+  | {
+      type: "mode_toggle";
+      mode: ConversationMode;
+      conversationIndex: number;
+    };
+
+export interface TranscriptIngestState {
+  entries: TranscriptEntry[];
+  /** Index of the entry being built up by streaming parts, null outside a stream. */
+  streamingEntryIndex: number | null;
+  /** True from a stream "start" part until the final full message finalizes it. */
+  isReceivingStream: boolean;
+  /** True once the first agent message of the session has arrived. */
+  receivedFirstAgentMessage: boolean;
+}
+
+export function createIngestState(): TranscriptIngestState {
+  return {
+    entries: [],
+    streamingEntryIndex: null,
+    isReceivingStream: false,
+    receivedFirstAgentMessage: false,
+  };
+}
+
+export interface TranscriptIngestContext {
+  /** True when the current conversation is text-only. */
+  isTextConversation: boolean;
+  conversationIndex: number;
+  /**
+   * Text mode is always started by the user sending a text message. When a
+   * configured first message exists in a text-only conversation, the first
+   * agent message must be ignored as it is immediately interrupted by the
+   * user input.
+   */
+  suppressFirstAgentMessage: boolean;
+}
+
+export type TranscriptIngestEvent =
+  | { type: "message"; role: Role; message: string; eventId?: number }
+  | {
+      type: "response_part";
+      part: "start" | "delta" | "stop";
+      text: string;
+      eventId?: number;
+    }
+  | {
+      type: "tool_request";
+      toolName: string;
+      toolCallId: string;
+      eventId: number;
+    }
+  | {
+      type: "tool_response";
+      toolCallId: string;
+      isError: boolean;
+      eventId: number;
+    }
+  | { type: "user_message"; message: string; fileInput?: TranscriptFileInput }
+  | { type: "mode_toggle"; mode: ConversationMode }
+  | { type: "disconnection"; role: Role }
+  | { type: "error"; message: string };
+
+export interface TranscriptIngestResult {
+  state: TranscriptIngestState;
+  /** False when the event was ignored by first-agent-message suppression. */
+  accepted: boolean;
+}
+
+export function applyTranscriptEvent(
+  state: TranscriptIngestState,
+  event: TranscriptIngestEvent,
+  context: TranscriptIngestContext
+): TranscriptIngestResult {
+  switch (event.type) {
+    case "message":
+      return applyMessage(state, event, context);
+    case "response_part":
+      return applyResponsePart(state, event, context);
+    case "tool_request":
+      return accept(
+        append(state, {
+          type: "agent_tool_request",
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          eventId: event.eventId,
+          conversationIndex: context.conversationIndex,
+        })
+      );
+    case "tool_response":
+      return accept(
+        append(state, {
+          type: "agent_tool_response",
+          toolCallId: event.toolCallId,
+          eventId: event.eventId,
+          isError: event.isError,
+          conversationIndex: context.conversationIndex,
+        })
+      );
+    case "user_message": {
+      const entry: Extract<TranscriptEntry, { type: "message" }> = {
+        type: "message",
+        role: "user",
+        message: event.message,
+        isText: true,
+        conversationIndex: context.conversationIndex,
+      };
+      if (event.fileInput) {
+        entry.fileInput = event.fileInput;
+      }
+      return accept(append(state, entry));
+    }
+    case "mode_toggle":
+      return accept(
+        append(state, {
+          type: "mode_toggle",
+          mode: event.mode,
+          conversationIndex: context.conversationIndex,
+        })
+      );
+    case "disconnection":
+      return accept(
+        resetIngestBookkeeping(
+          append(state, {
+            type: "disconnection",
+            role: event.role,
+            conversationIndex: context.conversationIndex,
+          })
+        )
+      );
+    case "error":
+      return accept(
+        resetIngestBookkeeping(
+          append(state, {
+            type: "error",
+            message: event.message,
+            conversationIndex: context.conversationIndex,
+          })
+        )
+      );
+  }
+}
+
+function applyMessage(
+  state: TranscriptIngestState,
+  event: Extract<TranscriptIngestEvent, { type: "message" }>,
+  context: TranscriptIngestContext
+): TranscriptIngestResult {
+  const { role, message, eventId } = event;
+
+  if (
+    role === "agent" &&
+    context.suppressFirstAgentMessage &&
+    !state.receivedFirstAgentMessage
+  ) {
+    return {
+      state: { ...state, receivedFirstAgentMessage: true },
+      accepted: false,
+    };
+  }
+
+  const entry: Extract<TranscriptEntry, { type: "message" }> = {
+    type: "message",
+    role,
+    message,
+    isText: context.isTextConversation,
+    conversationIndex: context.conversationIndex,
+    eventId,
+  };
+  const receivedFirstAgentMessage =
+    role === "agent" || state.receivedFirstAgentMessage;
+
+  if (role === "agent" && state.isReceivingStream) {
+    // The full message finalizes the entry built up by streaming parts. If the
+    // stream already stopped (streamingEntryIndex is null), the streamed entry
+    // holds the full text and the event is dropped to avoid a duplicate.
+    const entries =
+      state.streamingEntryIndex !== null
+        ? replaceEntryAt(state.entries, state.streamingEntryIndex, entry)
+        : state.entries;
+    return accept({
+      ...state,
+      entries,
+      isReceivingStream: false,
+      receivedFirstAgentMessage,
+    });
+  }
+
+  return accept({
+    ...append(state, entry),
+    receivedFirstAgentMessage,
+  });
+}
+
+function applyResponsePart(
+  state: TranscriptIngestState,
+  event: Extract<TranscriptIngestEvent, { type: "response_part" }>,
+  context: TranscriptIngestContext
+): TranscriptIngestResult {
+  if (context.suppressFirstAgentMessage && !state.receivedFirstAgentMessage) {
+    return { state, accepted: false };
+  }
+
+  if (event.part === "start") {
+    return accept({
+      ...append(state, {
+        type: "message",
+        role: "agent",
+        message: "",
+        isText: context.isTextConversation,
+        conversationIndex: context.conversationIndex,
+        eventId: event.eventId,
+      }),
+      streamingEntryIndex: state.entries.length,
+      isReceivingStream: true,
+    });
+  }
+
+  if (event.part === "delta") {
+    const index = state.streamingEntryIndex;
+    if (index === null || !event.text) {
+      return accept(state);
+    }
+    const entry = state.entries[index];
+    if (entry?.type !== "message") {
+      return accept(state);
+    }
+    return accept({
+      ...state,
+      entries: replaceEntryAt(state.entries, index, {
+        ...entry,
+        message: entry.message + event.text,
+      }),
+    });
+  }
+
+  // "stop" only ends delta accumulation; isReceivingStream stays set so the
+  // final full message is not appended as a duplicate of the streamed entry.
+  return accept({ ...state, streamingEntryIndex: null });
+}
+
+function append(
+  state: TranscriptIngestState,
+  entry: TranscriptEntry
+): TranscriptIngestState {
+  return { ...state, entries: [...state.entries, entry] };
+}
+
+function replaceEntryAt(
+  entries: TranscriptEntry[],
+  index: number,
+  entry: TranscriptEntry
+): TranscriptEntry[] {
+  const updated = [...entries];
+  updated[index] = entry;
+  return updated;
+}
+
+function resetIngestBookkeeping(
+  state: TranscriptIngestState
+): TranscriptIngestState {
+  return {
+    ...state,
+    streamingEntryIndex: null,
+    isReceivingStream: false,
+    receivedFirstAgentMessage: false,
+  };
+}
+
+function accept(state: TranscriptIngestState): TranscriptIngestResult {
+  return { state, accepted: true };
+}


### PR DESCRIPTION
Follow-up to https://github.com/elevenlabs/packages/pull/871
Linear: AP-2457

**Why:**
Transcript entries were constructed inline at five call sites in `useConversationSetup`, each re-deriving `isText` independently, with streaming bookkeeping spread across three mutable refs threaded through the SDK callbacks. One of those call sites hardcoding `isText: false` caused the markdown regression fixed in #871. This centralizes the logic so that class of bug has one home and unit-level coverage.

**What:**
- New `utils/transcript-events.ts`: pure `applyTranscriptEvent(state, event, context)` reducer that owns all `TranscriptEntry` construction, `isText` derivation, streaming start/delta/stop bookkeeping, and first-agent-message suppression. It returns `{ state, accepted }`; `accepted` is false only when suppression drops the event, which the hook uses to decide typing-indicator clearing.
- `contexts/conversation.tsx`: the three refs (`isReceivingStreamRef`, `streamingMessageIndexRef`, `receivedFirstMessageRef`) collapse into one ingest-state ref; every SDK callback and send method now dispatches a single event through the reducer, which is the only mutation path for the transcript signal.
- `TranscriptEntry`/`TranscriptFileInput` types move to the new module and are re-exported from `contexts/conversation.tsx`, so existing importers are unaffected.
- Existing quirks are preserved and now documented and pinned by tests: a final `agent_response` arriving after the stream `stop` is dropped (the streamed entry already holds the text); response parts arriving under first-message suppression are ignored without consuming the suppression; `stop` clears the streaming index but keeps the stream open until the final message.

**Scope:**
- No behavior change intended; the full browser suite passes unchanged.
- Two unobservable ordering changes: typing-indicator clearing happens after the transcript write instead of before (same synchronous callback), and `startSession` with an initial message performs two transcript signal writes (reset, then append) instead of one.
- Session lifecycle (`lockRef`, terms, fingerprinting), first-message suppression semantics, and the conversation context shape are untouched.

**Test:** 24 table-driven unit tests for the reducer in `utils/transcript-events.test.ts`, covering `isText` derivation (including the blocking-guardrail event shape from AP-2457), suppression, streaming sequences and finalization orderings, tool/local events, and disconnect resets.

_Written by claude-fable-5, using Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core live-conversation transcript and streaming semantics across many SDK callbacks; regressions would show as wrong messages, duplicates, or markdown/`isText` bugs, though coverage and an explicit no-behavior-change goal mitigate risk.
> 
> **Overview**
> Moves **widget transcript building** out of inline SDK callbacks into a new **`applyTranscriptEvent`** pure reducer in `utils/transcript-events.ts`, with **`dispatchTranscriptEvent`** as the only path that updates the transcript signal in `conversation.tsx`.
> 
> **`TranscriptEntry`** / **`TranscriptFileInput`** types live in the new module and are re-exported from `conversation.tsx` so existing imports stay the same. Three mutable refs for streaming and first-agent suppression are replaced by a single **ingest state** ref.
> 
> The reducer centralizes **`isText`** derivation, streaming start/delta/stop handling, first-agent-message suppression (returns **`accepted`** for typing-indicator behavior), and tool/disconnect/error/local user events. **24 unit tests** in `transcript-events.test.ts` pin prior behavior (including post-`stop` duplicate message drop).
> 
> Intended **no user-visible behavior change**; minor ordering: typing clears after transcript write, and `startSession` with an initial message may trigger two signal updates (reset then append).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c30a21bcac6b57c49f3fcf41dde242cae1de3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->