### PR TITLE
docs(react-native): note Metro package exports caveat for RN < 0.79

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -20,6 +20,17 @@ The LiveKit peer dependencies provide the native WebRTC modules required for voi
 
 > **Note:** This SDK requires Expo development builds. Expo Go is not supported due to native module requirements.
 
+> **Note:** This package resolves its React Native entry point via the `package.json` [`"exports"`](https://nodejs.org/api/packages.html#exports) field. Metro only resolves `"exports"` by default starting with Metro 0.82.0, which shipped in [React Native 0.79.0](https://reactnative.dev/blog/2025/04/08/react-native-0.79) (released April 8, 2025). If you're on a React Native version older than 0.79, set `resolver.unstable_enablePackageExports = true` in your `metro.config.js` so this package resolves correctly:
+>
+> ```js
+> const { getDefaultConfig } = require("metro-config");
+>
+> const config = getDefaultConfig(__dirname);
+> config.resolver.unstable_enablePackageExports = true;
+>
+> module.exports = config;
+> ```
+
 ## Quick Start
 
 ```tsx


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a caveat to the `@elevenlabs/react-native` README about Metro's `package.json` `"exports"` resolution.

## Why

`@elevenlabs/react-native`'s `package.json` uses the `"exports"` field with a `react-native` condition to select the correct entry point. Metro only resolves `"exports"` **by default** starting with Metro 0.82.0, which shipped as part of [React Native 0.79.0](https://reactnative.dev/blog/2025/04/08/react-native-0.79) (released April 8, 2025). Package Exports resolution was previously opt-in (via `resolver.unstable_enablePackageExports`) since Metro 0.76.1 / React Native 0.72.

Since this package's `peerDependencies` allow `react-native": ">=0.70.0"`, consumers on React Native versions older than 0.79 could hit module resolution issues unless they manually enable `resolver.unstable_enablePackageExports = true` in their `metro.config.js`. This PR documents that requirement.

## Changes

- Added a note in `packages/react-native/README.md` explaining the Metro/React Native version requirement and the `metro.config.js` snippet needed for older React Native versions.

## Testing

Documentation-only change. Verified formatting with `prettier --check`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf382a61-44ab-41b7-8d51-6ef7591ede64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf382a61-44ab-41b7-8d51-6ef7591ede64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

