### PR TITLE
fix(scribe): report microphone setup failures

### DIFF
--- a/.changeset/fix-scribe-microphone-setup-errors.md
+++ b/.changeset/fix-scribe-microphone-setup-errors.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Scribe realtime now reports microphone setup failures through `RealtimeEvents.ERROR` instead of leaving an unhandled rejection. Generic local Scribe errors now use the same typed error payload as server errors.

--- a/packages/client/src/scribe/connection.ts
+++ b/packages/client/src/scribe/connection.ts
@@ -92,6 +92,24 @@ class EventEmitter {
   }
 }
 
+function normalizeError(error: unknown): ScribeErrorMessage {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message_type" in error &&
+    "error" in error &&
+    typeof error.message_type === "string" &&
+    typeof error.error === "string"
+  ) {
+    return error as ScribeErrorMessage;
+  }
+
+  return {
+    message_type: "error",
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
 /**
  * Events emitted by the RealtimeConnection.
  */
@@ -366,16 +384,13 @@ export class RealtimeConnection {
         }
       } catch (error) {
         console.error("Failed to parse WebSocket message:", error, event.data);
-        this.eventEmitter.emit(
-          RealtimeEvents.ERROR,
-          new Error(`Failed to parse message: ${error}`)
-        );
+        this._emitError(new Error(`Failed to parse message: ${error}`));
       }
     });
 
     this.websocket.addEventListener("error", (error: Event) => {
       console.error("WebSocket error:", error);
-      this.eventEmitter.emit(RealtimeEvents.ERROR, error);
+      this._emitError(new Error("WebSocket error"));
     });
 
     this.websocket.addEventListener("close", (event: CloseEvent) => {
@@ -387,7 +402,7 @@ export class RealtimeConnection {
       if (!event.wasClean || (event.code !== 1000 && event.code !== 1005)) {
         const errorMessage = `WebSocket closed unexpectedly: ${event.code} - ${event.reason || "No reason provided"}`;
         console.error(errorMessage);
-        this.eventEmitter.emit(RealtimeEvents.ERROR, new Error(errorMessage));
+        this._emitError(new Error(errorMessage));
       }
 
       this.eventEmitter.emit(RealtimeEvents.CLOSE, event);
@@ -446,6 +461,11 @@ export class RealtimeConnection {
       : (data: RealtimeEventMap[E]) => void
   ): void {
     this.eventEmitter.off(event, listener as (...args: unknown[]) => void);
+  }
+
+  /** @internal Report a local failure through the public Scribe error event. */
+  public _emitError(error: unknown): void {
+    this.eventEmitter.emit(RealtimeEvents.ERROR, normalizeError(error));
   }
 
   /**

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -457,6 +457,106 @@ describe("Scribe", () => {
       server.close();
     });
 
+    it("normalizes malformed WebSocket messages as Scribe errors", async () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123"
+      );
+      const clientPromise = new Promise<Client>((resolve, reject) => {
+        server.on("connection", socket => resolve(socket));
+        server.on("error", reject);
+        setTimeout(() => reject(new Error("timeout")), 5000);
+      });
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+      });
+      const onError = vi.fn();
+      connection.on(RealtimeEvents.ERROR, onError);
+
+      const client = await clientPromise;
+      await sleep(100);
+      client.send("not valid JSON");
+
+      await sleep(100);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message_type: "error",
+          error: expect.stringContaining("Failed to parse message:"),
+        })
+      );
+
+      connection.close();
+      server.close();
+    });
+
+    it("normalizes WebSocket error events as Scribe errors", async () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123"
+      );
+      const clientPromise = new Promise<Client>((resolve, reject) => {
+        server.on("connection", socket => resolve(socket));
+        server.on("error", reject);
+        setTimeout(() => reject(new Error("timeout")), 5000);
+      });
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+      });
+      const onError = vi.fn();
+      connection.on(RealtimeEvents.ERROR, onError);
+
+      const client = await clientPromise;
+      await sleep(100);
+      client.target.dispatchEvent(new Event("error"));
+
+      await sleep(100);
+      expect(onError).toHaveBeenCalledWith({
+        message_type: "error",
+        error: "WebSocket error",
+      });
+
+      connection.close();
+      server.close();
+    });
+
+    it("normalizes unexpected WebSocket closes as Scribe errors", async () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123"
+      );
+      const clientPromise = new Promise<Client>((resolve, reject) => {
+        server.on("connection", socket => resolve(socket));
+        server.on("error", reject);
+        setTimeout(() => reject(new Error("timeout")), 5000);
+      });
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+      });
+      const onError = vi.fn();
+      connection.on(RealtimeEvents.ERROR, onError);
+
+      const client = await clientPromise;
+      await sleep(100);
+      client.close({ code: 1011, reason: "server failed", wasClean: false });
+
+      await sleep(100);
+      expect(onError).toHaveBeenCalledWith({
+        message_type: "error",
+        error: "WebSocket closed unexpectedly: 1011 - server failed",
+      });
+
+      server.close();
+    });
+
     it("handles auth_error event", async () => {
       const server = new Server(
         "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=test-token-123"

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -442,7 +442,7 @@ describe("Scribe", () => {
       client.send(
         JSON.stringify({
           message_type: "error",
-          message: "Test error message",
+          error: "Test error message",
         })
       );
 
@@ -450,7 +450,7 @@ describe("Scribe", () => {
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith({
         message_type: "error",
-        message: "Test error message",
+        error: "Test error message",
       });
 
       connection.close();
@@ -914,6 +914,40 @@ describe("Scribe", () => {
       connection.close();
       expect(cleanup).toHaveBeenCalledTimes(1);
 
+      server.close();
+    });
+
+    it("emits an error instead of rejecting when microphone setup fails", async () => {
+      const setupError = new Error("microphone permission denied");
+      setScribeMicrophoneSetup(() => Promise.reject(setupError));
+
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123"
+      );
+      const clientPromise = new Promise<Client>((resolve, reject) => {
+        server.on("connection", socket => resolve(socket));
+        server.on("error", reject);
+        setTimeout(() => reject(new Error("timeout")), 5000);
+      });
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        microphone: { echoCancellation: true },
+      });
+      const onError = vi.fn();
+      connection.on(RealtimeEvents.ERROR, onError);
+
+      await clientPromise;
+      await sleep(100);
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith({
+        message_type: "error",
+        error: setupError.message,
+      });
+
+      connection.close();
       server.close();
     });
   });

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -281,7 +281,7 @@ export class ScribeRealtime {
       connection._audioCleanup = result.cleanup;
     } catch (error) {
       console.error("Failed to start microphone streaming:", error);
-      throw error;
+      connection._emitError(error);
     }
   }
 }


### PR DESCRIPTION
Fixes #879.

Scribe starts microphone setup from a WebSocket open listener. When setup rejects, `streamFromMicrophone` rethrows from an async callback that nobody awaits. The rejection reaches the runtime as unhandled and `RealtimeEvents.ERROR` receives nothing.

This reports local microphone setup failures through the existing typed `RealtimeEvents.ERROR` payload and does not rethrow. Parse, socket, and unexpected-close failures now use the same `{ message_type: "error", error }` shape. Server error payloads and caller-managed connection lifetime stay unchanged.

Tests:
pnpm --filter @elevenlabs/client exec vitest run --project "Unit tests" src/scribe/scribe.test.ts
pnpm --filter @elevenlabs/client exec tsc --build --pretty false
pnpm --filter @elevenlabs/client lint:es

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side error handling and event payload consistency in Scribe realtime; no auth or server contract changes beyond aligning local errors with existing typed ERROR events.
> 
> **Overview**
> Fixes microphone setup failures surfacing as **unhandled promise rejections** when Scribe starts capture from an un-awaited WebSocket `open` handler. Those failures now emit **`RealtimeEvents.ERROR`** with the same **`{ message_type: "error", error }`** shape as server errors, without rethrowing.
> 
> **Local WebSocket failures** (bad JSON, socket `error`, unclean/unexpected close) also route through **`_emitError`** / **`normalizeError`** instead of passing raw `Error` or DOM `Event` objects to listeners. Server-originated error payloads and connection lifecycle behavior are otherwise unchanged.
> 
> Tests cover normalized error payloads, the microphone permission/setup path, and the corrected **`error`** field on generic error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59425683593514c92a3e098bcebf05eb47b45d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->