### PR TITLE
fix(scribe): release resources after setup failures

### DIFF
--- a/.changeset/fix-scribe-microphone-setup-rollback.md
+++ b/.changeset/fix-scribe-microphone-setup-rollback.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Release microphone resources when Scribe setup fails after capture starts.

--- a/packages/client/src/platform/web/scribeMicrophone.test.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./scribeAudioProcessor.generated.js", () => ({
+  loadScribeAudioProcessor: vi.fn(),
+}));
+
+import { loadScribeAudioProcessor } from "./scribeAudioProcessor.generated.js";
+import { webScribeMicrophoneSetup } from "./scribeMicrophone.js";
+
+function installAudioEnvironment(options?: {
+  state?: "running" | "suspended";
+  resumeError?: Error;
+}) {
+  const track = {
+    getSettings: vi.fn(() => ({ sampleRate: 16000 })),
+    stop: vi.fn(),
+  };
+  const stream = {
+    getAudioTracks: vi.fn(() => [track]),
+    getTracks: vi.fn(() => [track]),
+  };
+  const source = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+  const scribeNode = {
+    disconnect: vi.fn(),
+    port: {
+      onmessage: null,
+      postMessage: vi.fn(),
+    },
+  };
+  const audioContext = {
+    audioWorklet: {},
+    close: vi.fn().mockResolvedValue(undefined),
+    createMediaStreamSource: vi.fn(() => source),
+    resume: options?.resumeError
+      ? vi.fn().mockRejectedValue(options.resumeError)
+      : vi.fn().mockResolvedValue(undefined),
+    sampleRate: 16000,
+    state: options?.state ?? "running",
+  };
+
+  vi.stubGlobal("navigator", {
+    mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+  });
+  vi.stubGlobal(
+    "AudioContext",
+    vi.fn(function MockAudioContext() {
+      return audioContext;
+    })
+  );
+  vi.stubGlobal(
+    "AudioWorkletNode",
+    vi.fn(function MockAudioWorkletNode() {
+      return scribeNode;
+    })
+  );
+
+  return { audioContext, scribeNode, source, track };
+}
+
+describe("webScribeMicrophoneSetup", () => {
+  afterEach(() => {
+    vi.mocked(loadScribeAudioProcessor).mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("releases the stream and AudioContext when worklet loading fails", async () => {
+    const { audioContext, track } = installAudioEnvironment();
+    const workletError = new Error("worklet blocked");
+    vi.mocked(loadScribeAudioProcessor).mockRejectedValueOnce(workletError);
+
+    await expect(webScribeMicrophoneSetup({}, vi.fn())).rejects.toThrow(
+      workletError
+    );
+
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(audioContext.close).toHaveBeenCalledOnce();
+  });
+
+  it("releases the partial pipeline when AudioContext resume fails", async () => {
+    const resumeError = new Error("resume failed");
+    const { audioContext, scribeNode, source, track } = installAudioEnvironment(
+      { state: "suspended", resumeError }
+    );
+    vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+    await expect(webScribeMicrophoneSetup({}, vi.fn())).rejects.toThrow(
+      resumeError
+    );
+
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(source.disconnect).toHaveBeenCalledOnce();
+    expect(scribeNode.disconnect).toHaveBeenCalledOnce();
+    expect(audioContext.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/client/src/platform/web/scribeMicrophone.test.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.test.ts
@@ -66,6 +66,22 @@ describe("webScribeMicrophoneSetup", () => {
     vi.unstubAllGlobals();
   });
 
+  it("retains the successful setup cleanup behavior", async () => {
+    const { audioContext, scribeNode, source, track } =
+      installAudioEnvironment();
+    vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+    const result = await webScribeMicrophoneSetup({}, vi.fn());
+    result.cleanup();
+
+    expect(result.mediaStreamTrack).toBe(track);
+    expect(source.connect).toHaveBeenCalledWith(scribeNode);
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(source.disconnect).toHaveBeenCalledOnce();
+    expect(scribeNode.disconnect).toHaveBeenCalledOnce();
+    expect(audioContext.close).toHaveBeenCalledOnce();
+  });
+
   it("releases the stream and AudioContext when worklet loading fails", async () => {
     const { audioContext, track } = installAudioEnvironment();
     const workletError = new Error("worklet blocked");

--- a/packages/client/src/platform/web/scribeMicrophone.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.ts
@@ -19,67 +19,76 @@ export const webScribeMicrophoneSetup: ScribeMicrophoneSetup = async (
   config: ScribeMicrophoneConfig,
   onAudioData: (base64Audio: string) => void
 ): Promise<ScribeMicrophoneResult> => {
-  // Get microphone access
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      deviceId: config.deviceId,
-      echoCancellation: config.echoCancellation ?? true,
-      noiseSuppression: config.noiseSuppression ?? true,
-      autoGainControl: config.autoGainControl ?? true,
-      channelCount: config.channelCount ?? 1,
-      sampleRate: { ideal: TARGET_SAMPLE_RATE },
-    },
-  });
+  let stream: MediaStream | undefined;
+  let audioContext: AudioContext | undefined;
+  let source: MediaStreamAudioSourceNode | undefined;
+  let scribeNode: AudioWorkletNode | undefined;
 
-  // Get the actual sample rate from the stream — the ideal may not have been honored
-  const [audioTrack] = stream.getAudioTracks();
-  const streamSampleRate = audioTrack?.getSettings().sampleRate;
+  const cleanup = () => {
+    for (const track of stream?.getTracks() ?? []) {
+      track.stop();
+    }
+    source?.disconnect();
+    scribeNode?.disconnect();
+    void audioContext?.close();
+  };
 
-  // Create audio context matching the stream's sample rate to avoid Firefox errors.
-  // Firefox requires the AudioContext to match the microphone's native sample rate.
-  const audioContext = new AudioContext(
-    streamSampleRate ? { sampleRate: streamSampleRate } : {}
-  );
-
-  // Load scribe worklet
-  await loadScribeAudioProcessor(audioContext.audioWorklet);
-
-  // Set up audio pipeline
-  const source = audioContext.createMediaStreamSource(stream);
-  const scribeNode = new AudioWorkletNode(audioContext, "scribeAudioProcessor");
-
-  // Configure the worklet with sample rate info for resampling
-  // (only needed when AudioContext sample rate differs from target)
-  if (audioContext.sampleRate !== TARGET_SAMPLE_RATE) {
-    scribeNode.port.postMessage({
-      type: "configure",
-      inputSampleRate: audioContext.sampleRate,
-      outputSampleRate: TARGET_SAMPLE_RATE,
+  try {
+    // Get microphone access
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        deviceId: config.deviceId,
+        echoCancellation: config.echoCancellation ?? true,
+        noiseSuppression: config.noiseSuppression ?? true,
+        autoGainControl: config.autoGainControl ?? true,
+        channelCount: config.channelCount ?? 1,
+        sampleRate: { ideal: TARGET_SAMPLE_RATE },
+      },
     });
+
+    // Get the actual sample rate from the stream — the ideal may not have been honored
+    const [audioTrack] = stream.getAudioTracks();
+    const streamSampleRate = audioTrack?.getSettings().sampleRate;
+
+    // Create audio context matching the stream's sample rate to avoid Firefox errors.
+    // Firefox requires the AudioContext to match the microphone's native sample rate.
+    audioContext = new AudioContext(
+      streamSampleRate ? { sampleRate: streamSampleRate } : {}
+    );
+
+    // Load scribe worklet
+    await loadScribeAudioProcessor(audioContext.audioWorklet);
+
+    // Set up audio pipeline
+    source = audioContext.createMediaStreamSource(stream);
+    scribeNode = new AudioWorkletNode(audioContext, "scribeAudioProcessor");
+
+    // Configure the worklet with sample rate info for resampling
+    // (only needed when AudioContext sample rate differs from target)
+    if (audioContext.sampleRate !== TARGET_SAMPLE_RATE) {
+      scribeNode.port.postMessage({
+        type: "configure",
+        inputSampleRate: audioContext.sampleRate,
+        outputSampleRate: TARGET_SAMPLE_RATE,
+      });
+    }
+
+    // Handle audio data from worklet
+    scribeNode.port.onmessage = event => {
+      onAudioData(arrayBufferToBase64(event.data.audioData));
+    };
+
+    // Connect audio pipeline
+    source.connect(scribeNode);
+
+    // Resume audio context if needed
+    if (audioContext.state === "suspended") {
+      await audioContext.resume();
+    }
+
+    return { mediaStreamTrack: audioTrack, cleanup };
+  } catch (error) {
+    cleanup();
+    throw error;
   }
-
-  // Handle audio data from worklet
-  scribeNode.port.onmessage = event => {
-    onAudioData(arrayBufferToBase64(event.data.audioData));
-  };
-
-  // Connect audio pipeline
-  source.connect(scribeNode);
-
-  // Resume audio context if needed
-  if (audioContext.state === "suspended") {
-    await audioContext.resume();
-  }
-
-  return {
-    mediaStreamTrack: audioTrack,
-    cleanup: () => {
-      for (const track of stream.getTracks()) {
-        track.stop();
-      }
-      source.disconnect();
-      scribeNode.disconnect();
-      void audioContext.close();
-    },
-  };
 };


### PR DESCRIPTION
Fixes #889

Failure mechanism

webScribeMicrophoneSetup acquires a MediaStream before worklet and graph setup finishes. If a later step rejects, no ScribeMicrophoneResult exists yet, so streamFromMicrophone can emit ERROR but cannot release the captured track or AudioContext.

Semantic change

The setup now retains each resource as it is acquired. On failure, it stops captured tracks, disconnects any created nodes, closes the AudioContext, and rethrows the original error. Successful setup still returns the same cleanup callback.

Preserved behavior

The public API and successful microphone setup path are unchanged. The existing ERROR forwarding for a rejected setup remains responsible for notifying consumers.

Coverage

The regression tests cover successful setup cleanup, a worklet-load rejection after getUserMedia succeeds, and an AudioContext.resume rejection after the source and worklet node exist. A patch Changeset is included for @elevenlabs/client.

Verification

Passed: pnpm exec prettier --check packages/client/src/platform/web/scribeMicrophone.ts packages/client/src/platform/web/scribeMicrophone.test.ts .changeset/fix-scribe-microphone-setup-rollback.md
Passed: pnpm --filter @elevenlabs/client exec vitest --browser.headless run src/platform/web/scribeMicrophone.test.ts (3 tests)
Passed: pnpm --filter @elevenlabs/client exec vitest --browser.headless run --project "Unit tests" (118 tests)
Passed: pnpm --filter @elevenlabs/client run lint:es
Passed: pnpm --filter @elevenlabs/types run build; pnpm --filter @elevenlabs/client run generate-version; pnpm --filter @elevenlabs/client run build:esm

The browser test project was not run locally because the required Playwright Chromium binary was unavailable in the Linux verification environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling fix in web Scribe setup with no API changes; successful behavior preserved and covered by new tests.
> 
> **Overview**
> Fixes a **resource leak** in `webScribeMicrophoneSetup` when microphone capture starts but a later step (worklet load, graph wiring, or `AudioContext.resume`) throws—previously no `cleanup` ran because setup never returned a result.
> 
> Setup now tracks `stream`, `AudioContext`, and audio nodes as they are created, wraps the pipeline in **try/catch**, and on failure runs the same teardown (stop tracks, disconnect nodes, close context) before rethrowing. The successful path still returns the same `cleanup` callback; the public API is unchanged.
> 
> Adds **unit tests** for success cleanup, worklet-load failure after `getUserMedia`, and resume failure with a partial graph, plus a **patch** changeset for `@elevenlabs/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366c4f1897dd5965ec4574e8c10a004ef4f42a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->