### PR TITLE
fix: bump postcss to 8.5.12 (CVE-2026-45623)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "msw"
     ],
     "overrides": {
-      "@asyncapi/parser": "^3.6.0"
+      "@asyncapi/parser": "^3.6.0",
+      "postcss": "^8.5.12"
     },
     "patchedDependencies": {
       "livekit-client@2.16.1": "patches/livekit-client@2.16.1.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@asyncapi/parser': ^3.6.0
+  postcss: ^8.5.12
 
 patchedDependencies:
   livekit-client@2.16.1:
@@ -6252,7 +6253,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: ^8.5.12
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -10547,19 +10548,19 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: ^8.5.12
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: ^8.5.12
 
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
-      postcss: '>=8.0.9'
+      postcss: ^8.5.12
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -10571,7 +10572,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: ^8.5.12
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -10587,14 +10588,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.4.49:
-    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -13298,7 +13291,7 @@ snapshots:
       '@types/node': 20.4.6
       '@types/react': 18.2.18
       '@types/react-dom': 18.2.7
-      autoprefixer: 10.4.14(postcss@8.4.31)
+      autoprefixer: 10.4.14(postcss@8.5.14)
       codemirror: 6.0.2
       driver.js: 1.4.0
       js-base64: 3.7.8
@@ -13307,7 +13300,7 @@ snapshots:
       monaco-editor: 0.34.1
       monaco-yaml: 4.0.2(monaco-editor@0.34.1)
       next: 14.2.35(@babel/core@7.12.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      postcss: 8.4.31
+      postcss: 8.5.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-hot-toast: 2.4.0(csstype@3.2.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -16017,7 +16010,7 @@ snapshots:
       jsc-safe-url: 0.2.4
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.4.49
+      postcss: 8.5.14
       resolve-from: 5.0.0
     optionalDependencies:
       expo: 55.0.23(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.28.5)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -20796,14 +20789,14 @@ snapshots:
 
   async@3.2.6: {}
 
-  autoprefixer@10.4.14(postcss@8.4.31):
+  autoprefixer@10.4.14(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001781
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.4.31
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -25309,7 +25302,7 @@ snapshots:
       busboy: 1.6.0
       caniuse-lite: 1.0.30001781
       graceful-fs: 4.2.11
-      postcss: 8.4.31
+      postcss: 8.5.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.1(@babel/core@7.12.9)(react@18.2.0)
@@ -26088,18 +26081,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.4.49:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.14:
     dependencies:


### PR DESCRIPTION
## Security fix: CVE-2026-45623

Bumps `postcss` to `8.5.12` to resolve CVE-2026-45623. This closes 44 Wiz-tracked issue(s).

**Rationale for this fix:** Step 2 (scoped to REPOSITORY_BRANCH/CODE assets, status=OPEN, has_fix=true, ordered by RESOURCE_COUNT desc) ranked GHSA-r28c-9q8g-f849 first (46 findings) but that is excluded per the in-progress list. Among remaining candidates, CVE-2026-45623 (postcss arbitrary file read via sourceMappingURL, HIGH 7.5) ranked #1 with 44 findings across 16 distinct GitHub repos/branches, ahead of CVE-2026-41305 (41 findings, also postcss but a different XSS bug) and a cluster of Next.js CVE-2026-646xx issues (30 findings/13 assets each). Effort assessment: CVE-2026-45623 is LOW effort — every one of the 44 findings names the exact same single package (postcss) and the exact same single fixed version (8.5.12) both in the catalog record and in every individual finding, with no conflicting or ambiguous fix targets. By contrast CVE-2026-41305's findings showed inconsistent/ambiguous fixedVersion values (8.5.10 for some, a 'next@16.3.0-canary.6' value for transitive findings, and null for at least one finding), making it a messier, higher-effort fix to reconcile; the Next.js CVE-2026-646xx cluster would each only need a minor Next.js bump too but affects fewer resources (30 vs 44) and splitting effort across three separate CVEs is less efficient than one consolidated postcss bump. Because CVE-2026-45623 is simultaneously the highest-impact non-excluded candidate (44 findings/16 repos) AND clearly LOW-effort (single package, single semver-patch fix version, satisfiable via a direct/override dependency bump with no breaking API changes noted in the advisory), there is no impact-vs-effort tradeoff to make, so it is selected outright per the guidance to not sacrifice impact when effort is already low. Ecosystem is npm (JavaScript/Node package manager), consistent with Wiz's own classification (npm GitHub Advisory feed, package-lock.json/pnpm-lock.yaml/package.json manifests observed in findings).

### Patch stage results
- Test command used: `pnpm install --no-frozen-lockfile (after adding pnpm.overrides.postcss=^8.5.12 to package.json); pnpm build (turbo build, 13/13 tasks passed); pnpm vitest run --project "Unit tests" in packages/client (127/127 tests passed); pnpm vitest run in packages/react (133/133 tests passed)`
- Build passed: True
- Tests passed: True
- Vulnerability resolved: True
- Major version bump: False
- Notes: This is a JS/TS pnpm monorepo (turborepo). postcss was a transitive dependency pulled in at three different resolved versions (8.4.31 via @asyncapi/studio and next@14.2.35, used only in examples/types tooling; and 8.4.49 via @expo/metro-config, reached through @config-plugins/react-native-webrtc's peer dep on expo in the react-native example) plus an already-safe 8.5.14 used elsewhere. Since none of these packages declare postcss as a direct dependency in the root package.json, I added a pnpm `overrides` entry ("postcss": "^8.5.12") to package.json and ran `pnpm install --no-frozen-lockfile` (proper pnpm tooling, no manual lockfile editing) to force all postcss resolutions to dedupe onto the already-present safe version 8.5.14 (>= 8.5.12 fixed version). Verified via `pnpm why postcss -r` and lockfile grep that postcss@8.4.31 and postcss@8.4.49 no longer appear anywhere in the lockfile; only postcss@8.5.14 remains repo-wide, including under @config-plugins/react-native-webrtc's dependency chain. Full `pnpm build` (turbo, all 13 tasks) succeeded with the change. For tests: the repo's root `pnpm test` (turbo test) invokes vitest for packages/client, packages/convai-widget-core, and packages/react. packages/convai-widget-core's suite (and the 'Browser tests' project inside packages/client) require Playwright's Chromium browser plus OS-level shared libraries (libnss3, libatk, etc.) that need root/apt-get to install; this sandbox has no sudo/root access, so those specific browser-mode suites could not be executed. I verified this is a pre-existing sandbox/environment limitation unrelated to the postcss bump by stashing my changes and reproducing the identical failure on the unmodified repo. All non-browser test suites that could actually be run passed cleanly: packages/client's 'Unit tests' project (127/127 tests) and packages/react (133/133 tests), plus the full monorepo build (13/13 turbo tasks, 0 failures). This is a minor/patch-level bump (8.4.x -> 8.5.14, satisfying the required 8.5.12), not a breaking major version change.

### Independent verification results
- Regressions found: False
- Confidence: high
- Recommendation: proceed
- Findings:
- Patch applies cleanly to a fresh checkout (git apply --check and git apply both succeed).
- Vulnerability resolved: after applying the patch, `pnpm why postcss -r` and lockfile grep show only postcss@8.5.14 (>= fixed 8.5.12); the vulnerable 8.4.31 and 8.4.49 no longer appear anywhere in pnpm-lock.yaml.
- Lockfile integrity confirmed: `pnpm install --frozen-lockfile` succeeded, proving the edited lockfile is internally consistent with the new pnpm.overrides.postcss=^8.5.12 (not a hand-corrupted lockfile).
- pnpm build (turbo): 13/13 tasks successful.
- pnpm check-types (turbo): 16/16 tasks successful.
- packages/client 'Unit tests' project: 127/127 tests pass; packages/react: 133/133 tests pass — matching the patch stage's self-report.
- No direct source imports/usages of postcss found in packages/ or examples/ (.ts/.tsx/.js) — postcss is only a transitive/tooling dependency, minimizing behavioral risk from the bump.
- Diff is minimal and scoped strictly to postcss (override entry + lockfile dedupe of postcss and its peer-dependency descriptors); nothing unrelated changed.
- NON-BLOCKING: `pnpm lint` via turbo failed with exit 134 (SIGABRT) on @elevenlabs/convai-widget-core#lint:prettier, but running each lint task individually (eslint . on client, prettier --check on convai-widget-core) passes cleanly with exit 0. This is an environmental concurrency/OOM crash under turbo, unrelated to postcss (eslint/prettier do not use postcss).
- NON-BLOCKING: Node in sandbox is v22.23.1 while package.json engines requires >=24.0.0 (unsupported-engine warning only); everything still ran. Pre-existing environment condition, not introduced by the patch.
- Could NOT run browser-mode test suites (packages/convai-widget-core and the client 'Browser tests' project) — they require Playwright Chromium + OS libs not installable without root. This is a pre-existing environment limitation unrelated to postcss; all non-browser suites that could run passed.

---
🤖 Opened automatically by the CVE patch orchestrator. This PR is a draft pending human review — it will not be marked ready for review automatically.
