### PR TITLE
Widget text contents default translations

### DIFF
--- a/packages/convai-widget-core/src/contexts/text-contents.tsx
+++ b/packages/convai-widget-core/src/contexts/text-contents.tsx
@@ -1,7 +1,13 @@
-import { computed, ReadonlySignal, useComputed } from "@preact/signals";
+import {
+  computed,
+  ReadonlySignal,
+  useComputed,
+  useSignalEffect,
+} from "@preact/signals";
 import { ComponentChildren } from "preact";
 import { createContext, useMemo } from "preact/compat";
 import { DefaultTextContents, TextContents, TextKeys } from "../types/config";
+import { ensureTranslationLoaded, loadedTranslations } from "../translations";
 import { useAttribute } from "./attributes";
 import { useWidgetConfig } from "./widget-config";
 
@@ -37,6 +43,10 @@ export function TextContentsProvider({ children }: TextContentsProviderProps) {
     return {};
   });
 
+  useSignalEffect(() => {
+    ensureTranslationLoaded(language.value.languageCode);
+  });
+
   const value = useMemo(() => {
     return Object.fromEntries(
       TextKeys.map(key => [
@@ -47,6 +57,7 @@ export function TextContentsProvider({ children }: TextContentsProviderProps) {
             config.value.language_presets?.[language.value.languageCode]
               ?.text_contents?.[key] ??
             config.value.text_contents?.[key] ??
+            loadedTranslations.value[language.value.languageCode]?.[key] ??
             DefaultTextContents[key]
         ),
       ])

--- a/packages/convai-widget-core/src/translations/af.ts
+++ b/packages/convai-widget-core/src/translations/af.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Afrikaans (af) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const af: Partial<TextContents> = {};
+
+export default af;

--- a/packages/convai-widget-core/src/translations/ar.ts
+++ b/packages/convai-widget-core/src/translations/ar.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Arabic (ar) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ar: Partial<TextContents> = {};
+
+export default ar;

--- a/packages/convai-widget-core/src/translations/as.ts
+++ b/packages/convai-widget-core/src/translations/as.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Assamese (as) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const as: Partial<TextContents> = {};
+
+export default as;

--- a/packages/convai-widget-core/src/translations/az.ts
+++ b/packages/convai-widget-core/src/translations/az.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Azerbaijani (az) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const az: Partial<TextContents> = {};
+
+export default az;

--- a/packages/convai-widget-core/src/translations/be.ts
+++ b/packages/convai-widget-core/src/translations/be.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Belarusian (be) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const be: Partial<TextContents> = {};
+
+export default be;

--- a/packages/convai-widget-core/src/translations/bg.ts
+++ b/packages/convai-widget-core/src/translations/bg.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Bulgarian (bg) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const bg: Partial<TextContents> = {};
+
+export default bg;

--- a/packages/convai-widget-core/src/translations/bn.ts
+++ b/packages/convai-widget-core/src/translations/bn.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Bengali (bn) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const bn: Partial<TextContents> = {};
+
+export default bn;

--- a/packages/convai-widget-core/src/translations/bs.ts
+++ b/packages/convai-widget-core/src/translations/bs.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Bosnian (bs) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const bs: Partial<TextContents> = {};
+
+export default bs;

--- a/packages/convai-widget-core/src/translations/ca.ts
+++ b/packages/convai-widget-core/src/translations/ca.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Catalan (ca) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ca: Partial<TextContents> = {};
+
+export default ca;

--- a/packages/convai-widget-core/src/translations/cs.ts
+++ b/packages/convai-widget-core/src/translations/cs.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Czech (cs) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const cs: Partial<TextContents> = {};
+
+export default cs;

--- a/packages/convai-widget-core/src/translations/cy.ts
+++ b/packages/convai-widget-core/src/translations/cy.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Welsh (cy) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const cy: Partial<TextContents> = {};
+
+export default cy;

--- a/packages/convai-widget-core/src/translations/da.ts
+++ b/packages/convai-widget-core/src/translations/da.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Danish (da) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const da: Partial<TextContents> = {};
+
+export default da;

--- a/packages/convai-widget-core/src/translations/de.ts
+++ b/packages/convai-widget-core/src/translations/de.ts
@@ -1,0 +1,68 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * German (de) localized default text contents.
+ *
+ * Machine-generated for a conversational AI chat widget; review before relying
+ * on in production. Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`.
+ */
+const de: Partial<TextContents> = {
+  main_label: "Brauchst du Hilfe?",
+  start_call: "Anruf starten",
+  start_chat: "Nachricht",
+  send_message: "Senden",
+  new_call: "Neuer Anruf",
+  end_call: "Beenden",
+  mute_microphone: "Mikrofon stummschalten",
+  text_mode: "Zum Textmodus wechseln",
+  voice_mode: "Zum Sprachmodus wechseln",
+  switched_to_text_mode: "Zum Textmodus gewechselt",
+  switched_to_voice_mode: "Zum Sprachmodus gewechselt",
+  change_language: "Sprache ändern",
+  collapse: "Einklappen",
+  expand: "Ausklappen",
+  copied: "Kopiert!",
+  accept_terms: "Akzeptieren",
+  dismiss_terms: "Abbrechen",
+
+  listening_status: "Hört zu",
+  speaking_status: "Sprich, um zu unterbrechen",
+  connecting_status: "Verbindung wird hergestellt",
+  chatting_status: "Chat mit KI-Agent",
+
+  input_label: "Texteingabe",
+  input_placeholder: "Nachricht senden...",
+  input_placeholder_text_only: "Nachricht senden...",
+  input_placeholder_new_conversation: "Neue Unterhaltung starten",
+
+  user_ended_conversation: "Du hast die Unterhaltung beendet",
+  agent_ended_conversation: "Der Agent hat die Unterhaltung beendet",
+  conversation_id: "ID",
+  error_occurred: "Ein Fehler ist aufgetreten",
+  copy_id: "ID kopieren",
+  initiate_feedback: "Wie war diese Unterhaltung?",
+  request_follow_up_feedback: "Erzähl uns mehr",
+  thanks_for_feedback: "Vielen Dank für dein Feedback!",
+  thanks_for_feedback_details:
+    "Dein Feedback hilft uns, unseren Service zu verbessern und dich in Zukunft besser zu unterstützen.",
+  follow_up_feedback_placeholder: "Erzähl uns mehr über deine Erfahrung...",
+  submit: "Absenden",
+  go_back: "Zurück",
+  copy: "Kopieren",
+  download: "Herunterladen",
+  wrap: "Umbrechen",
+  agent_working: "Arbeitet...",
+  agent_done: "Abgeschlossen",
+  agent_error: "Ein Fehler ist aufgetreten",
+  attach_file: "Datei anhängen",
+  remove_file: "Datei entfernen",
+  file_upload_error: "Datei konnte nicht hochgeladen werden.",
+  file_type_unsupported: "Nicht unterstützter Dateityp. Zulässige Typen:",
+  file_too_large: "Die Dateigröße überschreitet das maximale Limit.",
+  file_limit_reached:
+    "Maximale Anzahl an Dateien für diese Unterhaltung erreicht.",
+  typing_indicator: "Agent schreibt ...",
+};
+
+export default de;

--- a/packages/convai-widget-core/src/translations/el.ts
+++ b/packages/convai-widget-core/src/translations/el.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Greek (el) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const el: Partial<TextContents> = {};
+
+export default el;

--- a/packages/convai-widget-core/src/translations/es.ts
+++ b/packages/convai-widget-core/src/translations/es.ts
@@ -1,0 +1,68 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Spanish (es) localized default text contents.
+ *
+ * Machine-generated for a conversational AI chat widget; review before relying
+ * on in production. Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`.
+ */
+const es: Partial<TextContents> = {
+  main_label: "¿Necesitas ayuda?",
+  start_call: "Iniciar llamada",
+  start_chat: "Mensaje",
+  send_message: "Enviar",
+  new_call: "Nueva llamada",
+  end_call: "Finalizar",
+  mute_microphone: "Silenciar micrófono",
+  text_mode: "Cambiar a modo texto",
+  voice_mode: "Cambiar a modo voz",
+  switched_to_text_mode: "Cambiado a modo texto",
+  switched_to_voice_mode: "Cambiado a modo voz",
+  change_language: "Cambiar idioma",
+  collapse: "Contraer",
+  expand: "Expandir",
+  copied: "¡Copiado!",
+  accept_terms: "Aceptar",
+  dismiss_terms: "Cancelar",
+
+  listening_status: "Escuchando",
+  speaking_status: "Habla para interrumpir",
+  connecting_status: "Conectando",
+  chatting_status: "Chateando con el agente de IA",
+
+  input_label: "Entrada de mensaje de texto",
+  input_placeholder: "Envía un mensaje...",
+  input_placeholder_text_only: "Envía un mensaje...",
+  input_placeholder_new_conversation: "Inicia una nueva conversación",
+
+  user_ended_conversation: "Finalizaste la conversación",
+  agent_ended_conversation: "El agente finalizó la conversación",
+  conversation_id: "ID",
+  error_occurred: "Se produjo un error",
+  copy_id: "Copiar ID",
+  initiate_feedback: "¿Qué te pareció esta conversación?",
+  request_follow_up_feedback: "Cuéntanos más",
+  thanks_for_feedback: "¡Gracias por tus comentarios!",
+  thanks_for_feedback_details:
+    "Tus comentarios nos ayudan a mejorar nuestro servicio y a brindarte una mejor atención en el futuro.",
+  follow_up_feedback_placeholder: "Cuéntanos más sobre tu experiencia...",
+  submit: "Enviar",
+  go_back: "Volver",
+  copy: "Copiar",
+  download: "Descargar",
+  wrap: "Ajustar líneas",
+  agent_working: "Trabajando...",
+  agent_done: "Completado",
+  agent_error: "Se produjo un error",
+  attach_file: "Adjuntar archivo",
+  remove_file: "Eliminar archivo",
+  file_upload_error: "No se pudo subir el archivo.",
+  file_type_unsupported: "Tipo de archivo no admitido. Tipos aceptados:",
+  file_too_large: "El tamaño del archivo supera el límite máximo.",
+  file_limit_reached:
+    "Se alcanzó el número máximo de archivos para esta conversación.",
+  typing_indicator: "El agente está escribiendo ...",
+};
+
+export default es;

--- a/packages/convai-widget-core/src/translations/et.ts
+++ b/packages/convai-widget-core/src/translations/et.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Estonian (et) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const et: Partial<TextContents> = {};
+
+export default et;

--- a/packages/convai-widget-core/src/translations/fa.ts
+++ b/packages/convai-widget-core/src/translations/fa.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Persian (fa) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const fa: Partial<TextContents> = {};
+
+export default fa;

--- a/packages/convai-widget-core/src/translations/fi.ts
+++ b/packages/convai-widget-core/src/translations/fi.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Finnish (fi) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const fi: Partial<TextContents> = {};
+
+export default fi;

--- a/packages/convai-widget-core/src/translations/fr.ts
+++ b/packages/convai-widget-core/src/translations/fr.ts
@@ -1,0 +1,68 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * French (fr) localized default text contents.
+ *
+ * Machine-generated for a conversational AI chat widget; review before relying
+ * on in production. Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`.
+ */
+const fr: Partial<TextContents> = {
+  main_label: "Besoin d'aide ?",
+  start_call: "Démarrer un appel",
+  start_chat: "Message",
+  send_message: "Envoyer",
+  new_call: "Nouvel appel",
+  end_call: "Terminer",
+  mute_microphone: "Couper le micro",
+  text_mode: "Passer en mode texte",
+  voice_mode: "Passer en mode vocal",
+  switched_to_text_mode: "Passé en mode texte",
+  switched_to_voice_mode: "Passé en mode vocal",
+  change_language: "Changer de langue",
+  collapse: "Réduire",
+  expand: "Développer",
+  copied: "Copié !",
+  accept_terms: "Accepter",
+  dismiss_terms: "Annuler",
+
+  listening_status: "À l'écoute",
+  speaking_status: "Parlez pour interrompre",
+  connecting_status: "Connexion",
+  chatting_status: "Discussion avec l'agent IA",
+
+  input_label: "Saisie de message texte",
+  input_placeholder: "Envoyez un message...",
+  input_placeholder_text_only: "Envoyez un message...",
+  input_placeholder_new_conversation: "Démarrer une nouvelle conversation",
+
+  user_ended_conversation: "Vous avez mis fin à la conversation",
+  agent_ended_conversation: "L'agent a mis fin à la conversation",
+  conversation_id: "ID",
+  error_occurred: "Une erreur s'est produite",
+  copy_id: "Copier l'ID",
+  initiate_feedback: "Comment s'est passée cette conversation ?",
+  request_follow_up_feedback: "Dites-nous en plus",
+  thanks_for_feedback: "Merci pour votre retour !",
+  thanks_for_feedback_details:
+    "Vos retours nous aident à améliorer notre service et à mieux vous accompagner à l'avenir.",
+  follow_up_feedback_placeholder: "Dites-nous en plus sur votre expérience...",
+  submit: "Envoyer",
+  go_back: "Retour",
+  copy: "Copier",
+  download: "Télécharger",
+  wrap: "Retour à la ligne",
+  agent_working: "En cours...",
+  agent_done: "Terminé",
+  agent_error: "Une erreur s'est produite",
+  attach_file: "Joindre un fichier",
+  remove_file: "Supprimer le fichier",
+  file_upload_error: "Échec du téléchargement du fichier.",
+  file_type_unsupported: "Type de fichier non pris en charge. Types acceptés :",
+  file_too_large: "La taille du fichier dépasse la limite maximale.",
+  file_limit_reached:
+    "Nombre maximal de fichiers atteint pour cette conversation.",
+  typing_indicator: "L'agent est en train d'écrire ...",
+};
+
+export default fr;

--- a/packages/convai-widget-core/src/translations/ga.ts
+++ b/packages/convai-widget-core/src/translations/ga.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Irish (ga) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ga: Partial<TextContents> = {};
+
+export default ga;

--- a/packages/convai-widget-core/src/translations/gl.ts
+++ b/packages/convai-widget-core/src/translations/gl.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Galician (gl) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const gl: Partial<TextContents> = {};
+
+export default gl;

--- a/packages/convai-widget-core/src/translations/gu.ts
+++ b/packages/convai-widget-core/src/translations/gu.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Gujarati (gu) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const gu: Partial<TextContents> = {};
+
+export default gu;

--- a/packages/convai-widget-core/src/translations/ha.ts
+++ b/packages/convai-widget-core/src/translations/ha.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Hausa (ha) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ha: Partial<TextContents> = {};
+
+export default ha;

--- a/packages/convai-widget-core/src/translations/he.ts
+++ b/packages/convai-widget-core/src/translations/he.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Hebrew (he) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const he: Partial<TextContents> = {};
+
+export default he;

--- a/packages/convai-widget-core/src/translations/hi.ts
+++ b/packages/convai-widget-core/src/translations/hi.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Hindi (hi) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const hi: Partial<TextContents> = {};
+
+export default hi;

--- a/packages/convai-widget-core/src/translations/hr.ts
+++ b/packages/convai-widget-core/src/translations/hr.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Croatian (hr) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const hr: Partial<TextContents> = {};
+
+export default hr;

--- a/packages/convai-widget-core/src/translations/hu.ts
+++ b/packages/convai-widget-core/src/translations/hu.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Hungarian (hu) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const hu: Partial<TextContents> = {};
+
+export default hu;

--- a/packages/convai-widget-core/src/translations/hy.ts
+++ b/packages/convai-widget-core/src/translations/hy.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Armenian (hy) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const hy: Partial<TextContents> = {};
+
+export default hy;

--- a/packages/convai-widget-core/src/translations/id.ts
+++ b/packages/convai-widget-core/src/translations/id.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Indonesian (id) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const id: Partial<TextContents> = {};
+
+export default id;

--- a/packages/convai-widget-core/src/translations/index.ts
+++ b/packages/convai-widget-core/src/translations/index.ts
@@ -1,0 +1,122 @@
+import { signal } from "@preact/signals";
+import type { Language } from "@elevenlabs/client";
+import type { TextContents } from "../types/config";
+
+type TranslationModule = { default: Partial<TextContents> };
+
+/**
+ * Per-language loaders for localized default text contents.
+ *
+ * Each entry is a dynamic import so the bundler emits a separate chunk per
+ * language; only the language actually in use is fetched at runtime, keeping
+ * the main widget bundle small. English lives in `DefaultTextContents` and is
+ * always available synchronously as the ultimate fallback.
+ */
+const loaders: Partial<Record<Language, () => Promise<TranslationModule>>> = {
+  zh: () => import("./zh"),
+  es: () => import("./es"),
+  hi: () => import("./hi"),
+  pt: () => import("./pt"),
+  "pt-br": () => import("./pt-br"),
+  fr: () => import("./fr"),
+  de: () => import("./de"),
+  ja: () => import("./ja"),
+  ar: () => import("./ar"),
+  ru: () => import("./ru"),
+  ko: () => import("./ko"),
+  id: () => import("./id"),
+  it: () => import("./it"),
+  nl: () => import("./nl"),
+  tr: () => import("./tr"),
+  pl: () => import("./pl"),
+  sv: () => import("./sv"),
+  ms: () => import("./ms"),
+  ro: () => import("./ro"),
+  uk: () => import("./uk"),
+  el: () => import("./el"),
+  cs: () => import("./cs"),
+  da: () => import("./da"),
+  fi: () => import("./fi"),
+  bg: () => import("./bg"),
+  hr: () => import("./hr"),
+  sk: () => import("./sk"),
+  ta: () => import("./ta"),
+  hu: () => import("./hu"),
+  no: () => import("./no"),
+  vi: () => import("./vi"),
+  tl: () => import("./tl"),
+  af: () => import("./af"),
+  hy: () => import("./hy"),
+  as: () => import("./as"),
+  az: () => import("./az"),
+  be: () => import("./be"),
+  bn: () => import("./bn"),
+  bs: () => import("./bs"),
+  ca: () => import("./ca"),
+  et: () => import("./et"),
+  gl: () => import("./gl"),
+  ka: () => import("./ka"),
+  gu: () => import("./gu"),
+  ha: () => import("./ha"),
+  he: () => import("./he"),
+  is: () => import("./is"),
+  ga: () => import("./ga"),
+  jv: () => import("./jv"),
+  kn: () => import("./kn"),
+  kk: () => import("./kk"),
+  ky: () => import("./ky"),
+  lv: () => import("./lv"),
+  lt: () => import("./lt"),
+  lb: () => import("./lb"),
+  mk: () => import("./mk"),
+  ml: () => import("./ml"),
+  mr: () => import("./mr"),
+  ne: () => import("./ne"),
+  ps: () => import("./ps"),
+  fa: () => import("./fa"),
+  pa: () => import("./pa"),
+  sr: () => import("./sr"),
+  sd: () => import("./sd"),
+  sl: () => import("./sl"),
+  so: () => import("./so"),
+  sw: () => import("./sw"),
+  te: () => import("./te"),
+  th: () => import("./th"),
+  ur: () => import("./ur"),
+  cy: () => import("./cy"),
+};
+
+export const loadedTranslations = signal<
+  Partial<Record<Language, Partial<TextContents>>>
+>({});
+
+const inFlight = new Set<Language>();
+
+export function ensureTranslationLoaded(language: Language): void {
+  console.log("in translations index", loadedTranslations);
+
+  if (loadedTranslations.peek()[language] || inFlight.has(language)) {
+    return;
+  }
+  const load = loaders[language];
+  if (!load) {
+    return;
+  }
+  inFlight.add(language);
+  load()
+    .then(mod => {
+      loadedTranslations.value = {
+        ...loadedTranslations.value,
+        [language]: mod.default,
+      };
+    })
+    .catch(e => {
+      console.error(
+        `[ConversationalAI] Failed to load translations for "${language}":`,
+        e
+      );
+    })
+    .finally(() => {
+      inFlight.delete(language);
+    });
+}

--- a/packages/convai-widget-core/src/translations/index.ts
+++ b/packages/convai-widget-core/src/translations/index.ts
@@ -93,8 +93,6 @@ export const loadedTranslations = signal<
 const inFlight = new Set<Language>();
 
 export function ensureTranslationLoaded(language: Language): void {
-  console.log("in translations index", loadedTranslations);
-
   if (loadedTranslations.peek()[language] || inFlight.has(language)) {
     return;
   }

--- a/packages/convai-widget-core/src/translations/is.ts
+++ b/packages/convai-widget-core/src/translations/is.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Icelandic (is) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const is: Partial<TextContents> = {};
+
+export default is;

--- a/packages/convai-widget-core/src/translations/it.ts
+++ b/packages/convai-widget-core/src/translations/it.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Italian (it) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const it: Partial<TextContents> = {};
+
+export default it;

--- a/packages/convai-widget-core/src/translations/ja.ts
+++ b/packages/convai-widget-core/src/translations/ja.ts
@@ -1,0 +1,67 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Japanese (ja) localized default text contents.
+ *
+ * Machine-generated for a conversational AI chat widget; review before relying
+ * on in production. Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`.
+ */
+const ja: Partial<TextContents> = {
+  main_label: "お困りですか？",
+  start_call: "通話を開始",
+  start_chat: "メッセージ",
+  send_message: "送信",
+  new_call: "新しい通話",
+  end_call: "終了",
+  mute_microphone: "マイクをミュート",
+  text_mode: "テキストモードに切り替え",
+  voice_mode: "音声モードに切り替え",
+  switched_to_text_mode: "テキストモードに切り替えました",
+  switched_to_voice_mode: "音声モードに切り替えました",
+  change_language: "言語を変更",
+  collapse: "折りたたむ",
+  expand: "展開",
+  copied: "コピーしました！",
+  accept_terms: "同意する",
+  dismiss_terms: "キャンセル",
+
+  listening_status: "聞き取り中",
+  speaking_status: "話しかけて中断",
+  connecting_status: "接続中",
+  chatting_status: "AIエージェントとチャット中",
+
+  input_label: "テキストメッセージ入力",
+  input_placeholder: "メッセージを送信...",
+  input_placeholder_text_only: "メッセージを送信...",
+  input_placeholder_new_conversation: "新しい会話を開始",
+
+  user_ended_conversation: "会話を終了しました",
+  agent_ended_conversation: "エージェントが会話を終了しました",
+  conversation_id: "ID",
+  error_occurred: "エラーが発生しました",
+  copy_id: "IDをコピー",
+  initiate_feedback: "この会話はいかがでしたか？",
+  request_follow_up_feedback: "詳しく教えてください",
+  thanks_for_feedback: "フィードバックありがとうございます！",
+  thanks_for_feedback_details:
+    "いただいたフィードバックは、サービスの改善と今後のより良いサポートに役立てさせていただきます。",
+  follow_up_feedback_placeholder: "ご感想を詳しくお聞かせください...",
+  submit: "送信",
+  go_back: "戻る",
+  copy: "コピー",
+  download: "ダウンロード",
+  wrap: "折り返し",
+  agent_working: "処理中...",
+  agent_done: "完了",
+  agent_error: "エラーが発生しました",
+  attach_file: "ファイルを添付",
+  remove_file: "ファイルを削除",
+  file_upload_error: "ファイルのアップロードに失敗しました。",
+  file_type_unsupported: "サポートされていないファイル形式です。対応形式:",
+  file_too_large: "ファイルサイズが上限を超えています。",
+  file_limit_reached: "この会話で添付できるファイルの上限に達しました。",
+  typing_indicator: "エージェントが入力中 ...",
+};
+
+export default ja;

--- a/packages/convai-widget-core/src/translations/jv.ts
+++ b/packages/convai-widget-core/src/translations/jv.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Javanese (jv) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const jv: Partial<TextContents> = {};
+
+export default jv;

--- a/packages/convai-widget-core/src/translations/ka.ts
+++ b/packages/convai-widget-core/src/translations/ka.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Georgian (ka) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ka: Partial<TextContents> = {};
+
+export default ka;

--- a/packages/convai-widget-core/src/translations/kk.ts
+++ b/packages/convai-widget-core/src/translations/kk.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Kazakh (kk) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const kk: Partial<TextContents> = {};
+
+export default kk;

--- a/packages/convai-widget-core/src/translations/kn.ts
+++ b/packages/convai-widget-core/src/translations/kn.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Kannada (kn) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const kn: Partial<TextContents> = {};
+
+export default kn;

--- a/packages/convai-widget-core/src/translations/ko.ts
+++ b/packages/convai-widget-core/src/translations/ko.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Korean (ko) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ko: Partial<TextContents> = {};
+
+export default ko;

--- a/packages/convai-widget-core/src/translations/ky.ts
+++ b/packages/convai-widget-core/src/translations/ky.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Kyrgyz (ky) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ky: Partial<TextContents> = {};
+
+export default ky;

--- a/packages/convai-widget-core/src/translations/lb.ts
+++ b/packages/convai-widget-core/src/translations/lb.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Luxembourgish (lb) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const lb: Partial<TextContents> = {};
+
+export default lb;

--- a/packages/convai-widget-core/src/translations/lt.ts
+++ b/packages/convai-widget-core/src/translations/lt.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Lithuanian (lt) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const lt: Partial<TextContents> = {};
+
+export default lt;

--- a/packages/convai-widget-core/src/translations/lv.ts
+++ b/packages/convai-widget-core/src/translations/lv.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Latvian (lv) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const lv: Partial<TextContents> = {};
+
+export default lv;

--- a/packages/convai-widget-core/src/translations/mk.ts
+++ b/packages/convai-widget-core/src/translations/mk.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Macedonian (mk) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const mk: Partial<TextContents> = {};
+
+export default mk;

--- a/packages/convai-widget-core/src/translations/ml.ts
+++ b/packages/convai-widget-core/src/translations/ml.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Malayalam (ml) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ml: Partial<TextContents> = {};
+
+export default ml;

--- a/packages/convai-widget-core/src/translations/mr.ts
+++ b/packages/convai-widget-core/src/translations/mr.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Marathi (mr) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const mr: Partial<TextContents> = {};
+
+export default mr;

--- a/packages/convai-widget-core/src/translations/ms.ts
+++ b/packages/convai-widget-core/src/translations/ms.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Malay (ms) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ms: Partial<TextContents> = {};
+
+export default ms;

--- a/packages/convai-widget-core/src/translations/ne.ts
+++ b/packages/convai-widget-core/src/translations/ne.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Nepali (ne) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ne: Partial<TextContents> = {};
+
+export default ne;

--- a/packages/convai-widget-core/src/translations/nl.ts
+++ b/packages/convai-widget-core/src/translations/nl.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Dutch (nl) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const nl: Partial<TextContents> = {};
+
+export default nl;

--- a/packages/convai-widget-core/src/translations/no.ts
+++ b/packages/convai-widget-core/src/translations/no.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Norwegian (no) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const no: Partial<TextContents> = {};
+
+export default no;

--- a/packages/convai-widget-core/src/translations/pa.ts
+++ b/packages/convai-widget-core/src/translations/pa.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Punjabi (pa) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const pa: Partial<TextContents> = {};
+
+export default pa;

--- a/packages/convai-widget-core/src/translations/pl.ts
+++ b/packages/convai-widget-core/src/translations/pl.ts
@@ -1,0 +1,67 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Polish (pl) localized default text contents.
+ *
+ * Machine-generated for a conversational AI chat widget; review before relying
+ * on in production. Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`.
+ */
+const pl: Partial<TextContents> = {
+  main_label: "Potrzebujesz pomocy?",
+  start_call: "Rozpocznij rozmowę",
+  start_chat: "Wiadomość",
+  send_message: "Wyślij",
+  new_call: "Nowa rozmowa",
+  end_call: "Zakończ",
+  mute_microphone: "Wycisz mikrofon",
+  text_mode: "Przełącz na tryb tekstowy",
+  voice_mode: "Przełącz na tryb głosowy",
+  switched_to_text_mode: "Przełączono na tryb tekstowy",
+  switched_to_voice_mode: "Przełączono na tryb głosowy",
+  change_language: "Zmień język",
+  collapse: "Zwiń",
+  expand: "Rozwiń",
+  copied: "Skopiowano!",
+  accept_terms: "Akceptuję",
+  dismiss_terms: "Anuluj",
+
+  listening_status: "Słucham",
+  speaking_status: "Mów, aby przerwać",
+  connecting_status: "Łączenie",
+  chatting_status: "Rozmowa z agentem AI",
+
+  input_label: "Pole wpisywania wiadomości",
+  input_placeholder: "Wyślij wiadomość...",
+  input_placeholder_text_only: "Wyślij wiadomość...",
+  input_placeholder_new_conversation: "Rozpocznij nową rozmowę",
+
+  user_ended_conversation: "Zakończyłeś rozmowę",
+  agent_ended_conversation: "Agent zakończył rozmowę",
+  conversation_id: "ID",
+  error_occurred: "Wystąpił błąd",
+  copy_id: "Kopiuj ID",
+  initiate_feedback: "Jak oceniasz tę rozmowę?",
+  request_follow_up_feedback: "Powiedz nam więcej",
+  thanks_for_feedback: "Dziękujemy za opinię!",
+  thanks_for_feedback_details:
+    "Twoja opinia pomaga nam ulepszać naszą usługę i lepiej wspierać Cię w przyszłości.",
+  follow_up_feedback_placeholder: "Opowiedz nam więcej o swoich wrażeniach...",
+  submit: "Wyślij",
+  go_back: "Wróć",
+  copy: "Kopiuj",
+  download: "Pobierz",
+  wrap: "Zawijaj wiersze",
+  agent_working: "Pracuję...",
+  agent_done: "Ukończono",
+  agent_error: "Wystąpił błąd",
+  attach_file: "Załącz plik",
+  remove_file: "Usuń plik",
+  file_upload_error: "Nie udało się przesłać pliku.",
+  file_type_unsupported: "Nieobsługiwany typ pliku. Akceptowane typy:",
+  file_too_large: "Rozmiar pliku przekracza maksymalny limit.",
+  file_limit_reached: "Osiągnięto maksymalną liczbę plików dla tej rozmowy.",
+  typing_indicator: "Agent pisze ...",
+};
+
+export default pl;

--- a/packages/convai-widget-core/src/translations/ps.ts
+++ b/packages/convai-widget-core/src/translations/ps.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Pashto (ps) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ps: Partial<TextContents> = {};
+
+export default ps;

--- a/packages/convai-widget-core/src/translations/pt-br.ts
+++ b/packages/convai-widget-core/src/translations/pt-br.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Portuguese (Brazil) (pt-br) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ptBr: Partial<TextContents> = {};
+
+export default ptBr;

--- a/packages/convai-widget-core/src/translations/pt.ts
+++ b/packages/convai-widget-core/src/translations/pt.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Portuguese (Portugal) (pt) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const pt: Partial<TextContents> = {};
+
+export default pt;

--- a/packages/convai-widget-core/src/translations/ro.ts
+++ b/packages/convai-widget-core/src/translations/ro.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Romanian (ro) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ro: Partial<TextContents> = {};
+
+export default ro;

--- a/packages/convai-widget-core/src/translations/ru.ts
+++ b/packages/convai-widget-core/src/translations/ru.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Russian (ru) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ru: Partial<TextContents> = {};
+
+export default ru;

--- a/packages/convai-widget-core/src/translations/sd.ts
+++ b/packages/convai-widget-core/src/translations/sd.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Sindhi (sd) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const sd: Partial<TextContents> = {};
+
+export default sd;

--- a/packages/convai-widget-core/src/translations/sk.ts
+++ b/packages/convai-widget-core/src/translations/sk.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Slovak (sk) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const sk: Partial<TextContents> = {};
+
+export default sk;

--- a/packages/convai-widget-core/src/translations/sl.ts
+++ b/packages/convai-widget-core/src/translations/sl.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Slovenian (sl) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const sl: Partial<TextContents> = {};
+
+export default sl;

--- a/packages/convai-widget-core/src/translations/so.ts
+++ b/packages/convai-widget-core/src/translations/so.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Somali (so) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const so: Partial<TextContents> = {};
+
+export default so;

--- a/packages/convai-widget-core/src/translations/sr.ts
+++ b/packages/convai-widget-core/src/translations/sr.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Serbian (sr) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const sr: Partial<TextContents> = {};
+
+export default sr;

--- a/packages/convai-widget-core/src/translations/sv.ts
+++ b/packages/convai-widget-core/src/translations/sv.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Swedish (sv) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const sv: Partial<TextContents> = {};
+
+export default sv;

--- a/packages/convai-widget-core/src/translations/sw.ts
+++ b/packages/convai-widget-core/src/translations/sw.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Swahili (sw) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const sw: Partial<TextContents> = {};
+
+export default sw;

--- a/packages/convai-widget-core/src/translations/ta.ts
+++ b/packages/convai-widget-core/src/translations/ta.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Tamil (ta) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ta: Partial<TextContents> = {};
+
+export default ta;

--- a/packages/convai-widget-core/src/translations/te.ts
+++ b/packages/convai-widget-core/src/translations/te.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Telugu (te) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const te: Partial<TextContents> = {};
+
+export default te;

--- a/packages/convai-widget-core/src/translations/th.ts
+++ b/packages/convai-widget-core/src/translations/th.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Thai (th) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const th: Partial<TextContents> = {};
+
+export default th;

--- a/packages/convai-widget-core/src/translations/tl.ts
+++ b/packages/convai-widget-core/src/translations/tl.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Filipino (tl) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const tl: Partial<TextContents> = {};
+
+export default tl;

--- a/packages/convai-widget-core/src/translations/tr.ts
+++ b/packages/convai-widget-core/src/translations/tr.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Turkish (tr) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const tr: Partial<TextContents> = {};
+
+export default tr;

--- a/packages/convai-widget-core/src/translations/uk.ts
+++ b/packages/convai-widget-core/src/translations/uk.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Ukrainian (uk) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const uk: Partial<TextContents> = {};
+
+export default uk;

--- a/packages/convai-widget-core/src/translations/ur.ts
+++ b/packages/convai-widget-core/src/translations/ur.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Urdu (ur) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const ur: Partial<TextContents> = {};
+
+export default ur;

--- a/packages/convai-widget-core/src/translations/vi.ts
+++ b/packages/convai-widget-core/src/translations/vi.ts
@@ -1,0 +1,11 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Vietnamese (vi) localized default text contents.
+ *
+ * Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`. Add translated strings as they become available.
+ */
+const vi: Partial<TextContents> = {};
+
+export default vi;

--- a/packages/convai-widget-core/src/translations/zh.ts
+++ b/packages/convai-widget-core/src/translations/zh.ts
@@ -1,0 +1,67 @@
+import type { TextContents } from "../types/config";
+
+/**
+ * Chinese (Simplified) (zh) localized default text contents.
+ *
+ * Machine-generated for a conversational AI chat widget; review before relying
+ * on in production. Any key omitted here falls back to the English defaults in
+ * `DefaultTextContents`.
+ */
+const zh: Partial<TextContents> = {
+  main_label: "需要帮助吗？",
+  start_call: "开始通话",
+  start_chat: "发消息",
+  send_message: "发送",
+  new_call: "新通话",
+  end_call: "结束",
+  mute_microphone: "静音麦克风",
+  text_mode: "切换到文字模式",
+  voice_mode: "切换到语音模式",
+  switched_to_text_mode: "已切换到文字模式",
+  switched_to_voice_mode: "已切换到语音模式",
+  change_language: "更改语言",
+  collapse: "收起",
+  expand: "展开",
+  copied: "已复制！",
+  accept_terms: "接受",
+  dismiss_terms: "取消",
+
+  listening_status: "正在聆听",
+  speaking_status: "说话即可打断",
+  connecting_status: "正在连接",
+  chatting_status: "正在与 AI 智能体聊天",
+
+  input_label: "文字消息输入",
+  input_placeholder: "发送消息...",
+  input_placeholder_text_only: "发送消息...",
+  input_placeholder_new_conversation: "开始新对话",
+
+  user_ended_conversation: "您已结束对话",
+  agent_ended_conversation: "智能体已结束对话",
+  conversation_id: "ID",
+  error_occurred: "发生错误",
+  copy_id: "复制 ID",
+  initiate_feedback: "这次对话怎么样？",
+  request_follow_up_feedback: "告诉我们更多",
+  thanks_for_feedback: "感谢您的反馈！",
+  thanks_for_feedback_details:
+    "您的反馈有助于我们改进服务，并在未来为您提供更好的支持。",
+  follow_up_feedback_placeholder: "请告诉我们更多关于您的体验...",
+  submit: "提交",
+  go_back: "返回",
+  copy: "复制",
+  download: "下载",
+  wrap: "自动换行",
+  agent_working: "处理中...",
+  agent_done: "已完成",
+  agent_error: "发生错误",
+  attach_file: "添加附件",
+  remove_file: "移除文件",
+  file_upload_error: "文件上传失败。",
+  file_type_unsupported: "不支持的文件类型。支持的类型：",
+  file_too_large: "文件大小超出上限。",
+  file_limit_reached: "已达到此对话的文件数量上限。",
+  typing_indicator: "智能体正在输入 ...",
+};
+
+export default zh;


### PR DESCRIPTION
(Prototype before translating to all languages)

Introduces built-in, per-language default UI strings for the ConvAI widget so that when a visitor uses a non-English language, the widget shows localized text instead of falling back to English. Translations are lazy-loaded per language to keep the main bundle unchanged.