### PR TITLE
[agents] add onAgentReasoningResponsePart callback

### DIFF
--- a/.changeset/agent-reasoning-response-part.md
+++ b/.changeset/agent-reasoning-response-part.md
@@ -1,6 +1,7 @@
 ---
 "@elevenlabs/client": minor
 "@elevenlabs/react": minor
+"@elevenlabs/types": minor
 ---
 
 Add `onAgentReasoningResponsePart` callback to receive streaming reasoning response

--- a/.changeset/agent-reasoning-response-part.md
+++ b/.changeset/agent-reasoning-response-part.md
@@ -1,0 +1,8 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+---
+
+Add `onAgentReasoningResponsePart` callback to receive streaming reasoning response
+events from the agent. The callback receives `{ text, type, event_id }` where type
+is one of "start", "delta", or "stop".

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -210,6 +210,99 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("agent_reasoning_response_part events", () => {
+    it("calls onAgentReasoningResponsePart with the reasoning payload", async () => {
+      const onAgentReasoningResponsePart = vi.fn();
+      const onDebug = vi.fn();
+      const conversation = TestConversation.create({
+        onAgentReasoningResponsePart,
+        onDebug,
+      });
+
+      await conversation.receiveMessage({
+        type: "agent_reasoning_response_part",
+        reasoning_response_part: {
+          text: "Let me think about this...",
+          type: "delta",
+          event_id: "123",
+        },
+      });
+
+      expect(onAgentReasoningResponsePart).toHaveBeenCalledWith({
+        text: "Let me think about this...",
+        type: "delta",
+        event_id: "123",
+      });
+      expect(onDebug).not.toHaveBeenCalled();
+    });
+
+    it("handles start, delta, and stop types", async () => {
+      const onAgentReasoningResponsePart = vi.fn();
+      const conversation = TestConversation.create({
+        onAgentReasoningResponsePart,
+      });
+
+      await conversation.receiveMessage({
+        type: "agent_reasoning_response_part",
+        reasoning_response_part: {
+          text: "",
+          type: "start",
+          event_id: "1",
+        },
+      });
+
+      await conversation.receiveMessage({
+        type: "agent_reasoning_response_part",
+        reasoning_response_part: {
+          text: "Analyzing the request...",
+          type: "delta",
+          event_id: "1",
+        },
+      });
+
+      await conversation.receiveMessage({
+        type: "agent_reasoning_response_part",
+        reasoning_response_part: {
+          text: "",
+          type: "stop",
+          event_id: "1",
+        },
+      });
+
+      expect(onAgentReasoningResponsePart).toHaveBeenCalledTimes(3);
+      expect(onAgentReasoningResponsePart).toHaveBeenNthCalledWith(1, {
+        text: "",
+        type: "start",
+        event_id: "1",
+      });
+      expect(onAgentReasoningResponsePart).toHaveBeenNthCalledWith(2, {
+        text: "Analyzing the request...",
+        type: "delta",
+        event_id: "1",
+      });
+      expect(onAgentReasoningResponsePart).toHaveBeenNthCalledWith(3, {
+        text: "",
+        type: "stop",
+        event_id: "1",
+      });
+    });
+
+    it("does not throw when no callback is provided", async () => {
+      const conversation = TestConversation.create({});
+
+      await expect(
+        conversation.receiveMessage({
+          type: "agent_reasoning_response_part",
+          reasoning_response_part: {
+            text: "Thinking...",
+            type: "delta",
+            event_id: "42",
+          },
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("ping events", () => {
     it("replies with a pong and forwards the payload to onPing", async () => {
       const onPing = vi.fn();

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -10,6 +10,7 @@ import type { Conversation } from "./index.js";
 import type {
   AgentAudioEvent,
   AgentChatResponsePartEvent,
+  AgentReasoningResponsePartEvent,
   AgentResponseEvent,
   AgentResponseCorrectionEvent,
   AgentTypingEvent,
@@ -402,6 +403,14 @@ export abstract class BaseConversation {
     }
   }
 
+  protected handleAgentReasoningResponsePart(
+    event: AgentReasoningResponsePartEvent
+  ) {
+    if (this.options.onAgentReasoningResponsePart) {
+      this.options.onAgentReasoningResponsePart(event.reasoning_response_part);
+    }
+  }
+
   protected handleGuardrailTriggered(_event: GuardrailTriggeredEvent) {
     if (this.options.onGuardrailTriggered) {
       this.options.onGuardrailTriggered();
@@ -543,6 +552,11 @@ export abstract class BaseConversation {
 
       case "agent_chat_response_part": {
         this.handleAgentChatResponsePart(parsedEvent);
+        return;
+      }
+
+      case "agent_reasoning_response_part": {
+        this.handleAgentReasoningResponsePart(parsedEvent);
         return;
       }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -121,6 +121,14 @@ export type Callbacks = {
   onAgentChatResponsePart?: (
     props: AgentChatResponsePartClientEvent["text_response_part"]
   ) => void;
+  /**
+   * Called for each streaming reasoning response chunk from the agent.
+   * Receives `{ text, type, event_id }` where `type` is `"start"`, `"delta"`,
+   * or `"stop"`.
+   *
+   * @experimental This API is experimental and may change without following
+   * semver guarantees.
+   */
   onAgentReasoningResponsePart?: (
     props: AgentReasoningResponsePartClientEvent["reasoning_response_part"]
   ) => void;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -13,6 +13,7 @@ import type {
   Interruption,
   AgentResponseCorrection,
   AgentChatResponsePartClientEvent,
+  AgentReasoningResponsePartClientEvent,
   Ping,
 } from "@elevenlabs/types";
 
@@ -120,6 +121,9 @@ export type Callbacks = {
   onAgentChatResponsePart?: (
     props: AgentChatResponsePartClientEvent["text_response_part"]
   ) => void;
+  onAgentReasoningResponsePart?: (
+    props: AgentReasoningResponsePartClientEvent["reasoning_response_part"]
+  ) => void;
   onGuardrailTriggered?: () => void;
   onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   onAgentTyping?: (props: AgentTypingClientEvent["agent_typing_event"]) => void;
@@ -162,6 +166,7 @@ export const CALLBACK_KEYS = [
   "onInterruption",
   "onAgentResponseCorrection",
   "onAgentChatResponsePart",
+  "onAgentReasoningResponsePart",
   "onAudioAlignment",
   "onGuardrailTriggered",
   "onAgentTyping",

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -1,5 +1,6 @@
 import type {
   AgentChatResponsePartClientEvent,
+  AgentReasoningResponsePartClientEvent,
   AgentResponse,
   AgentResponseCorrection,
   AgentToolResponseClientEvent,
@@ -45,6 +46,8 @@ export type ConversationMetadataEvent = ConversationMetadata;
 export type AsrInitiationMetadataEvent = AsrMetadataEvent;
 export type MCPConnectionStatusEvent = McpConnectionStatusClientEvent;
 export type AgentChatResponsePartEvent = AgentChatResponsePartClientEvent;
+export type AgentReasoningResponsePartEvent =
+  AgentReasoningResponsePartClientEvent;
 export type ErrorMessageEvent = ErrorMessage;
 export type GuardrailTriggeredEvent = GuardrailTriggered;
 export type AgentTypingEvent = AgentTypingClientEvent;
@@ -70,6 +73,7 @@ export type IncomingSocketEvent =
   | AsrInitiationMetadataEvent
   | MCPConnectionStatusEvent
   | AgentChatResponsePartEvent
+  | AgentReasoningResponsePartEvent
   | ErrorMessageEvent
   | GuardrailTriggeredEvent
   | AgentTypingEvent

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -40,6 +40,7 @@ export type HookCallbacks = Pick<
   | "onMCPConnectionStatus"
   | "onAsrInitiationMetadata"
   | "onAgentChatResponsePart"
+  | "onAgentReasoningResponsePart"
   | "onAgentResponseCorrection"
   | "onAudioAlignment"
   | "onGuardrailTriggered"

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -172,6 +172,7 @@ export type ConversationConfigOverrideConversationClientEventsItem =
   | "agent_response"
   | "agent_response_correction"
   | "agent_chat_response_part"
+  | "agent_reasoning_response_part"
   | "interruption"
   | "user_transcript"
   | "tentative_user_transcript"
@@ -292,6 +293,19 @@ export interface TextResponsePart {
 }
 
 export type TextResponsePartType = "start" | "delta" | "stop";
+
+export interface AgentReasoningResponsePart {
+  type: "agent_reasoning_response_part";
+  reasoning_response_part: ReasoningResponsePart;
+}
+
+export interface ReasoningResponsePart {
+  text: string;
+  type: ReasoningResponsePartType;
+  event_id: string;
+}
+
+export type ReasoningResponsePartType = "start" | "delta" | "stop";
 
 export interface Interruption {
   type: "interruption";
@@ -591,6 +605,11 @@ export interface AgentResponseCorrectionClientEvent {
 export interface AgentChatResponsePartClientEvent {
   type: "agent_chat_response_part";
   text_response_part: TextResponsePart;
+}
+
+export interface AgentReasoningResponsePartClientEvent {
+  type: "agent_reasoning_response_part";
+  reasoning_response_part: ReasoningResponsePart;
 }
 
 export interface ClientToolCallClientEvent {

--- a/packages/types/generated/types/incoming.ts
+++ b/packages/types/generated/types/incoming.ts
@@ -1,6 +1,7 @@
 // Auto-generated barrel for incoming payloads
 export type {
   AgentChatResponsePartClientEvent,
+  AgentReasoningResponsePartClientEvent,
   AgentResponseClientEvent,
   AgentResponseCorrectionClientEvent,
   AgentToolRequestClientEvent,

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -52,6 +52,7 @@ channels:
           - $ref: "#/components/messages/AgentResponse"
           - $ref: "#/components/messages/AgentResponseCorrection"
           - $ref: "#/components/messages/AgentChatResponsePart"
+          - $ref: "#/components/messages/AgentReasoningResponsePart"
           - $ref: "#/components/messages/Interruption"
           - $ref: "#/components/messages/ConversationMetadata"
           - $ref: "#/components/messages/ClientToolCallMessage"
@@ -218,6 +219,14 @@ components:
       payload:
         $ref: "#/components/schemas/AgentChatResponsePartPayload"
 
+    AgentReasoningResponsePart:
+      name: AgentReasoningResponsePartClientEvent
+      title: Agent Reasoning Response Part
+      summary: Streaming reasoning text from agent
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/AgentReasoningResponsePartPayload"
+
     Interruption:
       name: InterruptionEvent
       title: Interruption
@@ -364,6 +373,7 @@ components:
         - agent_response
         - agent_response_correction
         - agent_chat_response_part
+        - agent_reasoning_response_part
         - interruption
         - user_transcript
         - tentative_user_transcript
@@ -820,6 +830,16 @@ components:
         text_response_part:
           $ref: "#/components/schemas/AgentChatResponsePartData"
 
+    AgentReasoningResponsePartPayload:
+      type: object
+      required: [reasoning_response_part, type]
+      properties:
+        type:
+          type: string
+          const: agent_reasoning_response_part
+        reasoning_response_part:
+          $ref: "#/components/schemas/AgentReasoningResponsePartData"
+
     InterruptionPayload:
       type: object
       required: [interruption_event, type]
@@ -996,6 +1016,27 @@ components:
         event_id:
           type: integer
           description: Event ID of this chat response part
+
+    AgentReasoningResponsePartType:
+      type: string
+      enum:
+        - start
+        - delta
+        - stop
+      description: Type of streaming reasoning response chunk
+
+    AgentReasoningResponsePartData:
+      type: object
+      required: [text, type, event_id]
+      properties:
+        text:
+          type: string
+          description: Reasoning text chunk (empty for start/stop events)
+        type:
+          $ref: "#/components/schemas/AgentReasoningResponsePartType"
+        event_id:
+          type: string
+          description: Event ID of this reasoning response part
 
     InterruptionData:
       type: object


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

https://eleven-labs-workspace.slack.com/archives/C0B233U4K5F/p1785186133909969

Add support for `agent_reasoning_response_part` events with a new `onAgentReasoningResponsePart` callback. The callback receives streaming reasoning response events with `{ text, type, event_id }` where `type` is one of `"start"`, `"delta"`, or `"stop"`.

## Changes

- Add `agent_reasoning_response_part` event to AsyncAPI schema (`packages/types/schemas/agent.asyncapi.yaml`)
- Types are auto-generated from the schema via `pnpm generate-types`
- Add `onAgentReasoningResponsePart` callback to `Callbacks` type in `@elevenlabs/client`
- Add handler in `BaseConversation` to process the new event type
- Add `onAgentReasoningResponsePart` to React `HookCallbacks` in `@elevenlabs/react`
- Add test cases for the new callback
- Add minor version changeset for client and react packages

## Usage

```typescript
const conversation = await Conversation.startSession({
  agentId: "your-agent-id",
  onAgentReasoningResponsePart: ({ text, type, event_id }) => {
    switch (type) {
      case "start":
        console.log("Reasoning started");
        break;
      case "delta":
        console.log("Reasoning:", text);
        break;
      case "stop":
        console.log("Reasoning finished");
        break;
    }
  },
});
```

## Testing

- Added 3 new test cases for the `agent_reasoning_response_part` event handling
- All existing tests continue to pass
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://eleven-labs-workspace.slack.com/archives/D094A2U16DS/p1785184500976009?thread_ts=1785184500.976009&cid=D094A2U16DS)

<div><a href="https://cursor.com/agents/bc-1102a773-938a-5cbf-9b5c-65c03ed1943a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1102a773-938a-5cbf-9b5c-65c03ed1943a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

