### PR TITLE
feat(scribe): support disabling logging via enableLogging

### DIFF
--- a/.changeset/scribe-enable-logging.md
+++ b/.changeset/scribe-enable-logging.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+---
+
+Add `enableLogging` option (`boolean`) to the Scribe realtime API, available on `Scribe.connect` and the `useScribe` hook. Setting it to `false` sends `enable_logging=false` on the WebSocket URL, which runs the session in zero retention mode so history features are unavailable for it. Zero retention mode may only be used by enterprise customers.

--- a/.changeset/scribe-session-started-enable-logging.md
+++ b/.changeset/scribe-session-started-enable-logging.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/types": minor
+---
+
+Rename `disable_logging` to `enable_logging` in the Scribe `session_started` config to match the field the server actually reports. `disable_logging` was never sent on the wire.

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -1,4 +1,4 @@
-import { it, expect, describe, vi, beforeEach } from "vitest";
+import { it, expect, describe, vi, beforeEach, onTestFinished } from "vitest";
 import { Server } from "mock-socket";
 import type { Client } from "mock-socket";
 import {
@@ -18,6 +18,31 @@ const TEST_MODEL_ID = "scribe_v2_realtime";
 const TEST_SESSION_ID = "test-session-id";
 const PARTIAL_TRANSCRIPT_TEXT = "Hello, this is a partial";
 const COMMITTED_TRANSCRIPT_TEXT = "Hello, this is a committed transcript.";
+const SCRIBE_WS_URL = "wss://api.elevenlabs.io/v1/speech-to-text/realtime";
+
+/**
+ * Starts a mock Scribe server and resolves with the query params the client
+ * connected with. The mock server matches on the URL without its query part, so
+ * inspecting the client URI is the only way to assert on the URI that was built.
+ * Call before connecting so the connection listener is already attached.
+ */
+function connectionQuery(): Promise<URLSearchParams> {
+  const server = new Server(SCRIBE_WS_URL);
+  onTestFinished(() => server.close());
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("timed out waiting for connection")),
+      5000
+    );
+    onTestFinished(() => clearTimeout(timeout));
+
+    server.on("connection", socket =>
+      resolve(new URL(socket.url).searchParams)
+    );
+    server.on("error", reject);
+  });
+}
 
 describe("Scribe", () => {
   describe("WebSocket URI Building", () => {
@@ -254,6 +279,41 @@ describe("Scribe", () => {
 
       connection.close();
       server.close();
+    });
+
+    it.each([
+      { enableLogging: false, expected: "false" },
+      { enableLogging: true, expected: "true" },
+    ])(
+      "builds URI with enable_logging=$expected when enableLogging is $enableLogging",
+      async ({ enableLogging, expected }) => {
+        const query = connectionQuery();
+
+        const connection = Scribe.connect({
+          token: TEST_TOKEN,
+          modelId: TEST_MODEL_ID,
+          audioFormat: AudioFormat.PCM_16000,
+          sampleRate: 16000,
+          enableLogging,
+        });
+        onTestFinished(() => connection.close());
+
+        expect((await query).get("enable_logging")).toBe(expected);
+      }
+    );
+
+    it("omits enable_logging when enableLogging is not set", async () => {
+      const query = connectionQuery();
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+      });
+      onTestFinished(() => connection.close());
+
+      expect((await query).has("enable_logging")).toBe(false);
     });
 
     it("accepts valid parameter values", () => {

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -81,6 +81,14 @@ interface BaseOptions {
    * @default false
    */
   noVerbatim?: boolean;
+  /**
+   * Whether the request may be logged by ElevenLabs.
+   * When set to false, zero retention mode is used for the session, which means
+   * history features are unavailable for it. Zero retention mode may only be
+   * used by enterprise customers.
+   * @default true
+   */
+  enableLogging?: boolean;
 }
 
 export interface AudioOptions extends BaseOptions {
@@ -200,6 +208,9 @@ export class ScribeRealtime {
     }
     if (options.noVerbatim !== undefined) {
       params.append("no_verbatim", options.noVerbatim ? "true" : "false");
+    }
+    if (options.enableLogging !== undefined) {
+      params.append("enable_logging", options.enableLogging ? "true" : "false");
     }
 
     const queryString = params.toString();

--- a/packages/react/src/scribe.test.tsx
+++ b/packages/react/src/scribe.test.tsx
@@ -73,4 +73,42 @@ describe("useScribe", () => {
       })
     );
   });
+
+  it("passes enableLogging through to the client", async () => {
+    const { result } = renderHook(() => useScribe({ enableLogging: false }));
+
+    await act(async () => {
+      await result.current.connect({
+        token: "test-token",
+        modelId: "scribe_v2_realtime",
+        audioFormat: AudioFormat.PCM_16000,
+        sampleRate: 16000,
+      });
+    });
+
+    expect(Scribe.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enableLogging: false,
+      })
+    );
+  });
+
+  it("lets connect() disable logging for a session enabled at the hook level", async () => {
+    const { result } = renderHook(() => useScribe({ enableLogging: true }));
+
+    await act(async () => {
+      await result.current.connect({
+        token: "test-token",
+        modelId: "scribe_v2_realtime",
+        microphone: {},
+        enableLogging: false,
+      });
+    });
+
+    expect(Scribe.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enableLogging: false,
+      })
+    );
+  });
 });

