### PR TITLE
Add onRichContent callback

### DIFF
--- a/.changeset/rich-content-callback.md
+++ b/.changeset/rich-content-callback.md
@@ -1,0 +1,13 @@
+---
+"@elevenlabs/types": minor
+"@elevenlabs/client": minor
+---
+
+Add the experimental `rich_content` event types and an `onRichContent` callback,
+called when the agent sends a component for the client to display, such as an
+item card. The callback receives `{ rich_content_id, component, props, event_id }`
+and nothing is sent back, so the agent's turn does not wait on the client.
+
+This backs the embedded widget, which is the only client the server offers
+components to today, so the callback does not fire for other consumers. Treat
+`props` as agent-authored and untrusted when rendering it into a document.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -303,6 +303,61 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("rich_content events", () => {
+    const richContentEvent = {
+      type: "rich_content" as const,
+      rich_content: {
+        rich_content_id: "show_rich_content_8c0948a3",
+        component: "item_card",
+        props: { id: "item_1", title: "Item Title" },
+        event_id: 2,
+      },
+    };
+
+    it("calls onRichContent with the component payload", async () => {
+      const onRichContent = vi.fn();
+      const onDebug = vi.fn();
+      const conversation = TestConversation.create({
+        onRichContent,
+        onDebug,
+      });
+
+      await conversation.receiveMessage(richContentEvent);
+
+      expect(onRichContent).toHaveBeenCalledWith({
+        rich_content_id: "show_rich_content_8c0948a3",
+        component: "item_card",
+        props: { id: "item_1", title: "Item Title" },
+        event_id: 2,
+      });
+      expect(onDebug).not.toHaveBeenCalled();
+    });
+
+    it("sends nothing back, unlike a client tool call", async () => {
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      const conversation = TestConversation.create(
+        { onRichContent: vi.fn() },
+        connection
+      );
+
+      await conversation.receiveMessage(richContentEvent);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when no callback is provided", async () => {
+      const conversation = TestConversation.create({});
+
+      await expect(
+        conversation.receiveMessage(richContentEvent)
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("ping events", () => {
     it("replies with a pong and forwards the payload to onPing", async () => {
       const onPing = vi.fn();

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -20,6 +20,7 @@ import type {
   InternalTentativeAgentResponseEvent,
   InterruptionEvent,
   PingEvent,
+  RichContentEvent,
   UserTranscriptionEvent,
   VadScoreEvent,
   MCPToolCallClientEvent,
@@ -411,6 +412,12 @@ export abstract class BaseConversation {
     }
   }
 
+  protected handleRichContent(event: RichContentEvent) {
+    if (this.options.onRichContent) {
+      this.options.onRichContent(event.rich_content);
+    }
+  }
+
   protected handleGuardrailTriggered(_event: GuardrailTriggeredEvent) {
     if (this.options.onGuardrailTriggered) {
       this.options.onGuardrailTriggered();
@@ -557,6 +564,11 @@ export abstract class BaseConversation {
 
       case "agent_reasoning_response_part": {
         this.handleAgentReasoningResponsePart(parsedEvent);
+        return;
+      }
+
+      case "rich_content": {
+        this.handleRichContent(parsedEvent);
         return;
       }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -15,6 +15,7 @@ import type {
   AgentChatResponsePartClientEvent,
   AgentReasoningResponsePartClientEvent,
   Ping,
+  RichContentClientEvent,
 } from "@elevenlabs/types";
 
 /**
@@ -132,6 +133,17 @@ export type Callbacks = {
   onAgentReasoningResponsePart?: (
     props: AgentReasoningResponsePartClientEvent["reasoning_response_part"]
   ) => void;
+  /**
+   * Called when the agent sends a component for the client to display, such as
+   * an item card. Receives `{ rich_content_id, component, props, event_id }`.
+   *
+   * Backs the embedded widget. The server only offers components to the widget
+   * today, so this does not fire for other consumers.
+   *
+   * @experimental This API is experimental and may change without following
+   * semver guarantees.
+   */
+  onRichContent?: (props: RichContentClientEvent["rich_content"]) => void;
   onGuardrailTriggered?: () => void;
   onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   onAgentTyping?: (props: AgentTypingClientEvent["agent_typing_event"]) => void;
@@ -175,6 +187,7 @@ export const CALLBACK_KEYS = [
   "onAgentResponseCorrection",
   "onAgentChatResponsePart",
   "onAgentReasoningResponsePart",
+  "onRichContent",
   "onAudioAlignment",
   "onGuardrailTriggered",
   "onAgentTyping",

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -137,9 +137,6 @@ export type Callbacks = {
    * Called when the agent sends a component for the client to display, such as
    * an item card. Receives `{ rich_content_id, component, props, event_id }`.
    *
-   * Backs the embedded widget. The server only offers components to the widget
-   * today, so this does not fire for other consumers.
-   *
    * @experimental This API is experimental and may change without following
    * semver guarantees.
    */

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -22,6 +22,7 @@ import type {
   InternalTentativeAgentResponse as TentativeAgentResponseInternal,
   UserTranscript,
   VadScore,
+  RichContentClientEvent,
 } from "@elevenlabs/types";
 import type { AudioAlignmentEvent } from "../types.js";
 
@@ -48,6 +49,7 @@ export type MCPConnectionStatusEvent = McpConnectionStatusClientEvent;
 export type AgentChatResponsePartEvent = AgentChatResponsePartClientEvent;
 export type AgentReasoningResponsePartEvent =
   AgentReasoningResponsePartClientEvent;
+export type RichContentEvent = RichContentClientEvent;
 export type ErrorMessageEvent = ErrorMessage;
 export type GuardrailTriggeredEvent = GuardrailTriggered;
 export type AgentTypingEvent = AgentTypingClientEvent;
@@ -74,6 +76,7 @@ export type IncomingSocketEvent =
   | MCPConnectionStatusEvent
   | AgentChatResponsePartEvent
   | AgentReasoningResponsePartEvent
+  | RichContentEvent
   | ErrorMessageEvent
   | GuardrailTriggeredEvent
   | AgentTypingEvent

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -42,6 +42,7 @@ export type HookCallbacks = Pick<
   | "onAgentChatResponsePart"
   | "onAgentReasoningResponsePart"
   | "onAgentResponseCorrection"
+  | "onRichContent"
   | "onAudioAlignment"
   | "onGuardrailTriggered"
   | "onAgentTyping"

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -178,6 +178,7 @@ export type ConversationConfigOverrideConversationClientEventsItem =
   | "tentative_user_transcript"
   | "conversation_initiation_metadata"
   | "client_tool_call"
+  | "rich_content"
   | "agent_tool_request"
   | "agent_tool_response"
   | "agent_tool_response_full_payload"
@@ -363,6 +364,24 @@ export interface ClientToolCall {
   tool_name: string;
   tool_call_id: string;
   parameters: Record<string, any>;
+  event_id: number;
+}
+
+/**
+ * @experimental
+ */
+export interface RichContentMessage {
+  type: "rich_content";
+  rich_content: RichContent;
+}
+
+/**
+ * @experimental
+ */
+export interface RichContent {
+  rich_content_id: string;
+  component: string;
+  props: Record<string, any>;
   event_id: number;
 }
 
@@ -627,6 +646,14 @@ export interface AgentReasoningResponsePartClientEvent {
 export interface ClientToolCallClientEvent {
   type: "client_tool_call";
   client_tool_call: ClientToolCall;
+}
+
+/**
+ * @experimental
+ */
+export interface RichContentClientEvent {
+  type: "rich_content";
+  rich_content: RichContent;
 }
 
 export interface AgentToolRequestClientEvent {

--- a/packages/types/generated/types/incoming.ts
+++ b/packages/types/generated/types/incoming.ts
@@ -22,6 +22,7 @@ export type {
   McpToolCallClientEvent,
   PartialTranscriptMessage,
   PingEvent,
+  RichContentClientEvent,
   ScribeAuthErrorMessage,
   ScribeChunkSizeExceededErrorMessage,
   ScribeCommitThrottledErrorMessage,

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -56,6 +56,7 @@ channels:
           - $ref: "#/components/messages/Interruption"
           - $ref: "#/components/messages/ConversationMetadata"
           - $ref: "#/components/messages/ClientToolCallMessage"
+          - $ref: "#/components/messages/RichContentMessage"
           - $ref: "#/components/messages/AgentToolRequestMessage"
           - $ref: "#/components/messages/AgentToolResponseMessage"
           - $ref: "#/components/messages/AgentToolResponseFullPayloadMessage"
@@ -252,6 +253,15 @@ components:
       payload:
         $ref: "#/components/schemas/ClientToolCallPayload"
 
+    RichContentMessage:
+      name: RichContentClientEvent
+      title: Rich Content
+      summary: Component for the client to display
+      contentType: application/json
+      x-experimental: true
+      payload:
+        $ref: "#/components/schemas/RichContentPayload"
+
     AgentToolRequestMessage:
       name: AgentToolRequestClientEvent
       title: Agent Tool Request
@@ -380,6 +390,7 @@ components:
         - tentative_user_transcript
         - conversation_initiation_metadata
         - client_tool_call
+        - rich_content
         - agent_tool_request
         - agent_tool_response
         - agent_tool_response_full_payload
@@ -870,6 +881,15 @@ components:
           const: client_tool_call
         client_tool_call:
           $ref: "#/components/schemas/ClientToolCallData"
+    RichContentPayload:
+      type: object
+      required: [rich_content, type]
+      properties:
+        type:
+          type: string
+          const: rich_content
+        rich_content:
+          $ref: "#/components/schemas/RichContentData"
     AgentToolRequestPayload:
       type: object
       required: [agent_tool_request, type]
@@ -1068,6 +1088,21 @@ components:
           type: string
         parameters:
           type: object
+        event_id:
+          type: integer
+
+    RichContentData:
+      type: object
+      required: [rich_content_id, component, props, event_id]
+      properties:
+        rich_content_id:
+          type: string
+        component:
+          type: string
+          description: Which component to display, for example item_card
+        props:
+          type: object
+          description:  Component-specific properties; the shape of this object is defined by the component
         event_id:
           type: integer
 


### PR DESCRIPTION
## Summary
Adds an experimental `onRichContent` callback so the SDK can hand off agent-driven UI components (e.g. an item card) to whoever's consuming it.

- New `RichContentClientEvent`/`RichContentData` schema in `@elevenlabs/types` (AsyncAPI + generated types)
- `onRichContent` callback in `@elevenlabs/client`, dispatched from `BaseConversation` the same way every other server-pushed event is — no reply sent back, the agent's turn doesn't wait on it
- Re-exported through `@elevenlabs/react`'s `HookCallbacks`

Backs the embedded widget, which is the only client the server sends components to today — this callback won't fire for other consumers yet. `props` is agent-authored; treat it as untrusted when rendering.

## Summary

[RFC](https://docs.google.com/document/d/1ZMxvMifKVaUxnDSLHVTI3JWxrfmC0OQzguC-d_Uf32k/edit?usp=sharing)

Adds an experimental `onRichContent` callback so the SDK can hand off agent driven UI to the widget.

- New `RichContentClientEvent`/`RichContentData` schema in `@elevenlabs/types` 
- `onRichContent` callback in `@elevenlabs/client`, dispatched from `BaseConversation`. No reply sent back, the agent's turn doesn't wait on it
- Re-exported through `@elevenlabs/react`'s `HookCallbacks`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New experimental surface that forwards untrusted `props` to app code; misuse when rendering could introduce XSS, but core conversation and auth paths are unchanged.
> 
> **Overview**
> Adds **`rich_content`** to the agent WebSocket contract and wires it through **`@elevenlabs/types`**, **`@elevenlabs/client`**, and **`@elevenlabs/react`** as an experimental **`onRichContent`** callback.
> 
> When the server sends a display component (e.g. **`item_card`**), the client invokes the callback with **`{ rich_content_id, component, props, event_id }`**. Unlike **`client_tool_call`**, the SDK does **not** send a response, so the agent turn is not blocked on the client.
> 
> **`BaseConversation`** dispatches **`rich_content`** in **`onMessage`** via **`handleRichContent`**; tests cover payload forwarding, no **`sendMessage`**, and missing callback. The changeset notes **`props`** should be treated as agent-authored and untrusted when rendering into a document.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b4b67e6ea3b3ab6ab4d39afd17e0f47469add6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->