### PR TITLE
fix: ignore .nitro build output in agent-testbench eslint

### DIFF
--- a/examples/agent-testbench/eslint.config.js
+++ b/examples/agent-testbench/eslint.config.js
@@ -7,5 +7,5 @@ import tseslint from "typescript-eslint";
 export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommended,
-  globalIgnores([".output/**", "src/*.gen.ts"])
+  globalIgnores([".output/**", ".nitro/**", "src/*.gen.ts"])
 );


### PR DESCRIPTION
## Problem

`@elevenlabs/agent-testbench`'s `lint:es` fails with ~1700 `no-undef` errors (`Response`, `process`, `console`, `structuredClone`, …). The build emits bundled server files under `.nitro/` (e.g. `.nitro/vite/services/ssr/server.js`, ~16k lines; `elevenlabs.server-*.js`, ~117k lines), and `eslint .` lints them.

This is latent on `main` — the repo Lint workflow last ran successfully on 2026-07-30, and the `.nitro` output was introduced since. It surfaces on any PR that runs Lint against current `main`.

## Fix

Add `.nitro/**` to the eslint `globalIgnores`, next to the existing `.output/**`.

## Test plan

- [x] `pnpm --filter @elevenlabs/agent-testbench build && pnpm --filter @elevenlabs/agent-testbench lint:es` passes with the change (fails without it)
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only ESLint ignore change with no runtime or application behavior impact.
> 
> **Overview**
> **Fixes `lint:es` failing** on `@elevenlabs/agent-testbench` after Nitro emits bundled server artifacts under `.nitro/` (which ESLint was treating as source and reporting thousands of `no-undef` errors).
> 
> Adds **`.nitro/**`** to `globalIgnores` in `eslint.config.js`, alongside the existing `.output/**` ignore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba0c30cc40288bbfe4929b9eabbeb201f3f4092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->