### PR TITLE
Add hide/show resize button widget config option

### DIFF
--- a/.changeset/hide-resize-button.md
+++ b/.changeset/hide-resize-button.md
@@ -1,0 +1,8 @@
+---
+"@elevenlabs/convai-widget-core": minor
+"@elevenlabs/convai-widget-embed": minor
+---
+
+Add a `hide_resize_button` widget config option (and matching
+`hide-resize-button` embed attribute) that hides the expand/collapse resize
+button in the widget header.

--- a/.changeset/hide-resize-button.md
+++ b/.changeset/hide-resize-button.md
@@ -1,8 +1,0 @@
----
-"@elevenlabs/convai-widget-core": minor
-"@elevenlabs/convai-widget-embed": minor
----
-
-Add a `hide_resize_button` widget config option (and matching
-`hide-resize-button` embed attribute) that hides the expand/collapse resize
-button in the widget header.

--- a/.changeset/show-resize-button.md
+++ b/.changeset/show-resize-button.md
@@ -1,0 +1,8 @@
+---
+"@elevenlabs/convai-widget-core": minor
+"@elevenlabs/convai-widget-embed": minor
+---
+
+Add a `show_resize_button` widget config option (and matching
+`show-resize-button` embed attribute) that controls the expand/collapse resize
+button in the widget header. Defaults to `true`; set to `false` to hide it.

