### PR TITLE
fix(client): guard handleErrorEvent against missing error_event payload

### DIFF
--- a/.changeset/guard-error-event-payload.md
+++ b/.changeset/guard-error-event-payload.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Guard `handleErrorEvent` against `error` messages that arrive without a populated `error_event` payload. Previously the handler read `event.error_event.error_type` directly, so a malformed error message threw an unhandled `TypeError: Cannot read properties of undefined (reading 'error_type')` from inside the message dispatcher. Because the `"error"` case is not wrapped in a try/catch, the throw escaped `onMessage` and crashed the consumer instead of surfacing through `onError`. The payload is now read defensively and always routed to `onError`.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -424,6 +424,62 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("error events", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("surfaces a non-terminal server error via onError", async () => {
+      const onError = vi.fn();
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const conversation = TestConversation.create({ onError });
+
+      await conversation.receiveMessage({
+        type: "error",
+        error_event: {
+          code: 1008 as const,
+          error_type: "override_error",
+          message: "Override not allowed",
+        },
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        "Server error: Override not allowed",
+        {
+          errorType: "override_error",
+          code: 1008,
+          debugMessage: undefined,
+          details: undefined,
+        }
+      );
+    });
+
+    it("does not throw when the error message has no error_event payload", async () => {
+      const onError = vi.fn();
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const conversation = TestConversation.create({ onError });
+
+      // The orchestrator can emit an `error` message without a populated
+      // `error_event`. This must surface via onError, not throw a TypeError
+      // ("Cannot read properties of undefined (reading 'error_type')") that
+      // escapes the message dispatcher and crashes the consumer.
+      const malformedError = { type: "error" } as unknown as Parameters<
+        typeof conversation.receiveMessage
+      >[0];
+
+      await expect(
+        conversation.receiveMessage(malformedError)
+      ).resolves.toBeUndefined();
+
+      expect(onError).toHaveBeenCalledWith("Server error: Unknown error", {
+        errorType: undefined,
+        code: undefined,
+        debugMessage: undefined,
+        details: undefined,
+      });
+    });
+  });
+
   describe("sendFeedback", () => {
     function createWithSpy() {
       const sendMessage = vi.fn();

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -421,9 +421,10 @@ export abstract class BaseConversation {
   }
 
   protected handleErrorEvent(event: ErrorMessageEvent) {
-    const errorType = event.error_event.error_type;
+    const errorEvent = event.error_event;
+    const errorType = errorEvent?.error_type;
     const message =
-      event.error_event.message || event.error_event.reason || "Unknown error";
+      errorEvent?.message || errorEvent?.reason || "Unknown error";
 
     if (errorType === "max_duration_exceeded") {
       void this.endSessionWithDetails({
@@ -441,9 +442,9 @@ export abstract class BaseConversation {
 
     this.onError(`Server error: ${message}`, {
       errorType,
-      code: event.error_event.code,
-      debugMessage: event.error_event.debug_message,
-      details: event.error_event.details,
+      code: errorEvent?.code,
+      debugMessage: errorEvent?.debug_message,
+      details: errorEvent?.details,
     });
   }
 


### PR DESCRIPTION
## Summary

`BaseConversation.handleErrorEvent` reads `event.error_event.error_type` (and `.message`, `.reason`, `.code`, `.debug_message`, `.details`) directly. When the orchestrator emits an `error` message whose `error_event` payload is absent/undefined, this throws:

```
TypeError: Cannot read properties of undefined (reading 'error_type')
```

The `"error"` branch of the `onMessage` dispatcher isn't wrapped in a try/catch (unlike `client_tool_call`), so the throw escapes `onMessage` and crashes the consumer's message/data-channel handler instead of being surfaced through `onError`. In a WebRTC (LiveKit) session this bubbles up out of the data-packet handler as an unhandled error and leaves the conversation wedged.

This is still present on `main` (`packages/client/src/BaseConversation.ts`).

## Change

- Read `event.error_event` once and access its fields with optional chaining, falling back to `"Unknown error"` for the message. Behavior for well-formed error events is unchanged; malformed ones now route to `onError` instead of throwing.
- Add tests covering a normal non-terminal server error and a malformed `error` message with no `error_event` payload.
- Add a changeset (`@elevenlabs/client` patch).

## Test plan

- [ ] `pnpm --filter @elevenlabs/client test` (new tests in `BaseConversation.test.ts` → `describe("error events")`)
- [ ] `pnpm --filter @elevenlabs/client lint` / typecheck