--- a/packages/react/src/scribe.ts
+++ b/packages/react/src/scribe.ts
@@ -116,6 +116,14 @@ export interface ScribeHookOptions extends ScribeCallbacks {
   // Keyterms and verbatim control
   keyterms?: string[];
   noVerbatim?: boolean;
+
+  /**
+   * Whether the session may be logged by ElevenLabs. Set to `false` to use zero
+   * retention mode, which makes history features unavailable for the session.
+   * Zero retention mode may only be used by enterprise customers.
+   * @default true
+   */
+  enableLogging?: boolean;
 }
 
 export interface UseScribeReturn {
@@ -199,6 +207,9 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
     // Keyterms and verbatim control
     keyterms: defaultKeyterms,
     noVerbatim: defaultNoVerbatim,
+
+    // Logging
+    enableLogging: defaultEnableLogging,
   } = options;
 
   const connectionRef = useRef<RealtimeConnection | null>(null);
@@ -258,6 +269,8 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
         const includeLanguageDetection =
           runtimeOptions.includeLanguageDetection ??
           defaultIncludeLanguageDetection;
+        const enableLogging =
+          runtimeOptions.enableLogging ?? defaultEnableLogging;
 
         if (microphone) {
           // Microphone mode
@@ -282,6 +295,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
             microphone,
             includeTimestamps,
             includeLanguageDetection,
+            enableLogging,
           } as MicrophoneOptions);
         } else if (audioFormat && sampleRate) {
           // Manual audio mode
@@ -305,6 +319,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
             noVerbatim: runtimeOptions.noVerbatim ?? defaultNoVerbatim,
             includeTimestamps,
             includeLanguageDetection,
+            enableLogging,
             audioFormat,
             sampleRate,
           } as AudioOptions);
@@ -492,6 +507,7 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
       defaultIncludeLanguageDetection,
       defaultKeyterms,
       defaultNoVerbatim,
+      defaultEnableLogging,
       onSessionStarted,
       onPartialTranscript,
       onCommittedTranscript,

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -776,7 +776,7 @@ export interface Config {
   min_speech_duration_ms?: number;
   min_silence_duration_ms?: number;
   model_id?: string;
-  disable_logging?: boolean;
+  enable_logging?: boolean;
   keyterms?: string[];
   no_verbatim?: boolean;
 }

