### PR TITLE
Fix agent messages being deleted mid conversation

### DIFF
--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -143,6 +143,29 @@ describe("elevenlabs-convai", () => {
       .toBeInTheDocument();
   });
 
+  it("consolidates a streamed partial and its final into a single bubble", async () => {
+    // The reducer must consolidate a streamed message into one entry. The mock
+    // streams "partial" then delivers "full" as an agent_response for the same
+    // event_id, so "full" overwrites the partial in place.
+    setupWebComponent({
+      "agent-id": "stream_consolidation",
+      variant: "compact",
+    });
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("go");
+    await userEvent.keyboard("{Enter}");
+
+    const finalMessage = page.getByText("full", { exact: true });
+    await expect.element(finalMessage).toBeInTheDocument();
+    expect(finalMessage.elements()).toHaveLength(1);
+    await expect
+      .element(page.getByText("partial", { exact: true }))
+      .not.toBeInTheDocument();
+  });
+
   it.each(Variants)(
     "$0 expandable variant should go through a happy path (text-only)",
     async variant => {

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -173,6 +173,15 @@ const codeBlock = true;
     default_expanded: true,
     first_message: "",
   },
+  stream_consolidation: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
   audio_tags_strip: {
     ...BASIC_CONFIG,
     text_only: true,
@@ -299,6 +308,7 @@ export const Worker = setupWorker(
         config.text_only &&
         agentId !== "end_call_test" &&
         agentId !== "tool_call" &&
+        agentId !== "stream_consolidation" &&
         agentId !== "file_upload" &&
         agentId !== "no_file_upload"
       ) {
@@ -449,6 +459,48 @@ export const Worker = setupWorker(
                 agent_response: "Tool completed successfully",
                 event_id: 2,
               },
+            })
+          );
+        });
+      }
+      if (agentId === "stream_consolidation") {
+        let hasStreamed = false;
+        client.addEventListener("message", async event => {
+          const data =
+            typeof event.data === "string" ? JSON.parse(event.data) : null;
+          if (data?.type !== "user_message" || hasStreamed) return;
+          hasStreamed = true;
+          // Stream a partial, then deliver the final text as an agent_response
+          // for the same event_id (before stop) so it overwrites in place.
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 2 },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: {
+                text: "partial",
+                type: "delta",
+                event_id: 2,
+              },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_response",
+              agent_response_event: { agent_response: "full", event_id: 2 },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "stop", event_id: 2 },
             })
           );
         });

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -144,9 +144,18 @@ describe("buildDisplayTranscript", () => {
       expected: Array<{ message: string }>;
     }>([
       {
-        description: "groups consecutive agent messages with same eventId",
+        description:
+          "keeps two non-empty agent messages with the same eventId as separate bubbles",
         input: [
-          msg("agent", "partial", { eventId: 2 }),
+          msg("agent", "before", { eventId: 2 }),
+          msg("agent", "after", { eventId: 2 }),
+        ],
+        expected: [{ message: "before" }, { message: "after" }],
+      },
+      {
+        description: "folds an empty placeholder into the following message",
+        input: [
+          msg("agent", "", { eventId: 2 }),
           msg("agent", "full", { eventId: 2 }),
         ],
         expected: [{ message: "full" }],
@@ -203,21 +212,40 @@ describe("buildDisplayTranscript", () => {
       expect(result[0]).toMatchObject({ message: "Done" });
     });
 
-    it("still merges a streamed partial into its finalized message after a tool", () => {
-      // The first segment ends, a tool runs, then a new segment streams a
-      // partial and finalizes. The partial/full pair (no tool between them)
-      // still collapses to the finalized message.
+    it("folds an empty placeholder into its finalized message after a tool", () => {
+      // The first segment ends, a tool runs, then a new segment starts with an
+      // empty placeholder that is finalized in place. The empty placeholder
+      // folds into the finalized message, leaving one bubble per segment.
       const input = [
         msg("agent", "before tool", { eventId: 2 }),
         toolReq(3),
         toolRes(3),
-        msg("agent", "partial", { eventId: 3 }),
+        msg("agent", "", { eventId: 3 }),
         msg("agent", "full", { eventId: 3 }),
       ];
       const result = build(input);
       expect(result).toHaveLength(2);
       expect(result[0]).toMatchObject({ message: "before tool" });
       expect(result[1]).toMatchObject({ message: "full" });
+    });
+
+    it("keeps pre-tool and post-tool messages when the tool emits no entries", () => {
+      // A server-side tool runs without emitting client agent_tool_request or
+      // agent_tool_response entries, so the pre-tool and post-tool replies
+      // (both non-empty, sharing the turn's eventId) sit adjacent in the
+      // transcript with nothing between them. They must remain separate bubbles.
+      const input = [
+        msg("agent", "Got it — let me look that up for you.", { eventId: 2 }),
+        msg("agent", "I've looked up the pricing for you.", { eventId: 2 }),
+      ];
+      const result = build(input, { showAgentStatus: true });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        message: "Got it — let me look that up for you.",
+      });
+      expect(result[1]).toMatchObject({
+        message: "I've looked up the pricing for you.",
+      });
     });
   });
 

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -101,16 +101,12 @@ export function buildDisplayTranscript(
     }
   }
 
-  // Whether a tool entry appeared since the last emitted message.
-  let toolBetween = false;
-
   for (const entry of entries) {
     // Skip tool entries (consumed into status)
     if (
       entry.type === "agent_tool_request" ||
       entry.type === "agent_tool_response"
     ) {
-      toolBetween = true;
       continue;
     }
 
@@ -131,9 +127,9 @@ export function buildDisplayTranscript(
     if (!config.transcriptEnabled && entry.type === "message" && !entry.isText)
       continue;
 
-    // Merge same-eventId+role messages (collapses streamed partials and empty
-    // placeholders into the final message). Don't merge text → tool → text:
-    // a tool split two non-empty segments, so they stay distinct bubbles.
+    // Fold an empty agent placeholder into the following same-turn message.
+    // Two non-empty entries sharing an eventId are always distinct messages
+    // (e.g. pre-tool and post-tool replies), so they stay separate bubbles.
     const prev = result[result.length - 1];
     if (
       entry.type === "message" &&
@@ -141,14 +137,13 @@ export function buildDisplayTranscript(
       prev?.type === "message" &&
       prev.eventId === entry.eventId &&
       prev.role === entry.role &&
-      (!toolBetween || !prev.message.trim())
+      !prev.message.trim()
     ) {
       result[result.length - 1] = entry;
       continue;
     }
 
     result.push(entry);
-    toolBetween = false;
   }
 
   // Attach tool status to the first agent bubble of each turn only — a turn can


### PR DESCRIPTION
Linear issue: [AWF-167: Widget messages replaced by new text during tool calls](https://linear.app/elevenlabs/issue/AWF-167/widget-messages-replaced-by-new-text-during-tool-calls)

Agent messages could be deleted and replaced mid-conversation. It happened when two replies in the same turn (one before a tool call and one after) shared an event_id. `buildDisplayTranscript` treated them as the same message and collapsed them into one bubble, so the second reply clobbered the first.

**Root cause**
The merge was gated by a `toolBetween` flag that only kept two same event_id replies apart if a tool request/response event showed up between them. But a server-side tool can run without emitting any client tool events, so the two replies end up back to back with nothing between them so `toolBetween` stays false and the second overwrites the first. (the `toolBetween` flag was introduced in this [PR](https://github.com/elevenlabs/packages/pull/861))

**Fix**
- Removed the `toolBetween` check entirely.
- Now we only fold an empty placeholder into the message that follows it. Two non-empty replies that share an event_id are always kept as separate bubbles.

This fix is safe because of how ingestion works: a streamed reply only ever lives in one transcript entry. start adds one empty row, each delta appends into that same row, and the final agent_response overwrites it in place (see onAgentChatResponsePart / onMessage in conversation.tsx). A partial and its final can never split into two rows. So two non-empty entries with the same event_id really are two different messages, and merging them would throw one away. Because the fix relies on that ingestion behavior, I added a browser test that verifies messages are consolidated into a single entry.

Before
<img width="582" height="568" alt="gif_pr" src="https://github.com/user-attachments/assets/b4396473-4bd0-495d-bc89-235258e60fca" />

After (There is a duplicate message issue now which I will fix in a separate PR but want to get this reviewed on it's own)
<img width="482" height="576" alt="fix" src="https://github.com/user-attachments/assets/25d30f5b-cf3d-46c1-8baa-c3323a6d5369" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transcript bubble merging behavior for all conversations; wrong logic could duplicate bubbles or break streaming placeholders, but coverage targets the main regressions.
> 
> **Overview**
> Fixes **agent messages disappearing mid-conversation** when a turn sends multiple non-empty replies under the same `event_id` (common around tool calls, including server-side tools that never emit client tool events).
> 
> **`buildDisplayTranscript`** no longer collapses same-`eventId` agent bubbles using a `toolBetween` flag. It **only folds an empty placeholder** into the next same-turn message; **two non-empty entries stay separate bubbles**.
> 
> Unit tests cover adjacent pre/post-tool replies without tool transcript entries, and updated grouping expectations. A **`stream_consolidation`** MSW agent plus a browser test assert streamed partial + final still render as **one** bubble when ingestion overwrites in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08ad14e134c2acfd9a7a9f150e7af4c0449ad0ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->