### PR TITLE
feat(client): support startingWorkflowNodeId in session config

### DIFF
--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -65,6 +65,8 @@ export type BaseSessionConfig = {
   textOnly?: boolean;
   userId?: string;
   environment?: string;
+  /** If set, the ElevenLabs agent workflow will start at this node id instead of the default entry node. */
+  startingWorkflowNodeId?: string;
 };
 
 export type ConnectionType = "websocket" | "webrtc";

--- a/packages/client/src/utils/overrides.ts
+++ b/packages/client/src/utils/overrides.ts
@@ -59,5 +59,9 @@ export function constructOverrides(
     };
   }
 
+  if (config.startingWorkflowNodeId) {
+    overridesEvent.starting_workflow_node_id = config.startingWorkflowNodeId;
+  }
+
   return overridesEvent;
 }


### PR DESCRIPTION
Add `startingWorkflowNodeId` to `BaseSessionConfig` and wire it through `constructOverrides`.

This allows callers using the private WebSocket or WebRTC session paths (signed URL / conversation token) to target a specific agent workflow node at conversation start, matching the behaviour already available on the server-side outbound-call API (`ConversationInitiationClientDataRequestInput`).

Also adds the field to `ConversationInitiationClientToOrchestratorEvent` in `@elevenlabs/types` so the type system is consistent end-to-end. Did not touch the auto-generated file, but it should probably be regenerated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small optional passthrough on session startup; no auth or data-model changes in this diff.
> 
> **Overview**
> Adds optional **`startingWorkflowNodeId`** on **`BaseSessionConfig`** so private WebSocket/WebRTC sessions (signed URL / conversation token) can tell the agent workflow which node to enter at conversation start, instead of always using the default entry node.
> 
> **`constructOverrides`** now copies that value onto the conversation initiation payload as **`starting_workflow_node_id`**, matching the server-side outbound initiation shape described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f3b7e57392a6c3a6760fa868afec7ef8d30c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->