--- a/packages/convai-widget-core/src/PlaygroundSettings.tsx
+++ b/packages/convai-widget-core/src/PlaygroundSettings.tsx
@@ -21,7 +21,7 @@ export function usePlaygroundSettings() {
   const [alwaysExpanded, setAlwaysExpanded] = useState(false);
   const [dismissible, setDismissible] = useState(false);
   const [showAgentStatus, setShowAgentStatus] = useState(false);
-  const [hideResizeButton, setHideResizeButton] = useState(false);
+  const [showResizeButton, setShowResizeButton] = useState(true);
   const [dynamicVariablesStr, setDynamicVariablesStr] = useState("");
   const [expanded, setExpanded] = useState(false);
   const [allowEvents, setAllowEvents] = useState(false);
@@ -68,8 +68,8 @@ export function usePlaygroundSettings() {
     setDismissible,
     showAgentStatus,
     setShowAgentStatus,
-    hideResizeButton,
-    setHideResizeButton,
+    showResizeButton,
+    setShowResizeButton,
     dynamicVariablesStr,
     setDynamicVariablesStr,
     dynamicVariables,
@@ -188,10 +188,10 @@ export function PlaygroundSettingsPanel({
       <label>
         <input
           type="checkbox"
-          checked={state.hideResizeButton}
-          onChange={e => state.setHideResizeButton(e.currentTarget.checked)}
+          checked={state.showResizeButton}
+          onChange={e => state.setShowResizeButton(e.currentTarget.checked)}
         />{" "}
-        Hide resize button
+        Show resize button
       </label>
       <label>
         Dynamic variables (i.e., new-line separated name=value)

--- a/packages/convai-widget-core/src/PlaygroundSettings.tsx
+++ b/packages/convai-widget-core/src/PlaygroundSettings.tsx
@@ -21,6 +21,7 @@ export function usePlaygroundSettings() {
   const [alwaysExpanded, setAlwaysExpanded] = useState(false);
   const [dismissible, setDismissible] = useState(false);
   const [showAgentStatus, setShowAgentStatus] = useState(false);
+  const [hideResizeButton, setHideResizeButton] = useState(false);
   const [dynamicVariablesStr, setDynamicVariablesStr] = useState("");
   const [expanded, setExpanded] = useState(false);
   const [allowEvents, setAllowEvents] = useState(false);
@@ -67,6 +68,8 @@ export function usePlaygroundSettings() {
     setDismissible,
     showAgentStatus,
     setShowAgentStatus,
+    hideResizeButton,
+    setHideResizeButton,
     dynamicVariablesStr,
     setDynamicVariablesStr,
     dynamicVariables,
@@ -94,9 +97,9 @@ export function PlaygroundSettingsPanel({
         Variant
         <select
           value={state.variant}
-          onChange={(e) => state.setVariant(parseVariant(e.currentTarget.value))}
+          onChange={e => state.setVariant(parseVariant(e.currentTarget.value))}
         >
-          {Variants.map((variant) => (
+          {Variants.map(variant => (
             <option key={variant} value={variant}>
               {variant}
             </option>
@@ -107,11 +110,11 @@ export function PlaygroundSettingsPanel({
         Placement
         <select
           value={state.placement}
-          onChange={(e) =>
+          onChange={e =>
             state.setPlacement(parsePlacement(e.currentTarget.value))
           }
         >
-          {Placements.map((placement) => (
+          {Placements.map(placement => (
             <option key={placement} value={placement}>
               {placement}
             </option>
@@ -122,7 +125,7 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.micMuting}
-          onChange={(e) => state.setMicMuting(e.currentTarget.checked)}
+          onChange={e => state.setMicMuting(e.currentTarget.checked)}
         />{" "}
         Mic muting
       </label>
@@ -130,7 +133,7 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.transcript}
-          onChange={(e) => state.setTranscript(e.currentTarget.checked)}
+          onChange={e => state.setTranscript(e.currentTarget.checked)}
         />{" "}
         Transcript
       </label>
@@ -138,7 +141,7 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.textInput}
-          onChange={(e) => state.setTextInput(e.currentTarget.checked)}
+          onChange={e => state.setTextInput(e.currentTarget.checked)}
         />{" "}
         Text input
       </label>
@@ -146,7 +149,7 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.textOnly}
-          onChange={(e) => state.setTextOnly(e.currentTarget.checked)}
+          onChange={e => state.setTextOnly(e.currentTarget.checked)}
         />{" "}
         Text only
       </label>
@@ -154,7 +157,7 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.alwaysExpanded}
-          onChange={(e) => state.setAlwaysExpanded(e.currentTarget.checked)}
+          onChange={e => state.setAlwaysExpanded(e.currentTarget.checked)}
         />{" "}
         Always expanded
       </label>
@@ -162,7 +165,7 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.dismissible}
-          onChange={(e) => state.setDismissible(e.currentTarget.checked)}
+          onChange={e => state.setDismissible(e.currentTarget.checked)}
         />{" "}
         Dismissible
       </label>
@@ -170,7 +173,7 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.allowEvents}
-          onChange={(e) => state.setAllowEvents(e.currentTarget.checked)}
+          onChange={e => state.setAllowEvents(e.currentTarget.checked)}
         />{" "}
         Allow events
       </label>
@@ -178,14 +181,22 @@ export function PlaygroundSettingsPanel({
         <input
           type="checkbox"
           checked={state.showAgentStatus}
-          onChange={(e) => state.setShowAgentStatus(e.currentTarget.checked)}
+          onChange={e => state.setShowAgentStatus(e.currentTarget.checked)}
         />{" "}
         Show agent status
       </label>
       <label>
+        <input
+          type="checkbox"
+          checked={state.hideResizeButton}
+          onChange={e => state.setHideResizeButton(e.currentTarget.checked)}
+        />{" "}
+        Hide resize button
+      </label>
+      <label>
         Dynamic variables (i.e., new-line separated name=value)
         <textarea
-          onChange={(e) => state.setDynamicVariablesStr(e.currentTarget.value)}
+          onChange={e => state.setDynamicVariablesStr(e.currentTarget.value)}
           value={state.dynamicVariablesStr}
           rows={5}
         />
@@ -196,7 +207,7 @@ export function PlaygroundSettingsPanel({
             <input
               type="checkbox"
               checked={state.overrideFirstMessage}
-              onChange={(e) =>
+              onChange={e =>
                 state.setOverrideFirstMessage(e.currentTarget.checked)
               }
             />{" "}
@@ -209,7 +220,7 @@ export function PlaygroundSettingsPanel({
               type="text"
               value={state.firstMessage}
               disabled={!state.overrideFirstMessage}
-              onChange={(e) => state.setFirstMessage(e.currentTarget.value)}
+              onChange={e => state.setFirstMessage(e.currentTarget.value)}
             />
           )}
         </div>
@@ -218,11 +229,11 @@ export function PlaygroundSettingsPanel({
         Server Location
         <select
           value={state.location}
-          onChange={(e) =>
+          onChange={e =>
             state.setLocation(parseLocation(e.currentTarget.value))
           }
         >
-          {["us", "global", "eu-residency", "in-residency"].map((location) => (
+          {["us", "global", "eu-residency", "in-residency"].map(location => (
             <option key={location} value={location}>
               {location}
             </option>

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -104,7 +104,7 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
   const useRtc = useAttribute("use-rtc");
   const showAgentStatus = useAttribute("show-agent-status");
   const showConversationId = useAttribute("show-conversation-id");
-  const hideResizeButton = useAttribute("hide-resize-button");
+  const showResizeButton = useAttribute("show-resize-button");
 
   const value = useComputed<WidgetConfig | null>(() => {
     if (!fetchedConfig.value) {
@@ -155,10 +155,10 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       parseBoolAttribute(showConversationId.value) ??
       fetchedConfig.value.show_conversation_id ??
       true;
-    const patchedHideResizeButton =
-      parseBoolAttribute(hideResizeButton.value) ??
-      fetchedConfig.value.hide_resize_button ??
-      false;
+    const patchedShowResizeButton =
+      parseBoolAttribute(showResizeButton.value) ??
+      fetchedConfig.value.show_resize_button ??
+      true;
 
     return {
       ...fetchedConfig.value,
@@ -175,7 +175,7 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       use_rtc: patchedUseRtc,
       show_agent_status: patchedShowAgentStatus,
       show_conversation_id: patchedShowConversationId,
-      hide_resize_button: patchedHideResizeButton,
+      show_resize_button: patchedShowResizeButton,
     };
   });
 

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -104,6 +104,7 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
   const useRtc = useAttribute("use-rtc");
   const showAgentStatus = useAttribute("show-agent-status");
   const showConversationId = useAttribute("show-conversation-id");
+  const hideResizeButton = useAttribute("hide-resize-button");
 
   const value = useComputed<WidgetConfig | null>(() => {
     if (!fetchedConfig.value) {
@@ -154,6 +155,10 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       parseBoolAttribute(showConversationId.value) ??
       fetchedConfig.value.show_conversation_id ??
       true;
+    const patchedHideResizeButton =
+      parseBoolAttribute(hideResizeButton.value) ??
+      fetchedConfig.value.hide_resize_button ??
+      false;
 
     return {
       ...fetchedConfig.value,
@@ -170,6 +175,7 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       use_rtc: patchedUseRtc,
       show_agent_status: patchedShowAgentStatus,
       show_conversation_id: patchedShowConversationId,
+      hide_resize_button: patchedHideResizeButton,
     };
   });
 

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -26,7 +26,10 @@ function Playground() {
 
   return (
     <div className="playground">
-      <PlaygroundSettingsPanel state={state} onToggleExpand={handleToggleExpand} />
+      <PlaygroundSettingsPanel
+        state={state}
+        onToggleExpand={handleToggleExpand}
+      />
       <div ref={ref} className="dev-host">
         <ConvAIWidget
           agent-id={import.meta.env.VITE_AGENT_ID}
@@ -40,6 +43,7 @@ function Playground() {
           allow-events={JSON.stringify(state.allowEvents)}
           dismissible={JSON.stringify(state.dismissible)}
           show-agent-status={JSON.stringify(state.showAgentStatus)}
+          hide-resize-button={JSON.stringify(state.hideResizeButton)}
           dynamic-variables={JSON.stringify(state.dynamicVariables)}
           server-location={state.location}
           override-first-message={

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -43,7 +43,7 @@ function Playground() {
           allow-events={JSON.stringify(state.allowEvents)}
           dismissible={JSON.stringify(state.dismissible)}
           show-agent-status={JSON.stringify(state.showAgentStatus)}
-          hide-resize-button={JSON.stringify(state.hideResizeButton)}
+          show-resize-button={JSON.stringify(state.showResizeButton)}
           dynamic-variables={JSON.stringify(state.dynamicVariables)}
           server-location={state.location}
           override-first-message={

--- a/packages/convai-widget-core/src/shadowdom.dev.tsx
+++ b/packages/convai-widget-core/src/shadowdom.dev.tsx
@@ -37,7 +37,7 @@ function Playground() {
       "allow-events": JSON.stringify(state.allowEvents),
       dismissible: JSON.stringify(state.dismissible),
       "show-agent-status": JSON.stringify(state.showAgentStatus),
-      "hide-resize-button": JSON.stringify(state.hideResizeButton),
+      "show-resize-button": JSON.stringify(state.showResizeButton),
       "dynamic-variables": JSON.stringify(state.dynamicVariables),
       "server-location": state.location,
       "override-first-message": state.overrideFirstMessage
@@ -65,7 +65,7 @@ function Playground() {
     state.allowEvents,
     state.dismissible,
     state.showAgentStatus,
-    state.hideResizeButton,
+    state.showResizeButton,
     state.dynamicVariables,
     state.location,
     state.overrideFirstMessage,

--- a/packages/convai-widget-core/src/shadowdom.dev.tsx
+++ b/packages/convai-widget-core/src/shadowdom.dev.tsx
@@ -37,17 +37,18 @@ function Playground() {
       "allow-events": JSON.stringify(state.allowEvents),
       dismissible: JSON.stringify(state.dismissible),
       "show-agent-status": JSON.stringify(state.showAgentStatus),
+      "hide-resize-button": JSON.stringify(state.hideResizeButton),
       "dynamic-variables": JSON.stringify(state.dynamicVariables),
       "server-location": state.location,
       "override-first-message": state.overrideFirstMessage
         ? state.firstMessage
         : undefined,
     };
-    
+
     for (const [key, value] of Object.entries(attrs)) {
       if (value != null) el.setAttribute(key, value);
     }
-    
+
     container.appendChild(el);
 
     return () => {
@@ -64,6 +65,7 @@ function Playground() {
     state.allowEvents,
     state.dismissible,
     state.showAgentStatus,
+    state.hideResizeButton,
     state.dynamicVariables,
     state.location,
     state.overrideFirstMessage,
@@ -81,7 +83,10 @@ function Playground() {
 
   return (
     <div className="playground">
-      <PlaygroundSettingsPanel state={state} onToggleExpand={handleToggleExpand} />
+      <PlaygroundSettingsPanel
+        state={state}
+        onToggleExpand={handleToggleExpand}
+      />
       <div ref={ref} />
     </div>
   );

--- a/packages/convai-widget-core/src/types/attributes.ts
+++ b/packages/convai-widget-core/src/types/attributes.ts
@@ -56,6 +56,7 @@ export const CustomAttributeList = [
   "allow-events",
   "show-agent-status",
   "show-conversation-id",
+  "hide-resize-button",
   "environment",
 ] as const;
 

--- a/packages/convai-widget-core/src/types/attributes.ts
+++ b/packages/convai-widget-core/src/types/attributes.ts
@@ -56,7 +56,7 @@ export const CustomAttributeList = [
   "allow-events",
   "show-agent-status",
   "show-conversation-id",
-  "hide-resize-button",
+  "show-resize-button",
   "environment",
 ] as const;
 

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -83,6 +83,7 @@ export interface WidgetConfig {
     enabled?: boolean;
     max_files_per_conversation?: number;
   };
+  hide_resize_button?: boolean;
 }
 
 export type AvatarConfig =

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -83,7 +83,7 @@ export interface WidgetConfig {
     enabled?: boolean;
     max_files_per_conversation?: number;
   };
-  hide_resize_button?: boolean;
+  show_resize_button?: boolean;
 }
 
 export type AvatarConfig =

--- a/packages/convai-widget-core/src/widget/Sheet.tsx
+++ b/packages/convai-widget-core/src/widget/Sheet.tsx
@@ -93,7 +93,9 @@ export function Sheet({ open }: SheetProps) {
       !isDisconnected.value
   );
 
-  const showExpandButton = useComputed(() => showTranscript.value);
+  const showExpandButton = useComputed(
+    () => showTranscript.value && !config.value.hide_resize_button
+  );
 
   return (
     <InOutTransition initial={false} active={open}>

--- a/packages/convai-widget-core/src/widget/Sheet.tsx
+++ b/packages/convai-widget-core/src/widget/Sheet.tsx
@@ -94,7 +94,7 @@ export function Sheet({ open }: SheetProps) {
   );
 
   const showExpandButton = useComputed(
-    () => showTranscript.value && !config.value.hide_resize_button
+    () => showTranscript.value && (config.value.show_resize_button ?? true)
   );
 
   return (


### PR DESCRIPTION
Adds a new `show_resize_button` config option that hides the expand/collapse resize button in the widget header.

[Linear Issue](https://linear.app/elevenlabs/issue/AP-2476/add-config-option-to-hide-widget-resize-button)

Resize button enabled
<img width="431" height="638" alt="Screenshot 2026-07-23 at 11 20 14 AM" src="https://github.com/user-attachments/assets/108510b8-5598-48d4-9a08-e9827caded73" />

Resize button disabled
<img width="430" height="649" alt="Screenshot 2026-07-23 at 11 20 42 AM" src="https://github.com/user-attachments/assets/82ecbef6-aa75-4ef2-8864-6f4840a8fdab" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in UI visibility flag with backward-compatible default; no auth or data-path changes.
> 
> **Overview**
> Adds **`show_resize_button`** on widget config (and embed attribute **`show-resize-button`**) so hosts can hide the header expand/collapse control. Resolution order matches other flags: embed attribute → fetched **`widget_config`** → default **`true`**.
> 
> **`Sheet`** only shows the resize control when the transcript UI would show it **and** **`show_resize_button`** is not false. Dev playgrounds get a **Show resize button** toggle wired through to the widget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 398fd4349d1fcb533ac6c5fede0c4e93b045a370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->