--- a/packages/types/schemas/scribe.asyncapi.yaml
+++ b/packages/types/schemas/scribe.asyncapi.yaml
@@ -347,9 +347,9 @@ components:
             model_id:
               type: string
               description: ID of the model to use for transcription
-            disable_logging:
+            enable_logging:
               type: boolean
-              description: Whether to disable logging
+              description: Whether the session may be logged. When false, zero retention mode is used and history features are unavailable for the session.
             keyterms:
               type: array
               items:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## description

Closes #545. Threads the realtime Scribe `enable_logging` query param through the SDKs so callers can opt into zero retention mode.

- `enableLogging?: boolean` on `BaseOptions` in `@elevenlabs/client`, appended to the WebSocket URI as `enable_logging=true|false`. Omitted entirely when unset, so the server default (logging enabled) still applies.
- `enableLogging?: boolean` on `ScribeHookOptions` in `@elevenlabs/react`, forwarded in both the microphone and manual-audio branches. Resolved with `??` so `connect({ enableLogging: false })` can disable logging for a single session even when the hook was created with `enableLogging: true`.

Confirmed against the backend repo: `/v1/speech-to-text/realtime` takes an `enable_logging` query param (bool, default `true`), and there is no `disable_logging` on the public API — `disable_logging` exists only internally as the derived/inverted value.

That also settles the naming. @kraenhansen raised `disableLogging: true` as affirmative-language alternative on #680, but `disable_logging` is an internal-only concept, so mirroring it in a public option would name something the API does not expose. `enableLogging` matches the query param, the Python SDK, and the LiveKit plugin, and is consistent with how this file already mirrors API names (`noVerbatim` → `no_verbatim`).

### second commit

`22baef6` renames `disable_logging` to `enable_logging` in the Scribe `session_started` config schema. The published [`/v1/speech-to-text/realtime` contract](https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime) reports `enable_logging` in `MessagesSessionStartedConfig` and has no `disable_logging`. `disable_logging` was hand-written into `scribe.asyncapi.yaml` when the file was created in #328 and is referenced nowhere else in the repo, so nothing consumes it today — the internal derived value is the likely source of the mistake. It matters here because this is how a caller would confirm zero retention mode took effect.

One thing worth a second pair of eyes from someone with backend access: this is the field name in the `session_started` *response payload*, not the query param. The published contract says `enable_logging`, but if the handler happens to serialize the internal config object into that message, it could emit the derived `disable_logging` instead. Confirming which model backs that payload would close it out; the commit is separable if you would rather not take it on faith.

Not touched: the same schema declares `vad_commit_strategy` where the published contract says `commit_strategy`. Same class of drift, unrelated to this issue.

## testing

Added unit tests, run with `pnpm exec vitest --browser.headless`:

```
 ✓ src/scribe/scribe.test.ts > builds URI with enable_logging='false' when enableLogging is false
 ✓ src/scribe/scribe.test.ts > builds URI with enable_logging='true' when enableLogging is true
 ✓ src/scribe/scribe.test.ts > omits enable_logging when enableLogging is not set
 ✓ src/scribe.test.tsx > useScribe > passes enableLogging through to the client
 ✓ src/scribe.test.tsx > useScribe > lets connect() disable logging for a session enabled at the hook level
```

Full suites pass: 160 tests in `@elevenlabs/client`, 133 in `@elevenlabs/react`, plus `turbo check-types lint` for `client`, `react`, and `types`.

The client-side assertions inspect the URI the mock server actually received. The existing `builds URI with ...` tests only put the expected query string in the `new Server(...)` URL, which `mock-socket` strips via `trimQueryPartFromURL` before matching, so those tests pass regardless of the query params that get built. I verified the new ones fail when the param name is misspelled, when the boolean is inverted, and when the `undefined` guard is removed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c8d57df-cc8c-4112-ad2c-4429d3c7a2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c8d57df-cc8c-4112-ad2c-4429d3c7a2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

