### PR TITLE
Render rich content components in the transcript

### DIFF
--- a/.changeset/rich-content-callback.md
+++ b/.changeset/rich-content-callback.md
@@ -1,0 +1,13 @@
+---
+"@elevenlabs/types": minor
+"@elevenlabs/client": minor
+---
+
+Add the experimental `rich_content` event types and an `onRichContent` callback,
+called when the agent sends a component for the client to display, such as an
+item card. The callback receives `{ rich_content_id, component, props, event_id }`
+and nothing is sent back, so the agent's turn does not wait on the client.
+
+This backs the embedded widget, which is the only client the server offers
+components to today, so the callback does not fire for other consumers. Treat
+`props` as agent-authored and untrusted when rendering it into a document.

--- a/.changeset/rich-content-widget.md
+++ b/.changeset/rich-content-widget.md
@@ -1,0 +1,11 @@
+---
+"@elevenlabs/convai-widget-core": minor
+---
+
+Render rich content components the agent sends, inline in the transcript,
+starting with an item card. Card buttons send a follow-up message as the user.
+
+Properties are validated before rendering, so a malformed or unrecognised
+component shows a short notice instead of breaking the transcript. A component
+stays where it arrived and no message is moved across it, and a component
+delivered more than once renders once.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -303,6 +303,61 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("rich_content events", () => {
+    const richContentEvent = {
+      type: "rich_content" as const,
+      rich_content: {
+        rich_content_id: "show_rich_content_8c0948a3",
+        component: "item_card",
+        props: { id: "item_1", title: "Item Title" },
+        event_id: 2,
+      },
+    };
+
+    it("calls onRichContent with the component payload", async () => {
+      const onRichContent = vi.fn();
+      const onDebug = vi.fn();
+      const conversation = TestConversation.create({
+        onRichContent,
+        onDebug,
+      });
+
+      await conversation.receiveMessage(richContentEvent);
+
+      expect(onRichContent).toHaveBeenCalledWith({
+        rich_content_id: "show_rich_content_8c0948a3",
+        component: "item_card",
+        props: { id: "item_1", title: "Item Title" },
+        event_id: 2,
+      });
+      expect(onDebug).not.toHaveBeenCalled();
+    });
+
+    it("sends nothing back, unlike a client tool call", async () => {
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      const conversation = TestConversation.create(
+        { onRichContent: vi.fn() },
+        connection
+      );
+
+      await conversation.receiveMessage(richContentEvent);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when no callback is provided", async () => {
+      const conversation = TestConversation.create({});
+
+      await expect(
+        conversation.receiveMessage(richContentEvent)
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("ping events", () => {
     it("replies with a pong and forwards the payload to onPing", async () => {
       const onPing = vi.fn();

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -20,6 +20,7 @@ import type {
   InternalTentativeAgentResponseEvent,
   InterruptionEvent,
   PingEvent,
+  RichContentEvent,
   UserTranscriptionEvent,
   VadScoreEvent,
   MCPToolCallClientEvent,
@@ -411,6 +412,12 @@ export abstract class BaseConversation {
     }
   }
 
+  protected handleRichContent(event: RichContentEvent) {
+    if (this.options.onRichContent) {
+      this.options.onRichContent(event.rich_content);
+    }
+  }
+
   protected handleGuardrailTriggered(_event: GuardrailTriggeredEvent) {
     if (this.options.onGuardrailTriggered) {
       this.options.onGuardrailTriggered();
@@ -557,6 +564,11 @@ export abstract class BaseConversation {
 
       case "agent_reasoning_response_part": {
         this.handleAgentReasoningResponsePart(parsedEvent);
+        return;
+      }
+
+      case "rich_content": {
+        this.handleRichContent(parsedEvent);
         return;
       }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -15,6 +15,7 @@ import type {
   AgentChatResponsePartClientEvent,
   AgentReasoningResponsePartClientEvent,
   Ping,
+  RichContentClientEvent,
 } from "@elevenlabs/types";
 
 /**
@@ -132,6 +133,17 @@ export type Callbacks = {
   onAgentReasoningResponsePart?: (
     props: AgentReasoningResponsePartClientEvent["reasoning_response_part"]
   ) => void;
+  /**
+   * Called when the agent sends a component for the client to display, such as
+   * an item card. Receives `{ rich_content_id, component, props, event_id }`.
+   *
+   * Backs the embedded widget. The server only offers components to the widget
+   * today, so this does not fire for other consumers.
+   *
+   * @experimental This API is experimental and may change without following
+   * semver guarantees.
+   */
+  onRichContent?: (props: RichContentClientEvent["rich_content"]) => void;
   onGuardrailTriggered?: () => void;
   onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   onAgentTyping?: (props: AgentTypingClientEvent["agent_typing_event"]) => void;
@@ -175,6 +187,7 @@ export const CALLBACK_KEYS = [
   "onAgentResponseCorrection",
   "onAgentChatResponsePart",
   "onAgentReasoningResponsePart",
+  "onRichContent",
   "onAudioAlignment",
   "onGuardrailTriggered",
   "onAgentTyping",

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -22,6 +22,7 @@ import type {
   InternalTentativeAgentResponse as TentativeAgentResponseInternal,
   UserTranscript,
   VadScore,
+  RichContentClientEvent,
 } from "@elevenlabs/types";
 import type { AudioAlignmentEvent } from "../types.js";
 
@@ -48,6 +49,7 @@ export type MCPConnectionStatusEvent = McpConnectionStatusClientEvent;
 export type AgentChatResponsePartEvent = AgentChatResponsePartClientEvent;
 export type AgentReasoningResponsePartEvent =
   AgentReasoningResponsePartClientEvent;
+export type RichContentEvent = RichContentClientEvent;
 export type ErrorMessageEvent = ErrorMessage;
 export type GuardrailTriggeredEvent = GuardrailTriggered;
 export type AgentTypingEvent = AgentTypingClientEvent;
@@ -74,6 +76,7 @@ export type IncomingSocketEvent =
   | MCPConnectionStatusEvent
   | AgentChatResponsePartEvent
   | AgentReasoningResponsePartEvent
+  | RichContentEvent
   | ErrorMessageEvent
   | GuardrailTriggeredEvent
   | AgentTypingEvent

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -65,6 +65,14 @@ export type TranscriptEntry =
       conversationIndex: number;
     }
   | {
+      type: "rich_content";
+      component: string;
+      props: unknown;
+      conversationIndex: number;
+      eventId: number;
+      richContentId: string;
+    }
+  | {
       type: "disconnection";
       role: Role;
       message?: undefined;
@@ -164,6 +172,33 @@ function useConversationSetup() {
     const conversationTextOnly = signal<boolean | null>(null);
     const isAgentTyping = signal(false);
     const isExternalAgentMode = signal(false);
+
+    const appendRichContent = (entry: {
+      component: string;
+      props: unknown;
+      eventId: number;
+      richContentId: string;
+    }) => {
+      const current = transcript.peek();
+      if (
+        current.some(
+          existing =>
+            existing.type === "rich_content" &&
+            existing.richContentId === entry.richContentId
+        )
+      ) {
+        return;
+      }
+
+      transcript.value = [
+        ...current,
+        {
+          type: "rich_content",
+          ...entry,
+          conversationIndex: conversationIndex.peek(),
+        },
+      ];
+    };
 
     const setAgentTyping = (typing: boolean, durationMs?: number | null) => {
       clearTypingTimer();
@@ -371,6 +406,14 @@ function useConversationSetup() {
                   conversationIndex: conversationIndex.peek(),
                 },
               ];
+            },
+            onRichContent: ({ component, props, event_id, rich_content_id }) => {
+              appendRichContent({
+                component,
+                props,
+                eventId: event_id,
+                richContentId: rich_content_id,
+              });
             },
             onAgentTyping: ({ is_typing, duration_ms }) => {
               setAgentTyping(is_typing, duration_ms);

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -241,11 +241,53 @@ const codeBlock = true;
     default_expanded: true,
     first_message: "",
   },
+  rich_content: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
 } as const satisfies Record<string, WidgetConfig>;
 
 function isValidAgentId(agentId: string): agentId is keyof typeof AGENTS {
   return agentId in AGENTS;
 }
+
+const RICH_CONTENT_CARDS = [
+  {
+    id: "item_1",
+    title: "First item, with a title long enough to wrap onto two lines",
+    subtitle: "Category",
+    description: "A sentence about the item.",
+    price: "$21.99",
+    image_url:
+      "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=",
+    buttons: [
+      {
+        label: "Ask more",
+        message: "Tell me more about the first item",
+      },
+    ],
+  },
+  {
+    id: "item_2",
+    title: "Second item",
+    subtitle: "Category",
+    description:
+      "A description over several lines.\nThe second line.\nThe third line.",
+    buttons: [
+      {
+        label: "Ask more",
+        message: "Tell me more about the second item",
+      },
+    ],
+  },
+];
+
+const RICH_CONTENT_REPLY = "Here are a couple of options.";
 
 export const Worker = setupWorker(
   http.get<{ agentId: string }>(
@@ -310,7 +352,8 @@ export const Worker = setupWorker(
         agentId !== "tool_call" &&
         agentId !== "stream_consolidation" &&
         agentId !== "file_upload" &&
-        agentId !== "no_file_upload"
+        agentId !== "no_file_upload" &&
+        agentId !== "rich_content"
       ) {
         const agentResponse =
           agentId === "markdown_agent_response"
@@ -378,6 +421,71 @@ export const Worker = setupWorker(
           );
           await new Promise(resolve => setTimeout(resolve, 50));
           client.close(1000);
+        });
+      }
+      if (agentId === "rich_content") {
+        client.addEventListener("message", async () => {
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 2 },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "stop", event_id: 2 },
+            })
+          );
+          for (const [index, props] of RICH_CONTENT_CARDS.entries()) {
+            await new Promise(resolve => setTimeout(resolve, 0));
+            client.send(
+              JSON.stringify({
+                type: "rich_content",
+                rich_content: {
+                  rich_content_id: `show_rich_content_${index + 1}`,
+                  component: "item_card",
+                  props,
+                  event_id: 2,
+                },
+              })
+            );
+          }
+          await new Promise(resolve => setTimeout(resolve, 500));
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 2 },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: {
+                text: RICH_CONTENT_REPLY,
+                type: "delta",
+                event_id: 2,
+              },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "stop", event_id: 2 },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_response",
+              agent_response_event: {
+                agent_response: RICH_CONTENT_REPLY,
+                event_id: 2,
+              },
+            })
+          );
         });
       }
       if (agentId === "tool_call") {

--- a/packages/convai-widget-core/src/rich-content/ItemCard.tsx
+++ b/packages/convai-widget-core/src/rich-content/ItemCard.tsx
@@ -1,0 +1,83 @@
+import { Button } from "../components/Button";
+import { useConversation } from "../contexts/conversation";
+
+export interface RichContentButton {
+  label: string;
+  /** Sent as the user's own turn when the button is pressed. */
+  message: string;
+}
+
+export interface ItemCardProps {
+  id: string;
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  description?: string;
+  /** Already formatted for the customer's locale and currency by the sender. */
+  price?: string;
+  buttons: RichContentButton[];
+}
+
+export function ItemCard({
+  title,
+  subtitle,
+  imageUrl,
+  description,
+  price,
+  buttons,
+}: ItemCardProps) {
+  const { sendUserMessage, status } = useConversation();
+  const disabled = status.value !== "connected";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-bubble border border-base-border bg-base p-3">
+      <div className="flex gap-3">
+        {imageUrl && (
+          <img
+            src={imageUrl}
+            alt={title}
+            loading="lazy"
+            className="w-16 h-16 shrink-0 rounded-input bg-base-active object-cover"
+          />
+        )}
+        <div className="flex min-w-0 flex-col gap-0.5 text-start">
+          <span dir="auto" className="text-sm font-medium wrap-break-word">
+            {title}
+          </span>
+          {subtitle && (
+            <span dir="auto" className="text-xs text-base-subtle">
+              {subtitle}
+            </span>
+          )}
+          {description && (
+            <span
+              dir="auto"
+              className="text-xs text-base-subtle whitespace-pre-line wrap-break-word"
+            >
+              {description}
+            </span>
+          )}
+          {price && (
+            <span className="mt-1 text-sm font-medium tabular-nums">
+              {price}
+            </span>
+          )}
+        </div>
+      </div>
+      {buttons.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {buttons.map(button => (
+            <Button
+              key={button.message}
+              variant="primary"
+              disabled={disabled}
+              onClick={() => sendUserMessage(button.message)}
+            >
+              {button.label}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/convai-widget-core/src/rich-content/RichContentRenderer.tsx
+++ b/packages/convai-widget-core/src/rich-content/RichContentRenderer.tsx
@@ -1,0 +1,32 @@
+import { useTextContents } from "../contexts/text-contents";
+import { ItemCard } from "./ItemCard";
+import { parseItemCardProps } from "./validate";
+
+interface RichContentRendererProps {
+  component: string;
+  props: unknown;
+}
+
+export function RichContentRenderer({
+  component,
+  props,
+}: RichContentRendererProps) {
+  if (component === "item_card") {
+    const parsed = parseItemCardProps(props);
+    if (parsed) {
+      return <ItemCard {...parsed} />;
+    }
+  }
+
+  return <RichContentUnavailable />;
+}
+
+function RichContentUnavailable() {
+  const text = useTextContents();
+
+  return (
+    <div className="rounded-bubble border border-base-border bg-base px-3 py-2.5 text-xs text-base-subtle">
+      {text.rich_content_unavailable}
+    </div>
+  );
+}

--- a/packages/convai-widget-core/src/rich-content/validate.test.ts
+++ b/packages/convai-widget-core/src/rich-content/validate.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { parseItemCardProps } from "./validate";
+
+const valid = {
+  id: "item_1",
+  title: "Item title",
+};
+
+describe("parseItemCardProps", () => {
+  it.each<{ description: string; input: unknown }>([
+    { description: "null", input: null },
+    { description: "a string", input: "item" },
+    { description: "an array", input: [valid] },
+    { description: "a missing id", input: { title: "Item title" } },
+    { description: "a missing title", input: { id: "item_1" } },
+    { description: "a blank title", input: { id: "item_1", title: "   " } },
+    { description: "a boolean title", input: { id: "item_1", title: true } },
+    { description: "an object title", input: { id: "item_1", title: {} } },
+  ])("rejects $description", ({ input }) => {
+    expect(parseItemCardProps(input)).toBeNull();
+  });
+
+  it.each<{ description: string; value: unknown; expected: string }>([
+    { description: "an integer", value: 78, expected: "78" },
+    { description: "a decimal", value: 1999.99, expected: "1999.99" },
+  ])(
+    "coerces $description so catalog data still renders",
+    ({ value, expected }) => {
+      expect(
+        parseItemCardProps({ id: value, title: "Item title", price: value })
+      ).toMatchObject({ id: expected, price: expected });
+    }
+  );
+
+  it("rejects a non-finite number", () => {
+    expect(
+      parseItemCardProps({ id: Infinity, title: "Item title" })
+    ).toBeNull();
+  });
+
+  it("keeps the required fields and defaults buttons to empty", () => {
+    expect(parseItemCardProps(valid)).toEqual({
+      id: "item_1",
+      title: "Item title",
+      subtitle: undefined,
+      imageUrl: undefined,
+      description: undefined,
+      price: undefined,
+      buttons: [],
+    });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(
+      parseItemCardProps({ id: " item_1 ", title: " Item title " })
+    ).toMatchObject({ id: "item_1", title: "Item title" });
+  });
+
+  it("caps the length of text", () => {
+    const parsed = parseItemCardProps({
+      ...valid,
+      description: "a".repeat(600),
+    });
+
+    expect(parsed?.description).toHaveLength(500);
+  });
+
+  it("accepts either casing for the image url", () => {
+    expect(
+      parseItemCardProps({ ...valid, image_url: "https://cdn.test/a.png" })
+    ).toMatchObject({ imageUrl: "https://cdn.test/a.png" });
+    expect(
+      parseItemCardProps({ ...valid, imageUrl: "https://cdn.test/b.png" })
+    ).toMatchObject({ imageUrl: "https://cdn.test/b.png" });
+  });
+
+  it.each<{ description: string; url: string }>([
+    { description: "javascript", url: "javascript:alert(1)" },
+    { description: "a bare path", url: "/local/a.png" },
+    { description: "a non-image data url", url: "data:text/html,<script>" },
+    { description: "a plain http", url: "http://cdn.test/a.png" },
+  ])("drops $description image url", ({ url }) => {
+    expect(parseItemCardProps({ ...valid, image_url: url })).toMatchObject({
+      imageUrl: undefined,
+    });
+  });
+
+  it("keeps inline images", () => {
+    const url = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAAA==";
+    expect(parseItemCardProps({ ...valid, image_url: url })).toMatchObject({
+      imageUrl: url,
+    });
+  });
+
+  it("drops buttons missing a label or a message", () => {
+    const parsed = parseItemCardProps({
+      ...valid,
+      buttons: [
+        { label: "Ask more", message: "Tell me more about this item" },
+        { label: "No message" },
+        { message: "No label" },
+        "not an object",
+      ],
+    });
+
+    expect(parsed?.buttons).toEqual([
+      { label: "Ask more", message: "Tell me more about this item" },
+    ]);
+  });
+
+  it("caps the number of buttons", () => {
+    const parsed = parseItemCardProps({
+      ...valid,
+      buttons: Array.from({ length: 6 }, (_, i) => ({
+        label: `Label ${i}`,
+        message: `Message ${i}`,
+      })),
+    });
+
+    expect(parsed?.buttons).toHaveLength(3);
+  });
+
+  it("ignores buttons that are not an array", () => {
+    expect(
+      parseItemCardProps({ ...valid, buttons: { label: "Ask more" } })
+    ).toMatchObject({ buttons: [] });
+  });
+});

--- a/packages/convai-widget-core/src/rich-content/validate.ts
+++ b/packages/convai-widget-core/src/rich-content/validate.ts
@@ -1,0 +1,80 @@
+import type { ItemCardProps, RichContentButton } from "./ItemCard";
+
+const MAX_BUTTONS = 3;
+const MAX_TEXT_LENGTH = 500;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseText(value: unknown): string | undefined {
+  let text: string;
+  if (typeof value === "string") {
+    text = value;
+  } else if (typeof value === "number" && Number.isFinite(value)) {
+    text = String(value);
+  } else {
+    return undefined;
+  }
+
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, MAX_TEXT_LENGTH);
+}
+
+/**
+ * Only remote and inline images are accepted.
+ */
+function parseImageUrl(value: unknown): string | undefined {
+  const raw = parseText(value);
+  if (!raw) return undefined;
+  if (/^https:\/\//i.test(raw)) return raw;
+  if (/^data:image\//i.test(raw)) return raw;
+  return undefined;
+}
+
+/**
+ * A button carries the message it sends. One without a label or a message can do
+ * nothing on press, so it is dropped rather than rendered as a dead control.
+ */
+function parseButtons(value: unknown): RichContentButton[] {
+  if (!Array.isArray(value)) return [];
+
+  const buttons: RichContentButton[] = [];
+  for (const item of value) {
+    if (buttons.length >= MAX_BUTTONS) break;
+    if (!isRecord(item)) continue;
+
+    const label = parseText(item.label);
+    if (!label) continue;
+
+    const message = parseText(item.message);
+    if (message) {
+      buttons.push({ label, message });
+    }
+  }
+  return buttons;
+}
+
+/**
+ * Properties arrive from the agent, so they are malformed by default rather
+ * than exceptionally. Returns null when the component cannot be rendered
+ * meaningfully, which the caller turns into a fallback rather than a throw.
+ */
+export function parseItemCardProps(value: unknown): ItemCardProps | null {
+  if (!isRecord(value)) return null;
+
+  const id = parseText(value.id);
+  const title = parseText(value.title);
+  if (!(id && title)) return null;
+
+  return {
+    id,
+    title,
+    subtitle: parseText(value.subtitle),
+    imageUrl: parseImageUrl(value.image_url ?? value.imageUrl),
+    description: parseText(value.description),
+    price: parseText(value.price),
+    buttons: parseButtons(value.buttons),
+  };
+}

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -156,6 +156,7 @@ export const DefaultTextContents = {
   file_too_large: "File size exceeds the maximum limit.",
   file_limit_reached: "Maximum number of files for this conversation reached.",
   typing_indicator: "Agent is typing ...",
+  rich_content_unavailable: "This content could not be displayed",
 };
 
 export const TextKeys = Object.keys(

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -50,6 +50,21 @@ function toolRes(
   };
 }
 
+/** Helper to create a rich content entry */
+function richContent(
+  id = "item_1",
+  opts: { eventId?: number } = {}
+): Extract<TranscriptEntry, { type: "rich_content" }> {
+  return {
+    type: "rich_content",
+    component: "item_card",
+    props: { id, title: "Item" },
+    conversationIndex: 0,
+    eventId: opts.eventId ?? 2,
+    richContentId: `rc_${id}`,
+  };
+}
+
 /** Default config — no status, transcript enabled */
 const defaults: DisplayTranscriptConfig = {
   showAgentStatus: false,
@@ -580,6 +595,119 @@ describe("buildDisplayTranscript", () => {
         type: "typing_indicator",
         conversationIndex: 0,
       });
+    });
+  });
+
+  describe("rich content", () => {
+    it("keeps cards where they arrived, in arrival order", () => {
+      const input = [
+        msg("user", "show me some options"),
+        msg("agent", "Two options", { eventId: 2 }),
+        richContent("item_1"),
+        richContent("item_2"),
+        msg("user", "thanks"),
+        msg("agent", "Anything else?", { eventId: 4 }),
+      ];
+      const result = build(input);
+
+      expect(result).toHaveLength(6);
+      expect(result[1]).toMatchObject({ message: "Two options" });
+      expect(result[2]).toMatchObject({ props: { id: "item_1" } });
+      expect(result[3]).toMatchObject({ props: { id: "item_2" } });
+      expect(result[4]).toMatchObject({ message: "thanks" });
+      expect(result[5]).toMatchObject({ message: "Anything else?" });
+    });
+
+    it("keeps a card above the reply even when a placeholder precedes it", () => {
+      // The placeholder survives only because it carries the status badge.
+      const input = [
+        msg("agent", "", { eventId: 2 }),
+        toolReq(2),
+        toolRes(2),
+        richContent(),
+        msg("agent", "Here you go", { eventId: 2 }),
+      ];
+      const result = build(input, { showAgentStatus: true });
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toMatchObject({ message: "", toolStatus: "success" });
+      expect(result[1]).toMatchObject({ type: "rich_content" });
+      expect(result[2]).toMatchObject({ message: "Here you go" });
+    });
+
+    it("drops the placeholder a card follows when there is no badge", () => {
+      // With no status to show, nothing keeps the empty placeholder.
+      const input = [
+        msg("agent", "", { eventId: 2 }),
+        richContent(),
+        msg("agent", "Here you go", { eventId: 2 }),
+      ];
+      const result = build(input);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ type: "rich_content" });
+      expect(result[1]).toMatchObject({ message: "Here you go" });
+    });
+
+    it("places cards above the reply for a real captured turn", () => {
+      // Replays the order the backend produces: empty text windows while the
+      // model calls the tool, a component per call, then the reply that
+      // introduces them.
+      const input = [
+        msg("user", "show me some options"),
+        msg("agent", "", { eventId: 2 }),
+        toolRes(2),
+        msg("agent", "", { eventId: 2 }),
+        richContent("item_1", { eventId: 2 }),
+        toolRes(2),
+        richContent("item_2", { eventId: 2 }),
+        toolRes(2),
+        msg("agent", "Here are some options.", { eventId: 2 }),
+      ];
+
+      for (const showAgentStatus of [false, true]) {
+        const result = build(input, { showAgentStatus });
+
+        expect(result).toHaveLength(4);
+        expect(result[0]).toMatchObject({ role: "user" });
+        expect(result[1]).toMatchObject({ props: { id: "item_1" } });
+        expect(result[2]).toMatchObject({ props: { id: "item_2" } });
+        expect(result[3]).toMatchObject({ message: "Here are some options." });
+      }
+    });
+
+    it("leaves the tool status badge on the first bubble of the turn", () => {
+      const input = [
+        msg("agent", "Running the tool now.", { eventId: 2 }),
+        toolReq(2),
+        toolRes(2),
+        richContent(),
+        msg("agent", "Tool completed successfully", { eventId: 2 }),
+      ];
+      const result = build(input, { showAgentStatus: true });
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toMatchObject({
+        message: "Running the tool now.",
+        toolStatus: "success",
+      });
+      expect(result[1]).toMatchObject({ type: "rich_content" });
+      expect(result[2]).toMatchObject({
+        message: "Tool completed successfully",
+      });
+      expect(result[2]).not.toHaveProperty("toolStatus");
+    });
+
+    it("places a card before an appended typing indicator", () => {
+      const input = [
+        msg("agent", "Here you go", { eventId: 2 }),
+        richContent(),
+      ];
+      const result = build(input, { showTypingIndicator: true });
+
+      expect(result).toHaveLength(3);
+      expect(result[1]).toMatchObject({ type: "rich_content" });
+      expect(result[2]).toMatchObject({ type: "typing_indicator" });
     });
   });
 });

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -44,6 +44,14 @@ export type DisplayTranscriptEntry =
   | {
       type: "typing_indicator";
       conversationIndex: number;
+    }
+  | {
+      type: "rich_content";
+      component: string;
+      props: unknown;
+      conversationIndex: number;
+      eventId: number;
+      richContentId: string;
     };
 
 export interface DisplayTranscriptConfig {

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -20,6 +20,7 @@ import { stripAudioTags } from "../utils/stripAudioTags";
 import { WidgetStreamdown } from "../markdown";
 import { isImageMimeType } from "./useFileUpload";
 import { ShimmeringText } from "../components/ShimmeringText";
+import { RichContentRenderer } from "../rich-content/RichContentRenderer";
 
 interface TranscriptMessageProps {
   entry: DisplayTranscriptEntry;
@@ -285,6 +286,18 @@ function TypingIndicatorMessage() {
   );
 }
 
+function RichContentMessage({
+  entry,
+}: {
+  entry: Extract<DisplayTranscriptEntry, { type: "rich_content" }>;
+}) {
+  return (
+    <div className="pe-8">
+      <RichContentRenderer component={entry.component} props={entry.props} />
+    </div>
+  );
+}
+
 function getMessageComponent(entry: DisplayTranscriptEntry) {
   if (entry.type === "disconnection") {
     return <DisconnectionMessage entry={entry} />;
@@ -297,6 +310,9 @@ function getMessageComponent(entry: DisplayTranscriptEntry) {
   }
   if (entry.type === "typing_indicator") {
     return <TypingIndicatorMessage />;
+  }
+  if (entry.type === "rich_content") {
+    return <RichContentMessage entry={entry} />;
   }
   if (entry.role === "agent") {
     return <AgentMessageBubble entry={entry} />;

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -42,6 +42,7 @@ export type HookCallbacks = Pick<
   | "onAgentChatResponsePart"
   | "onAgentReasoningResponsePart"
   | "onAgentResponseCorrection"
+  | "onRichContent"
   | "onAudioAlignment"
   | "onGuardrailTriggered"
   | "onAgentTyping"

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -178,6 +178,7 @@ export type ConversationConfigOverrideConversationClientEventsItem =
   | "tentative_user_transcript"
   | "conversation_initiation_metadata"
   | "client_tool_call"
+  | "rich_content"
   | "agent_tool_request"
   | "agent_tool_response"
   | "agent_tool_response_full_payload"
@@ -363,6 +364,24 @@ export interface ClientToolCall {
   tool_name: string;
   tool_call_id: string;
   parameters: Record<string, any>;
+  event_id: number;
+}
+
+/**
+ * @experimental
+ */
+export interface RichContentMessage {
+  type: "rich_content";
+  rich_content: RichContent;
+}
+
+/**
+ * @experimental
+ */
+export interface RichContent {
+  rich_content_id: string;
+  component: string;
+  props: Record<string, any>;
   event_id: number;
 }
 
@@ -627,6 +646,14 @@ export interface AgentReasoningResponsePartClientEvent {
 export interface ClientToolCallClientEvent {
   type: "client_tool_call";
   client_tool_call: ClientToolCall;
+}
+
+/**
+ * @experimental
+ */
+export interface RichContentClientEvent {
+  type: "rich_content";
+  rich_content: RichContent;
 }
 
 export interface AgentToolRequestClientEvent {

--- a/packages/types/generated/types/incoming.ts
+++ b/packages/types/generated/types/incoming.ts
@@ -22,6 +22,7 @@ export type {
   McpToolCallClientEvent,
   PartialTranscriptMessage,
   PingEvent,
+  RichContentClientEvent,
   ScribeAuthErrorMessage,
   ScribeChunkSizeExceededErrorMessage,
   ScribeCommitThrottledErrorMessage,

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -56,6 +56,7 @@ channels:
           - $ref: "#/components/messages/Interruption"
           - $ref: "#/components/messages/ConversationMetadata"
           - $ref: "#/components/messages/ClientToolCallMessage"
+          - $ref: "#/components/messages/RichContentMessage"
           - $ref: "#/components/messages/AgentToolRequestMessage"
           - $ref: "#/components/messages/AgentToolResponseMessage"
           - $ref: "#/components/messages/AgentToolResponseFullPayloadMessage"
@@ -252,6 +253,15 @@ components:
       payload:
         $ref: "#/components/schemas/ClientToolCallPayload"
 
+    RichContentMessage:
+      name: RichContentClientEvent
+      title: Rich Content
+      summary: Component for the client to display
+      contentType: application/json
+      x-experimental: true
+      payload:
+        $ref: "#/components/schemas/RichContentPayload"
+
     AgentToolRequestMessage:
       name: AgentToolRequestClientEvent
       title: Agent Tool Request
@@ -380,6 +390,7 @@ components:
         - tentative_user_transcript
         - conversation_initiation_metadata
         - client_tool_call
+        - rich_content
         - agent_tool_request
         - agent_tool_response
         - agent_tool_response_full_payload
@@ -870,6 +881,15 @@ components:
           const: client_tool_call
         client_tool_call:
           $ref: "#/components/schemas/ClientToolCallData"
+    RichContentPayload:
+      type: object
+      required: [rich_content, type]
+      properties:
+        type:
+          type: string
+          const: rich_content
+        rich_content:
+          $ref: "#/components/schemas/RichContentData"
     AgentToolRequestPayload:
       type: object
       required: [agent_tool_request, type]
@@ -1068,6 +1088,21 @@ components:
           type: string
         parameters:
           type: object
+        event_id:
+          type: integer
+
+    RichContentData:
+      type: object
+      required: [rich_content_id, component, props, event_id]
+      properties:
+        rich_content_id:
+          type: string
+        component:
+          type: string
+          description: Which component to display, for example item_card
+        props:
+          type: object
+          description:  Component-specific properties; the shape of this object is defined by the component
         event_id:
           type: integer
 


### PR DESCRIPTION
## Summary

[RFC](https://docs.google.com/document/d/1ZMxvMifKVaUxnDSLHVTI3JWxrfmC0OQzguC-d_Uf32k/edit?usp=sharing)

Renders the components an agent sends inline in the transcript, starting with an item card: an identifier and title, plus optional subtitle, image, description, price, and up to three buttons. Buttons send a follow-up message as the user.

Builds on the `onRichContent` callback from the SDK PR. The widget appends each component to the transcript as it arrives, and renders anything it doesn't recognize as a short notice rather than breaking the turn.

Nothing is visible until the backend can send `rich_content`, which isn't merged yet. Open to edit the design and props. Just wanted to get this out there as a first pass.

Preview of the item card with example data
<img width="357" height="266" alt="Screenshot 2026-08-03 at 6 02 40 PM" src="https://github.com/user-attachments/assets/cd496668-1137-4198-a782-e113ba72e5d7" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New user-facing transcript rendering and agent-driven UI (images, buttons sending messages) with validation mitigations; depends on SDK/backend rich_content delivery not yet merged.
> 
> **Overview**
> Adds **inline rich content** in the convai widget transcript when the agent sends `rich_content` events (via SDK `onRichContent`). The first supported component is **`item_card`**: title, optional subtitle, image, description, price, and up to three buttons that call `sendUserMessage` with preset text.
> 
> **Transcript pipeline:** a new `rich_content` entry type is appended on arrival with **deduplication by `richContentId`**. `buildDisplayTranscript` passes these through in order (cards stay where they arrived; empty agent placeholders can be dropped when a card follows). `TranscriptMessage` routes rich entries to `RichContentRenderer`.
> 
> **Safety:** `parseItemCardProps` validates and normalizes agent props (text limits, **https** / `data:image` URLs only, button caps). Unknown or invalid components show the configurable **`rich_content_unavailable`** notice instead of breaking the turn.
> 
> **Tests & mocks:** validation unit tests, display-transcript scenarios for ordering with tools/typing, and a `rich_content` mock agent for manual/dev testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3801266ab1a2b629f5cdd56b0e6575a8d984d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->