### PR TITLE
fix(types): Mark all nested types from experimental payloads as @experimental

### DIFF
--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -302,12 +302,18 @@ export interface AgentReasoningResponsePart {
   reasoning_response_part: ReasoningResponsePart;
 }
 
+/**
+ * @experimental
+ */
 export interface ReasoningResponsePart {
   text: string;
   type: ReasoningResponsePartType;
   event_id: string;
 }
 
+/**
+ * @experimental
+ */
 export type ReasoningResponsePartType = "start" | "delta" | "stop";
 
 export interface Interruption {

--- a/packages/types/scripts/generate-all-types.ts
+++ b/packages/types/scripts/generate-all-types.ts
@@ -186,7 +186,13 @@ async function main() {
         const root = models[0]?.modelName;
         if (root && dir)
           (dir === "incoming" ? incomingNames : outgoingNames).add(root);
-        if (root && experimental) experimentalTypes.add(root);
+
+        // Mark all types from an experimental payload as experimental
+        if (experimental) {
+          for (const m of models) {
+            experimentalTypes.add(m.modelName);
+          }
+        }
 
         for (const m of models) {
           if (emitted.has(m.modelName)) continue;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the type generator to mark ALL types generated from an experimental payload as `@experimental`, not just the root type.

## Problem

After merging PR #901, only the root types (`AgentReasoningResponsePart` and `AgentReasoningResponsePartClientEvent`) were marked as experimental. The nested types (`ReasoningResponsePart` and `ReasoningResponsePartType`) were missing the annotation.

## Solution

Modified the generator to iterate through all models generated from an experimental payload and add them to the `experimentalTypes` set, ensuring all related types get the `@experimental` JSDoc annotation.

## Types now marked as `@experimental`

- `AgentReasoningResponsePart`
- `ReasoningResponsePart`
- `ReasoningResponsePartType`
- `AgentReasoningResponsePartClientEvent`

## Related

Follow-up to PR #901
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://eleven-labs-workspace.slack.com/archives/D094A2U16DS/p1785187512562229?thread_ts=1785187512.562229&cid=D094A2U16DS)

<div><a href="https://cursor.com/agents/bc-80462a46-d6ef-5c5d-868e-4029d8e37903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80462a46-d6ef-5c5d-868e-4029d8e37903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

