### PR TITLE
Expose ping events via a dedicated onPing callback

### DIFF
--- a/.changeset/ping-events-onping.md
+++ b/.changeset/ping-events-onping.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": patch
+---
+
+Add a dedicated `onPing` callback that surfaces `ping` events (including the estimated `ping_ms`) to consumers. The SDK still replies to pings with a `pong` automatically; the callback is informational, useful for e.g. reporting connection latency. Also clarifies the documentation for `ping_ms`: "Estimated ping in milliseconds, based on previous ping/pong timing."

--- a/examples/agent-testbench/src/components/agent-page.tsx
+++ b/examples/agent-testbench/src/components/agent-page.tsx
@@ -38,6 +38,7 @@ const EVENT_METHOD_NAMES = [
   "onAgentChatResponsePart",
   "onAudioAlignment",
   "onGuardrailTriggered",
+  "onPing",
   "onDebug",
 ] satisfies (keyof PartialOptions)[];
 

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -210,6 +210,61 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("ping events", () => {
+    it("replies with a pong and forwards the payload to onPing", async () => {
+      const onPing = vi.fn();
+      const onDebug = vi.fn();
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      const conversation = TestConversation.create(
+        { onPing, onDebug },
+        connection
+      );
+
+      await conversation.receiveMessage({
+        type: "ping",
+        ping_event: {
+          event_id: 99,
+          ping_ms: 42,
+        },
+      });
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "pong",
+        event_id: 99,
+      });
+      expect(onPing).toHaveBeenCalledWith({
+        event_id: 99,
+        ping_ms: 42,
+      });
+      expect(onDebug).not.toHaveBeenCalled();
+    });
+
+    it("still replies with a pong when no onPing callback is provided", async () => {
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      const conversation = TestConversation.create({}, connection);
+
+      await conversation.receiveMessage({
+        type: "ping",
+        ping_event: {
+          event_id: 7,
+        },
+      });
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "pong",
+        event_id: 7,
+      });
+    });
+  });
+
   describe("agent_tool_response_full_payload events", () => {
     const basePayload = {
       tool_name: "lookup_kb",

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -18,6 +18,7 @@ import type {
   IncomingSocketEvent,
   InternalTentativeAgentResponseEvent,
   InterruptionEvent,
+  PingEvent,
   UserTranscriptionEvent,
   VadScoreEvent,
   MCPToolCallClientEvent,
@@ -137,6 +138,7 @@ export abstract class BaseConversation {
       onAgentResponseCorrection: () => {},
       onAgentTyping: () => {},
       onExternalAgentConnected: () => {},
+      onPing: () => {},
       ...partialOptions,
       textOnly,
       overrides: {
@@ -270,6 +272,12 @@ export abstract class BaseConversation {
       this.options.onVadScore({
         vadScore: event.vad_score_event.vad_score,
       });
+    }
+  }
+
+  protected handlePing(event: PingEvent) {
+    if (this.options.onPing) {
+      this.options.onPing(event.ping_event);
     }
   }
 
@@ -490,8 +498,10 @@ export abstract class BaseConversation {
           type: "pong",
           event_id: parsedEvent.ping_event.event_id,
         });
-        // parsedEvent.ping_event.ping_ms can be used on client side, for example
-        // to warn if ping is too high that experience might be degraded.
+        // Surface the ping event (including the estimated `ping_ms`) so
+        // consumers can, for example, warn when latency is high enough to
+        // degrade the experience.
+        this.handlePing(parsedEvent);
         return;
       }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -32,6 +32,7 @@ export type {
 export type {
   IncomingSocketEvent,
   VadScoreEvent,
+  PingEvent,
   AudioAlignmentEvent,
 } from "./utils/events.js";
 export type {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -13,6 +13,7 @@ import type {
   Interruption,
   AgentResponseCorrection,
   AgentChatResponsePartClientEvent,
+  Ping,
 } from "@elevenlabs/types";
 
 /**
@@ -123,6 +124,16 @@ export type Callbacks = {
   onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   onAgentTyping?: (props: AgentTypingClientEvent["agent_typing_event"]) => void;
   onExternalAgentConnected?: () => void;
+  /**
+   * Called for every `ping` event received from the server. The SDK
+   * automatically replies with a `pong`, so this callback is purely
+   * informational — a common use is surfacing connection latency to the user.
+   *
+   * The `ping_ms` property is the estimated ping in milliseconds, based on
+   * previous ping/pong timing. It may be `undefined` or `null` when no
+   * estimate is available yet.
+   */
+  onPing?: (props: Ping["ping_event"]) => void;
   // internal debug events, not to be used
   onDebug?: (props: any) => void;
 };
@@ -155,5 +166,6 @@ export const CALLBACK_KEYS = [
   "onGuardrailTriggered",
   "onAgentTyping",
   "onExternalAgentConnected",
+  "onPing",
   "onDebug",
 ] as const satisfies readonly (keyof Callbacks)[];

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -45,6 +45,7 @@ export type HookCallbacks = Pick<
   | "onGuardrailTriggered"
   | "onAgentTyping"
   | "onExternalAgentConnected"
+  | "onPing"
 >;
 
 export type HookOptions = Partial<

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -1157,7 +1157,7 @@ components:
           anyOf:
             - type: integer
             - type: "null"
-          description: Estimated round-trip time in milliseconds
+          description: Estimated ping in milliseconds, based on previous ping/pong timing.
 
     ASRInitiationMetadataPayload:
       type: object


### PR DESCRIPTION
## Summary

Adds a dedicated `onPing` callback so consumers can observe `ping` events (including the estimated `ping_ms`) without relying on `onDebug`.

The SDK still auto-replies to pings with a `pong`; the new callback is purely informational — a common use is surfacing connection latency to the user.

## Changes

- **client** — `handlePing()` handler (mirrors `handleVadScore`), invoked from the `ping` case (pong reply retained); `onPing` added to default options and `CALLBACK_KEYS`; `onPing?: (props: Ping["ping_event"]) => void` added to `Callbacks` with JSDoc documenting `ping_ms`; `PingEvent` type re-exported.
- **react** — `onPing` added to `HookCallbacks` (the rest auto-wires via `CALLBACK_KEYS`).
- **types** — `ping_ms` schema description clarified to "Estimated ping in milliseconds, based on previous ping/pong timing."

## Note on documentation

The type generator currently emits no JSDoc from schema descriptions, and the npm package publishes `generated`/`dist` (not `schemas`) — so a schema-only description never reaches consumers. Rather than enable the global description preset (a large diff across every generated type), `ping_ms` is documented on the `onPing` callback itself, which is what external developers consume. Happy to do the broader "emit all schema descriptions as JSDoc" change as a follow-up.

## Test plan

- [x] `check-types` passes for client, react, and types
- [x] Client unit tests pass, including new ping tests (pong reply + payload forwarding, and pong still sent without a callback)
- [x] React tests pass, including the `CALLBACK_KEYS` coverage check
- [x] `generate-types` produces no diff after the schema description change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and informational callback on the existing ping/pong path; behavior for consumers who omit onPing is unchanged aside from ping no longer falling through to onDebug.
> 
> **Overview**
> Adds a public **`onPing`** callback on the client and React SDKs so apps can observe server keepalive pings (including estimated **`ping_ms`**) without using **`onDebug`**. Automatic **`pong`** replies are unchanged.
> 
> **Client:** New **`handlePing`** runs on the existing **`ping`** message path after **`pong`** is sent; **`onPing`** is wired through default options, **`Callbacks`**, and **`CALLBACK_KEYS`**, with JSDoc for **`ping_ms`**. **`PingEvent`** is re-exported from the package entry.
> 
> **React:** **`onPing`** is included in **`HookCallbacks`** so hooks pick it up via **`CALLBACK_KEYS`**.
> 
> **Types / docs:** AsyncAPI **`ping_ms`** description is clarified; the agent testbench logs **`onPing`** like other conversation callbacks. Unit tests cover forwarding to **`onPing`** and **`pong`** when no callback is registered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c17ef5633eb33edf8ff19a63ec9520e335928bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->