### PR TITLE
feat(client): add enableLogging option to Scribe.connect

### DIFF
--- a/.changeset/scribe-enable-logging.md
+++ b/.changeset/scribe-enable-logging.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Add `enableLogging` option to `Scribe.connect`. It forwards the realtime speech-to-text `enable_logging` query parameter, so SDK sessions can request zero retention mode the same way direct WebSocket connections already can.

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -237,6 +237,25 @@ describe("Scribe", () => {
       server.close();
     });
 
+    it("builds URI with enableLogging", () => {
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&enable_logging=false"
+      );
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+        enableLogging: false,
+      });
+
+      expect(connection).toBeDefined();
+
+      connection.close();
+      server.close();
+    });
+
     it("builds URI with includeLanguageDetection", () => {
       const server = new Server(
         "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123&include_language_detection=true"

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -81,6 +81,13 @@ interface BaseOptions {
    * @default false
    */
   noVerbatim?: boolean;
+  /**
+   * Whether to log the request for history features. When false, the request
+   * uses zero retention mode. Zero retention mode may only be used by
+   * enterprise customers.
+   * @default true
+   */
+  enableLogging?: boolean;
 }
 
 export interface AudioOptions extends BaseOptions {
@@ -200,6 +207,9 @@ export class ScribeRealtime {
     }
     if (options.noVerbatim !== undefined) {
       params.append("no_verbatim", options.noVerbatim ? "true" : "false");
+    }
+    if (options.enableLogging !== undefined) {
+      params.append("enable_logging", options.enableLogging ? "true" : "false");
     }
 
     const queryString = params.toString();


### PR DESCRIPTION
## Motivation

The realtime speech-to-text WebSocket API documents an `enable_logging` query parameter:

> When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.

`Scribe.connect` currently has no way to set it, and since `buildWebSocketUri` constructs the URL itself (with `URLSearchParams` encoding the option values), there is no workaround from the SDK — enterprise users who need zero retention for speech-to-text have to drop down to a hand-rolled WebSocket client just for this one parameter.

## Change

- Add an optional `enableLogging?: boolean` to the Scribe connect options, forwarded as `enable_logging` — mirroring the existing `noVerbatim` pattern.
- Add a `builds URI with enableLogging` test alongside the other URI-builder tests.
- Changeset: minor bump for `@elevenlabs/client`.

## Testing

- `pnpm vitest run src/scribe/scribe.test.ts` — 42/42 passing.
- `pnpm turbo build --filter=@elevenlabs/client...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, optional query-parameter passthrough with no change to default connection behavior when the option is omitted.
> 
> **Overview**
> Adds optional **`enableLogging`** on `Scribe.connect` so the SDK can set the realtime STT WebSocket **`enable_logging`** query parameter (same idea as existing flags like `noVerbatim`).
> 
> When set to `false`, sessions can use **zero retention** (no history / request stitching); the option is documented as enterprise-only on the API side. **`buildWebSocketUri`** appends `enable_logging=true|false` only when the option is provided. A URI-builder test covers `enableLogging: false`, and the changeset bumps **`@elevenlabs/client`** minor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b01fa35caae9ce724358b7447d06d0faa2714d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->