### PR TITLE
[types] Add @experimental annotations to AgentReasoningResponsePart types

### DIFF
--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -281,9 +281,6 @@ export interface AgentResponseCorrectionEvent {
   event_id: number;
 }
 
-/**
- * @experimental
- */
 export interface AgentChatResponsePart {
   type: "agent_chat_response_part";
   text_response_part: TextResponsePart;
@@ -608,9 +605,6 @@ export interface AgentResponseCorrectionClientEvent {
   agent_response_correction_event: AgentResponseCorrectionEvent;
 }
 
-/**
- * @experimental
- */
 export interface AgentChatResponsePartClientEvent {
   type: "agent_chat_response_part";
   text_response_part: TextResponsePart;

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -281,6 +281,9 @@ export interface AgentResponseCorrectionEvent {
   event_id: number;
 }
 
+/**
+ * @experimental
+ */
 export interface AgentChatResponsePart {
   type: "agent_chat_response_part";
   text_response_part: TextResponsePart;
@@ -294,6 +297,9 @@ export interface TextResponsePart {
 
 export type TextResponsePartType = "start" | "delta" | "stop";
 
+/**
+ * @experimental
+ */
 export interface AgentReasoningResponsePart {
   type: "agent_reasoning_response_part";
   reasoning_response_part: ReasoningResponsePart;
@@ -602,11 +608,17 @@ export interface AgentResponseCorrectionClientEvent {
   agent_response_correction_event: AgentResponseCorrectionEvent;
 }
 
+/**
+ * @experimental
+ */
 export interface AgentChatResponsePartClientEvent {
   type: "agent_chat_response_part";
   text_response_part: TextResponsePart;
 }
 
+/**
+ * @experimental
+ */
 export interface AgentReasoningResponsePartClientEvent {
   type: "agent_reasoning_response_part";
   reasoning_response_part: ReasoningResponsePart;

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -216,7 +216,6 @@ components:
       title: Agent Chat Response Part
       summary: Streaming text chunk from agent (text-only mode)
       contentType: application/json
-      x-experimental: true
       payload:
         $ref: "#/components/schemas/AgentChatResponsePartPayload"
 

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -216,6 +216,7 @@ components:
       title: Agent Chat Response Part
       summary: Streaming text chunk from agent (text-only mode)
       contentType: application/json
+      x-experimental: true
       payload:
         $ref: "#/components/schemas/AgentChatResponsePartPayload"
 
@@ -224,6 +225,7 @@ components:
       title: Agent Reasoning Response Part
       summary: Streaming reasoning text from agent
       contentType: application/json
+      x-experimental: true
       payload:
         $ref: "#/components/schemas/AgentReasoningResponsePartPayload"
 

--- a/packages/types/scripts/generate-all-types.ts
+++ b/packages/types/scripts/generate-all-types.ts
@@ -39,6 +39,7 @@ type PayloadItem = {
   baseName: string;
   schema: any;
   dir?: Dir;
+  experimental?: boolean;
 };
 
 async function collectPayloads(
@@ -76,7 +77,12 @@ async function collectPayloads(
     const key = `c:${msgName}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    items.push({ baseName: msgName, schema: { ...payload, $id: msgName } });
+    const experimental = (message as any)?.["x-experimental"] === true;
+    items.push({
+      baseName: msgName,
+      schema: { ...payload, $id: msgName },
+      experimental,
+    });
   }
 
   // B) channels: publish & subscribe (handle oneOf)
@@ -102,10 +108,21 @@ async function collectPayloads(
         if (seen.has(key)) continue;
         seen.add(key);
 
+        // Check for experimental flag on the message or via $ref resolution
+        let experimental = (m as any)?.["x-experimental"] === true;
+        if (!experimental && m?.$ref) {
+          const refName = String(m.$ref).split("/").pop();
+          const refMessage = cm[refName as string];
+          if (refMessage?.["x-experimental"] === true) {
+            experimental = true;
+          }
+        }
+
         items.push({
           baseName: base,
           schema: { ...payload, $id: base },
           dir: opKindToDir(opKind, role),
+          experimental,
         });
       }
     }
@@ -148,6 +165,8 @@ async function main() {
   const pieces: string[] = [];
   const incomingNames = new Set<string>();
   const outgoingNames = new Set<string>();
+  // Track which type names should have @experimental JSDoc
+  const experimentalTypes = new Set<string>();
 
   // Process each schema file
   for (const schemaFile of schemaFiles) {
@@ -160,23 +179,29 @@ async function main() {
 
       console.log(`  Found ${payloads.length} payload(s) in ${fileName}`);
 
-      for (const { schema, dir } of payloads) {
+      for (const { schema, dir, experimental } of payloads) {
         const models = await generator.generate(schema);
 
         // Record root for barrels (first model matches $id)
         const root = models[0]?.modelName;
         if (root && dir)
           (dir === "incoming" ? incomingNames : outgoingNames).add(root);
+        if (root && experimental) experimentalTypes.add(root);
 
         for (const m of models) {
           if (emitted.has(m.modelName)) continue;
           emitted.add(m.modelName);
 
           // Add `export` to top-level declarations (interface | type | enum)
-          const exported = m.result
+          let exported = m.result
             .replace(/^(\s*)(interface\s+)/m, "$1export $2")
             .replace(/^(\s*)(type\s+)/m, "$1export $2")
             .replace(/^(\s*)(enum\s+)/m, "$1export $2");
+
+          // Prepend @experimental JSDoc if marked as experimental
+          if (experimentalTypes.has(m.modelName)) {
+            exported = "/**\n * @experimental\n */\n" + exported;
+          }
 
           pieces.push(exported);
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds support for marking generated AsyncAPI types as `@experimental` using JSDoc annotations.

## Changes

### Generator Enhancement (`generate-all-types.ts`)
- Added support for `x-experimental: true` extension in AsyncAPI message definitions
- Modified type generation to prepend `/** @experimental */` JSDoc comment to types marked as experimental
- Tracks experimental types through both `components.messages` and channel `$ref` resolution

### Schema Updates (`agent.asyncapi.yaml`)
- Added `x-experimental: true` to `AgentReasoningResponsePart` message definition

### Generated Types (`asyncapi-types.ts`)
The following types now include the `@experimental` JSDoc annotation:
- `AgentReasoningResponsePart`  
- `AgentReasoningResponsePartClientEvent`

## Usage

To mark other types as experimental in the future, add `x-experimental: true` to the message definition in the AsyncAPI schema:

```yaml
components:
  messages:
    SomeMessage:
      name: SomeMessageClientEvent
      x-experimental: true  # Add this line
      payload:
        $ref: "#/components/schemas/SomePayload"
```

## Related

Addresses PR comment: https://github.com/elevenlabs/packages/pull/901#discussion_r3661009764
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://eleven-labs-workspace.slack.com/archives/D094A2U16DS/p1785187512562229?thread_ts=1785187512.562229&cid=D094A2U16DS)

<div><a href="https://cursor.com/agents/bc-80462a46-d6ef-5c5d-868e-4029d8e37903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80462a46-d6ef-5c5d-868e-4029d8e37903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

