### PR TITLE
Fix conversation state consistency through disconnect

### DIFF
--- a/.changeset/brave-donkeys-repair.md
+++ b/.changeset/brave-donkeys-repair.md
@@ -1,0 +1,10 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react": patch
+---
+
+Fix conversation state consistency through disconnect:
+
+- `BaseConversation` now always reaches the `disconnected` status and fires `onDisconnect`, even when session teardown throws.
+- `ConversationProvider` no longer lets a late `onDisconnect` from a previous session clear a newer session's state, and no longer leaks unhandled rejections from `endSession()`.
+- `useConversationStatus` now reports `disconnected` as soon as teardown starts, instead of holding `connected` while the conversation was already released — consumers guarding conversation access with `status === "connected"` could previously crash during disconnect.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -515,6 +515,27 @@ describe("BaseConversation", () => {
         context: { type: "max_duration_exceeded" },
       });
     });
+
+    it("still reaches disconnected and fires onDisconnect if teardown throws", async () => {
+      const onDisconnect = vi.fn();
+      const onStatusChange = vi.fn();
+      const throwingConnection = {
+        ...noopConnection,
+        close: () => {
+          throw new Error("teardown boom");
+        },
+      } as unknown as BaseConnection;
+      const conversation = TestConversation.create(
+        { onDisconnect, onStatusChange },
+        throwingConnection
+      );
+      conversation.connect();
+
+      await expect(conversation.endSession()).rejects.toThrow("teardown boom");
+
+      expect(onStatusChange).toHaveBeenCalledWith({ status: "disconnected" });
+      expect(onDisconnect).toHaveBeenCalledWith({ reason: "user" });
+    });
   });
 
   describe("error events", () => {

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -172,10 +172,16 @@ export abstract class BaseConversation {
   private endSessionWithDetails = async (details: DisconnectionDetails) => {
     if (this.status !== "connected" && this.status !== "connecting") return;
     this.updateStatus("disconnecting");
-    await this.handleEndSession();
-    this.updateStatus("disconnected");
-    if (this.options.onDisconnect) {
-      this.options.onDisconnect(details);
+    try {
+      await this.handleEndSession();
+    } finally {
+      // Always reach "disconnected" and notify onDisconnect, even if
+      // teardown throws — otherwise callers relying on onDisconnect to
+      // release their reference to this conversation get stuck forever.
+      this.updateStatus("disconnected");
+      if (this.options.onDisconnect) {
+        this.options.onDisconnect(details);
+      }
     }
   };
 

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -41,15 +41,13 @@ const createMockConversation = (id = "test-id") =>
 
 function createWrapper(props: Record<string, unknown> = {}) {
   return function Wrapper({ children }: React.PropsWithChildren) {
-    return (
-      <ConversationProvider {...props}>
-        {children}
-      </ConversationProvider>
-    );
+    return <ConversationProvider {...props}>{children}</ConversationProvider>;
   };
 }
 
-type MockStartSessionOptions = Partial<Callbacks & ConversationLifecycleOptions> &
+type MockStartSessionOptions = Partial<
+  Callbacks & ConversationLifecycleOptions
+> &
   Record<string, unknown>;
 
 function driveConnectedSessionLifecycle(
@@ -61,7 +59,9 @@ function driveConnectedSessionLifecycle(
   options.onConnect?.({ conversationId: conversation.getId() });
 }
 
-function mockStartSessionWithLifecycle(conversation = createMockConversation()) {
+function mockStartSessionWithLifecycle(
+  conversation = createMockConversation()
+) {
   vi.mocked(Conversation.startSession).mockImplementation(async options => {
     driveConnectedSessionLifecycle(
       options as MockStartSessionOptions,
@@ -352,6 +352,48 @@ describe("ConversationProvider", () => {
 
     expect(userOnDisconnect).toHaveBeenCalledWith({ reason: "agent" });
     expect(result.current.conversation).toBeNull();
+  });
+
+  it("ignores a stale onDisconnect from a previous session after a new session has started", async () => {
+    const mockConversationA = createMockConversation("conv-a");
+    const mockConversationB = createMockConversation("conv-b");
+    vi.mocked(Conversation.startSession).mockResolvedValueOnce(
+      mockConversationA
+    );
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+    expect(result.current.conversation).toBe(mockConversationA);
+
+    // endSession() clears the ref optimistically, before the SDK confirms
+    // teardown via onDisconnect — this is what lets restart-from-callback
+    // patterns (see "restarting inside onConnect" tests) work.
+    act(() => {
+      result.current.endSession();
+    });
+    expect(result.current.conversation).toBeNull();
+
+    vi.mocked(Conversation.startSession).mockResolvedValueOnce(
+      mockConversationB
+    );
+    await act(async () => {
+      result.current.startSession();
+    });
+    expect(result.current.conversation).toBe(mockConversationB);
+
+    // Session A's own onDisconnect arrives late (its async teardown was
+    // still in flight when session B started). It must not clear session
+    // B's now-active conversation.
+    const [[optsA]] = vi.mocked(Conversation.startSession).mock.calls;
+    act(() => {
+      optsA.onDisconnect!({ reason: "user" });
+    });
+    expect(result.current.conversation).toBe(mockConversationB);
   });
 
   it("does not reconnect when textOnly prop changes while connecting", async () => {

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -427,6 +427,43 @@ describe("ConversationProvider", () => {
     expect(result.current.conversation).toBe(mockConversation);
   });
 
+  it("drops a superseded session's late callbacks so they can't clobber the new session", async () => {
+    const userOnDisconnect = vi.fn();
+    const mockConversationA = createMockConversation("conv-a");
+    const mockConversationB = createMockConversation("conv-b");
+    vi.mocked(Conversation.startSession)
+      .mockResolvedValueOnce(mockConversationA)
+      .mockResolvedValueOnce(mockConversationB);
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper({ onDisconnect: userOnDisconnect }),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    // External disconnect starts: the conversation is released, and a new
+    // session starts while the old session's teardown is still in flight.
+    const [[optsA]] = vi.mocked(Conversation.startSession).mock.calls;
+    act(() => {
+      optsA.onStatusChange!({ status: "disconnecting" });
+    });
+    await act(async () => {
+      result.current.startSession();
+    });
+    expect(result.current.conversation).toBe(mockConversationB);
+
+    // The old session's teardown completes. Its onDisconnect must not reach
+    // the listener chain — sub-providers registered there (mode, feedback)
+    // would reset state that now belongs to the new session.
+    act(() => {
+      optsA.onDisconnect!({ reason: "agent" });
+    });
+    expect(userOnDisconnect).not.toHaveBeenCalled();
+    expect(result.current.conversation).toBe(mockConversationB);
+  });
+
   it("does not reconnect when textOnly prop changes while connecting", async () => {
     const mockConversation = createMockConversation();
     const { promise, resolve: resolveStartSession } =

--- a/packages/react/src/conversation/ConversationProvider.test.tsx
+++ b/packages/react/src/conversation/ConversationProvider.test.tsx
@@ -396,6 +396,37 @@ describe("ConversationProvider", () => {
     expect(result.current.conversation).toBe(mockConversationB);
   });
 
+  it("releases the conversation when an external disconnect starts, allowing an immediate restart", async () => {
+    const mockConversation = createMockConversation();
+    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+
+    const { result } = renderHook(() => useTestContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+    expect(result.current.conversation).toBe(mockConversation);
+
+    // Agent hangup: the SDK fires "disconnecting" at the *start* of async
+    // teardown — onDisconnect only arrives once it completes. The provider
+    // must release the conversation here, not at onDisconnect, or Start
+    // would be enabled (status reads disconnected) while startSession()
+    // still no-ops on the lingering conversationRef.
+    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
+    act(() => {
+      opts.onStatusChange!({ status: "disconnecting" });
+    });
+    expect(result.current.conversation).toBeNull();
+
+    await act(async () => {
+      result.current.startSession();
+    });
+    expect(Conversation.startSession).toHaveBeenCalledTimes(2);
+    expect(result.current.conversation).toBe(mockConversation);
+  });
+
   it("does not reconnect when textOnly prop changes while connecting", async () => {
     const mockConversation = createMockConversation();
     const { promise, resolve: resolveStartSession } =

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -167,6 +167,30 @@ export function ConversationProvider({
         sessionOptions.onConnect?.(props);
       };
 
+      // "disconnecting" marks the moment the session stops being usable, on
+      // every path (agent hangup, raw endSession(), provider endSession()) —
+      // release the conversation here so it clears in the same React batch
+      // as the status transition, and consumers never observe a live status
+      // with a released conversation (or vice versa). Stale sessions are
+      // dropped entirely so a late "disconnected" can't clobber the status
+      // of a session that replaced this one.
+      const handleStatusChange: NonNullable<
+        Callbacks["onStatusChange"]
+      > = props => {
+        if (isStaleStartSession()) {
+          return;
+        }
+        if (
+          props.status === "disconnecting" &&
+          thisSessionConv !== null &&
+          conversationRef.current === thisSessionConv
+        ) {
+          conversationRef.current = null;
+          setConversation(null);
+        }
+        sessionOptions.onStatusChange?.(props);
+      };
+
       // Syncs provider state when this session ends, whether externally
       // (agent disconnect) or via endSession(). Only clears conversationRef
       // if it still points at this session's conversation.
@@ -181,10 +205,11 @@ export function ConversationProvider({
       };
 
       const providerLifecycleOptions: ConversationLifecycleOptions &
-        Pick<Callbacks, "onConnect" | "onDisconnect"> = {
+        Pick<Callbacks, "onConnect" | "onDisconnect" | "onStatusChange"> = {
         onConversationCreated: handleConversationCreated,
         onConnect: handleConnect,
         onDisconnect: handleDisconnect,
+        onStatusChange: handleStatusChange,
       };
 
       const startSessionOptions: Options = {

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Conversation,
   type Options,
@@ -45,13 +38,14 @@ type ConversationInputControlProps = Pick<
   "isMuted" | "onMutedChange"
 >;
 
-const SUB_PROVIDERS_WITHOUT_PROPS: React.ComponentType<React.PropsWithChildren>[] = [
-  ConversationControlsProvider,
-  ConversationStatusProvider,
-  ConversationModeProvider,
-  ConversationFeedbackProvider,
-  ConversationClientToolsProvider,
-];
+const SUB_PROVIDERS_WITHOUT_PROPS: React.ComponentType<React.PropsWithChildren>[] =
+  [
+    ConversationControlsProvider,
+    ConversationStatusProvider,
+    ConversationModeProvider,
+    ConversationFeedbackProvider,
+    ConversationClientToolsProvider,
+  ];
 
 export type ConversationProviderProps = React.PropsWithChildren<
   HookOptions & ConversationInputControlProps
@@ -76,7 +70,9 @@ export function ConversationProvider({
     () => new Map<string, NonNullable<Options["clientTools"]>[string]>()
   );
   /** Ref to the live clientTools object currently held by BaseConversation. */
-  const clientToolsRef = useRef<Record<string, NonNullable<Options["clientTools"]>[string]>>({});
+  const clientToolsRef = useRef<
+    Record<string, NonNullable<Options["clientTools"]>[string]>
+  >({});
   /** Always holds the latest provider props, avoiding stale closures in callbacks. */
   const defaultOptionsRef = useRef(defaultOptions);
   // eslint-disable-next-line react-hooks/refs -- intentional sync during render for latest-ref pattern
@@ -96,18 +92,6 @@ export function ConversationProvider({
     (callbacks: Partial<Callbacks>) => listenerMap.register(callbacks),
     [listenerMap]
   );
-
-  // Sync provider state when session ends externally (agent disconnect,
-  // raw instance endSession(), etc.). Uses the listener map so it composes
-  // with user-provided onDisconnect callbacks.
-  useLayoutEffect(() => {
-    return listenerMap.register({
-      onDisconnect: () => {
-        conversationRef.current = null;
-        setConversation(null);
-      },
-    });
-  }, [listenerMap]);
 
   const startSession = useCallback(
     (options?: HookOptions) => {
@@ -154,10 +138,19 @@ export function ConversationProvider({
       sessionOptions.clientTools = clientTools;
 
       const userOnConversationCreated = sessionOptions.onConversationCreated;
+      const userOnDisconnect = sessionOptions.onDisconnect;
       const isStaleStartSession = () =>
         startSessionId !== startSessionIdRef.current;
 
+      // Set once this session's conversation is known. endSession() clears
+      // conversationRef optimistically (so restart-from-callback patterns
+      // keep working), which means a session's own onDisconnect can still
+      // arrive after a *newer* session has taken the ref — this check stops
+      // that late arrival from clearing state that isn't its own.
+      let thisSessionConv: Conversation | null = null;
+
       const handleConversationCreated = (conv: Conversation) => {
+        thisSessionConv = conv;
         if (shouldEndRef.current || isStaleStartSession()) {
           return;
         }
@@ -174,10 +167,24 @@ export function ConversationProvider({
         sessionOptions.onConnect?.(props);
       };
 
+      // Syncs provider state when this session ends, whether externally
+      // (agent disconnect) or via endSession(). Only clears conversationRef
+      // if it still points at this session's conversation.
+      const handleDisconnect: NonNullable<
+        Callbacks["onDisconnect"]
+      > = details => {
+        if (conversationRef.current === thisSessionConv) {
+          conversationRef.current = null;
+          setConversation(null);
+        }
+        userOnDisconnect?.(details);
+      };
+
       const providerLifecycleOptions: ConversationLifecycleOptions &
-        Pick<Callbacks, "onConnect"> = {
+        Pick<Callbacks, "onConnect" | "onDisconnect"> = {
         onConversationCreated: handleConversationCreated,
         onConnect: handleConnect,
+        onDisconnect: handleDisconnect,
       };
 
       const startSessionOptions: Options = {
@@ -193,11 +200,14 @@ export function ConversationProvider({
             return;
           }
           if (shouldEndRef.current) {
-            conv.endSession();
+            conv
+              .endSession()
+              .catch(error => console.warn("Error ending session:", error));
             lockRef.current = null;
             return;
           }
           if (conversationRef.current !== conv) {
+            thisSessionConv = conv;
             conversationRef.current = conv;
             setConversation(conv);
           }
@@ -218,9 +228,7 @@ export function ConversationProvider({
           // so listeners (e.g. ConversationStatusProvider) transition to
           // the "error" state with a meaningful message.
           const message =
-            error instanceof Error
-              ? error.message
-              : "Session failed to start";
+            error instanceof Error ? error.message : "Session failed to start";
           sessionOptions.onError?.(message, error);
         }
       );
@@ -236,9 +244,17 @@ export function ConversationProvider({
     setConversation(null);
 
     if (pendingConnection) {
-      pendingConnection.then(c => c.endSession(), () => {});
+      pendingConnection.then(
+        c =>
+          c
+            .endSession()
+            .catch(error => console.warn("Error ending session:", error)),
+        () => {}
+      );
     } else {
-      conv?.endSession();
+      conv
+        ?.endSession()
+        .catch(error => console.warn("Error ending session:", error));
     }
   }, []);
 
@@ -247,9 +263,12 @@ export function ConversationProvider({
     return () => {
       shouldEndRef.current = true;
       if (lockRef.current) {
-        lockRef.current.then(conv => conv.endSession(), () => {});
+        lockRef.current.then(
+          conv => conv.endSession().catch(() => {}),
+          () => {}
+        );
       } else {
-        conversationRef.current?.endSession();
+        conversationRef.current?.endSession().catch(() => {});
       }
     };
   }, []);
@@ -264,18 +283,27 @@ export function ConversationProvider({
       clientToolsRegistry,
       clientToolsRef,
     }),
-    [conversation, conversationRef, startSession, endSession, registerCallbacks, clientToolsRegistry, clientToolsRef]
+    [
+      conversation,
+      conversationRef,
+      startSession,
+      endSession,
+      registerCallbacks,
+      clientToolsRegistry,
+      clientToolsRef,
+    ]
   );
 
-  const wrappedChildren = SUB_PROVIDERS_WITHOUT_PROPS.reduceRight<React.ReactNode>(
-    (nested, Provider) => <Provider>{nested}</Provider>,
-    <ConversationInputProvider
-      isMuted={isMuted}
-      onMutedChange={onMutedChange}
-    >
-      {children}
-    </ConversationInputProvider>
-  );
+  const wrappedChildren =
+    SUB_PROVIDERS_WITHOUT_PROPS.reduceRight<React.ReactNode>(
+      (nested, Provider) => <Provider>{nested}</Provider>,
+      <ConversationInputProvider
+        isMuted={isMuted}
+        onMutedChange={onMutedChange}
+      >
+        {children}
+      </ConversationInputProvider>
+    );
 
   return (
     <ConversationContext.Provider value={contextValue}>

--- a/packages/react/src/conversation/ConversationProvider.tsx
+++ b/packages/react/src/conversation/ConversationProvider.tsx
@@ -137,10 +137,30 @@ export function ConversationProvider({
       clientToolsRef.current = clientTools;
       sessionOptions.clientTools = clientTools;
 
-      const userOnConversationCreated = sessionOptions.onConversationCreated;
-      const userOnDisconnect = sessionOptions.onDisconnect;
       const isStaleStartSession = () =>
         startSessionId !== startSessionIdRef.current;
+
+      // A superseded session can outlive its replacement's start: its async
+      // teardown keeps emitting events (final "disconnected", teardown
+      // onDisconnect, errors) that would otherwise reach the listener map
+      // and clobber sub-provider state now reflecting the newer session
+      // (e.g. ConversationModeProvider resets mode on onDisconnect). Drop
+      // every callback once this start is stale.
+      for (const key of CALLBACK_KEYS) {
+        const callback = sessionOptions[key];
+        if (typeof callback === "function") {
+          (sessionOptions as Record<string, unknown>)[key] = (
+            ...args: never[]
+          ) => {
+            if (!isStaleStartSession()) {
+              (callback as (...a: never[]) => void)(...args);
+            }
+          };
+        }
+      }
+
+      const userOnConversationCreated = sessionOptions.onConversationCreated;
+      const userOnDisconnect = sessionOptions.onDisconnect;
 
       // Set once this session's conversation is known. endSession() clears
       // conversationRef optimistically (so restart-from-callback patterns
@@ -197,6 +217,9 @@ export function ConversationProvider({
       const handleDisconnect: NonNullable<
         Callbacks["onDisconnect"]
       > = details => {
+        if (isStaleStartSession()) {
+          return;
+        }
         if (conversationRef.current === thisSessionConv) {
           conversationRef.current = null;
           setConversation(null);

--- a/packages/react/src/conversation/ConversationStatus.test.tsx
+++ b/packages/react/src/conversation/ConversationStatus.test.tsx
@@ -35,15 +35,13 @@ function useTestHook() {
 
 function createWrapper(props: Record<string, unknown> = {}) {
   return function Wrapper({ children }: React.PropsWithChildren) {
-    return (
-      <ConversationProvider {...props}>
-        {children}
-      </ConversationProvider>
-    );
+    return <ConversationProvider {...props}>{children}</ConversationProvider>;
   };
 }
 
-type MockStartSessionOptions = Partial<Callbacks & ConversationLifecycleOptions> &
+type MockStartSessionOptions = Partial<
+  Callbacks & ConversationLifecycleOptions
+> &
   Record<string, unknown>;
 
 function driveConnectedSessionLifecycle(
@@ -197,7 +195,7 @@ describe("ConversationStatus", () => {
     expect(result.current.status.message).toBe("boom");
   });
 
-  it("ignores disconnecting status (transient)", async () => {
+  it("reports disconnecting as disconnected (conversation is already released)", async () => {
     const mockConversation = createMockConversation();
     vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
 
@@ -216,10 +214,58 @@ describe("ConversationStatus", () => {
     });
     expect(result.current.status.status).toBe("connected");
 
+    // endSession() releases the conversation optimistically the moment
+    // "disconnecting" fires — status must never read "connected" while the
+    // conversation is gone (consumers guard conversation access on it).
     act(() => {
       opts.onStatusChange!({ status: "disconnecting" });
     });
-    expect(result.current.status.status).toBe("connected");
+    expect(result.current.status.status).toBe("disconnected");
+  });
+
+  it("never renders status connected while the conversation is released", async () => {
+    const observed: Array<{ status: string; hasConversation: boolean }> = [];
+
+    function useObserver() {
+      const ctx = useContext(ConversationContext) as ConversationContextValue;
+      const { status } = useConversationStatus();
+      observed.push({ status, hasConversation: ctx.conversation !== null });
+      return ctx;
+    }
+
+    const mockConversation = createMockConversation();
+    let opts: MockStartSessionOptions | null = null;
+    vi.mocked(Conversation.startSession).mockImplementation(async options => {
+      opts = options as MockStartSessionOptions;
+      driveConnectedSessionLifecycle(opts, mockConversation);
+      return mockConversation;
+    });
+    // Mirror the real SDK: endSession() synchronously fires "disconnecting"
+    // before its async teardown completes.
+    vi.mocked(mockConversation.endSession).mockImplementation(async () => {
+      opts?.onStatusChange?.({ status: "disconnecting" });
+    });
+
+    const { result } = renderHook(() => useObserver(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    act(() => {
+      result.current.endSession();
+    });
+
+    // Consumers guard conversation access with status === "connected"
+    // (e.g. calling getId() during render) — no render may observe that
+    // status while the conversation has already been released.
+    const broken = observed.filter(
+      o => o.status === "connected" && !o.hasConversation
+    );
+    expect(broken).toEqual([]);
+    expect(result.current.conversation).toBeNull();
   });
 
   it("composes with user-provided onStatusChange callback", async () => {

--- a/packages/react/src/conversation/ConversationStatus.test.tsx
+++ b/packages/react/src/conversation/ConversationStatus.test.tsx
@@ -30,7 +30,7 @@ const createMockConversation = (id = "test-id") =>
 function useTestHook() {
   const ctx = useContext(ConversationContext) as ConversationContextValue;
   const status = useConversationStatus();
-  return { startSession: ctx.startSession, status };
+  return { startSession: ctx.startSession, endSession: ctx.endSession, status };
 }
 
 function createWrapper(props: Record<string, unknown> = {}) {
@@ -221,6 +221,38 @@ describe("ConversationStatus", () => {
       opts.onStatusChange!({ status: "disconnecting" });
     });
     expect(result.current.status.status).toBe("disconnected");
+  });
+
+  it("ignores status events from a superseded session", async () => {
+    const mockConversation = createMockConversation();
+    vi.mocked(Conversation.startSession).mockResolvedValue(mockConversation);
+
+    const { result } = renderHook(() => useTestHook(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.startSession();
+    });
+    act(() => {
+      result.current.endSession();
+    });
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    const [[optsA], [optsB]] = vi.mocked(Conversation.startSession).mock.calls;
+    act(() => {
+      optsB.onStatusChange!({ status: "connected" });
+    });
+    expect(result.current.status.status).toBe("connected");
+
+    // Session A's teardown completes late and fires its final
+    // "disconnected" — it must not clobber session B's live status.
+    act(() => {
+      optsA.onStatusChange!({ status: "disconnected" });
+    });
+    expect(result.current.status.status).toBe("connected");
   });
 
   it("never renders status connected while the conversation is released", async () => {

--- a/packages/react/src/conversation/ConversationStatus.tsx
+++ b/packages/react/src/conversation/ConversationStatus.tsx
@@ -30,11 +30,11 @@ export function ConversationStatusProvider({
 
   useRegisterCallbacks({
     onStatusChange({ status: newStatus }) {
-      if (newStatus === "disconnecting") {
-        // Transient state — keep current status
-        return;
-      }
-      setStatus(newStatus);
+      // "disconnecting" means the provider has already released the
+      // conversation (endSession clears it optimistically), so report
+      // "disconnected" immediately — holding "connected" here would let
+      // consumers observe status === "connected" with no conversation.
+      setStatus(newStatus === "disconnecting" ? "disconnected" : newStatus);
       // Clear error message when transitioning to a non-error state
       setMessage(undefined);
     },


### PR DESCRIPTION
## Summary

Fixes a crash and two state-consistency gaps around session disconnect, found while dogfooding the React Native example (`getId()` threw `"No active conversation. Call startSession() first."` during render on every manual disconnect, despite the documented `status === "connected"` guard).

- **`@elevenlabs/client`**: `endSessionWithDetails` awaited `handleEndSession()` with no error handling — a throwing teardown skipped both `updateStatus("disconnected")` and `onDisconnect`, permanently stranding consumers that release their conversation reference in `onDisconnect`. Teardown now runs in a `try`/`finally` so both always fire.
- **`@elevenlabs/react`**: `ConversationStatusProvider` suppressed the `"disconnecting"` status, holding `"connected"` while `endSession()` had already (intentionally, optimistically) released the conversation — so a render could observe `status === "connected"` with no conversation behind it. It now reports `"disconnected"` as soon as teardown starts; both updates land in the same React batch, so no render can observe the mismatch.
- **`@elevenlabs/react`**: a session's `onDisconnect` arriving after a newer session had claimed `conversationRef` could wrongly clear the newer session's state — each session's handler now only clears state it still owns. Also added `.catch()` on `endSession()` call sites that previously leaked unhandled rejections.

## Test plan

- [x] New unit tests for all three fixes; each verified to fail with the fix reverted
- [x] `pnpm turbo build check-types lint test` for `@elevenlabs/client` and `@elevenlabs/react`
- [x] Verified on-device (React Native example, Android): the render crash on disconnect is gone and sessions no longer get stuck after teardown errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session lifecycle and callback routing in client and React providers; behavior changes during disconnect/restart could affect apps that relied on the old timing, though the changes are targeted fixes with new tests.
> 
> **Overview**
> Fixes disconnect-time crashes and stuck sessions by aligning client teardown guarantees with React provider lifecycle handling.
> 
> **`@elevenlabs/client`**: `endSessionWithDetails` now wraps teardown in `try`/`finally` so **`disconnected`** and **`onDisconnect`** always run even when `handleEndSession()` throws.
> 
> **`@elevenlabs/react`**: `ConversationProvider` releases the conversation when status becomes **`disconnecting`** (not only on **`onDisconnect`**), clears refs only for the owning session, and ignores callbacks from superseded starts. **`endSession()`** rejections are caught so they do not become unhandled rejections.
> 
> **`ConversationStatusProvider`**: maps **`disconnecting`** to **`disconnected`** immediately so consumers using `status === "connected"` do not touch a conversation that was already cleared optimistically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd54af6b13c7a3dc506db9573a8a8997065d461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->