### PR TITLE
Replace dynamic variables in first message

### DIFF
--- a/packages/convai-widget-core/src/contexts/session-config.tsx
+++ b/packages/convai-widget-core/src/contexts/session-config.tsx
@@ -9,8 +9,7 @@ import { useServerLocation } from "./server-location";
 import { useContextSafely } from "../utils/useContextSafely";
 import { parseBoolAttribute } from "../types/attributes";
 import { useTextOnly, useWebRTC } from "./widget-config";
-
-type DynamicVariables = Record<string, string | number | boolean>;
+import { parseDynamicVariables } from "../utils/dynamicVariables";
 
 const SessionConfigContext =
   createContext<ReadonlySignal<SessionConfig> | null>(null);
@@ -44,8 +43,12 @@ export function SessionConfigProvider({
     tts: {
       voiceId: overrideVoiceId.value,
       speed: overrideSpeed.value ? parseFloat(overrideSpeed.value) : undefined,
-      stability: overrideStability.value ? parseFloat(overrideStability.value) : undefined,
-      similarityBoost: overrideSimilarityBoost.value ? parseFloat(overrideSimilarityBoost.value) : undefined,
+      stability: overrideStability.value
+        ? parseFloat(overrideStability.value)
+        : undefined,
+      similarityBoost: overrideSimilarityBoost.value
+        ? parseFloat(overrideSimilarityBoost.value)
+        : undefined,
     },
     conversation: {
       textOnly: parseBoolAttribute(overrideTextOnly.value) ?? undefined,
@@ -53,19 +56,9 @@ export function SessionConfigProvider({
   }));
 
   const dynamicVariablesJSON = useAttribute("dynamic-variables");
-  const dynamicVariables = useComputed(() => {
-    if (dynamicVariablesJSON.value) {
-      try {
-        return JSON.parse(dynamicVariablesJSON.value) as DynamicVariables;
-      } catch (e: any) {
-        console.error(
-          `[ConversationalAI] Cannot parse dynamic-variables: ${e?.message}`
-        );
-      }
-    }
-
-    return undefined;
-  });
+  const dynamicVariables = useComputed(() =>
+    parseDynamicVariables(dynamicVariablesJSON.value)
+  );
 
   const rawAudioProcessor = useAttribute("worklet-path-raw-audio-processor");
   const audioConcatProcessor = useAttribute(

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -21,6 +21,10 @@ import { useContextSafely } from "../utils/useContextSafely";
 import { parseBoolAttribute } from "../types/attributes";
 import { useLanguageConfig } from "./language-config";
 import { useConversation } from "./conversation";
+import {
+  interpolateDynamicVariables,
+  parseDynamicVariables,
+} from "../utils/dynamicVariables";
 
 const WidgetConfigContext = createContext<ReadonlySignal<WidgetConfig> | null>(
   null
@@ -208,14 +212,22 @@ export function useFirstMessage() {
   const override = useAttribute("override-first-message");
   const config = useWidgetConfig();
   const { language } = useLanguageConfig();
-  return useComputed(
-    () =>
+  const dynamicVariablesJSON = useAttribute("dynamic-variables");
+  return useComputed(() => {
+    const firstMessage =
       override.value ??
       config.value.language_presets?.[language.value.languageCode]
         ?.first_message ??
       config.value.first_message ??
-      null
-  );
+      null;
+    if (firstMessage == null) {
+      return null;
+    }
+    return interpolateDynamicVariables(
+      firstMessage,
+      parseDynamicVariables(dynamicVariablesJSON.value)
+    );
+  });
 }
 
 export function useTextInputEnabled() {

--- a/packages/convai-widget-core/src/utils/dynamicVariables.ts
+++ b/packages/convai-widget-core/src/utils/dynamicVariables.ts
@@ -1,0 +1,31 @@
+export type DynamicVariables = Record<string, string | number | boolean>;
+
+export function parseDynamicVariables(
+  json: string | undefined
+): DynamicVariables | undefined {
+  if (!json) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(json) as DynamicVariables;
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error(
+      `[ConversationalAI] Cannot parse dynamic-variables: ${message}`
+    );
+    return undefined;
+  }
+}
+
+export function interpolateDynamicVariables(
+  template: string,
+  variables: DynamicVariables | undefined
+): string {
+  if (!variables) {
+    return template;
+  }
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (match, key: string) => {
+    const value = variables[key];
+    return value == null ? match : String(value);
+  });
+}


### PR DESCRIPTION
Fixes [AWF-141: Widget dynamic variables not displaying correctly](https://linear.app/elevenlabs/issue/AWF-141/widget-dynamic-variables-not-displaying-correctly)

Chat-only widgets render the first_message locally from the widget config, which holds the raw template (e.g. Hello, {{first_name}}). Previously those {{ }} placeholders were shown to the user unresolved. This PR substitutes  dynamic-variables supplied via the `dynamic-variables` attribute into the first message.

Before:
<img width="741" height="819" alt="Screenshot 2026-07-23 at 12 36 46 PM" src="https://github.com/user-attachments/assets/abef0ce9-456c-435a-913e-e56875f693ad" />

After:
<img width="726" height="850" alt="Screenshot 2026-07-23 at 12 35 01 PM" src="https://github.com/user-attachments/assets/a1fbc8fe-c541-4a25-9cd4-1c7fb1b77d49" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized display fix for first-message text with no auth or session behavior changes beyond clearer copy.
> 
> **Overview**
> Fixes chat-only widgets showing unresolved `{{…}}` placeholders in the **first message**, which is rendered from widget config on the client instead of from the server.
> 
> Adds shared helpers in `dynamicVariables.ts` to **parse** the `dynamic-variables` attribute and **replace** `{{ key }}` tokens in a template string. `useFirstMessage` now runs that interpolation before returning the greeting. Session config reuses the same parser for `dynamicVariables` instead of duplicating inline JSON parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd87af851c8abe1bcb2c383582b7d124daef1c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->