### PR TITLE
Add Scribe workletPaths option and publish worklets as static assets

### DIFF
--- a/.changeset/tame-owls-invite.md
+++ b/.changeset/tame-owls-invite.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+---
+
+Add `workletPaths.scribeAudioProcessor` to `Scribe.connect({ microphone })` so the Scribe audio worklet can be self-hosted, matching the existing `Conversation` `workletPaths` option. This lets strict CSPs (`script-src`/`script-src-elem` without `blob:`/`data:`) load the worklet from a same-origin URL instead of falling back to a blob or data URL.
+
+The generated worklet processors (including `scribeAudioProcessor.js`) are now also published as static assets under `@elevenlabs/client/worklets/*`, so bundlers can copy them into your own static assets and serve them under `script-src 'self'`.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -63,6 +63,46 @@ For the full API reference including connection types, client tools, conversatio
 | `@elevenlabs/client`                | Public, semver-stable          |
 | `@elevenlabs/client/internal`       | Internal, no semver guarantees |
 | `@elevenlabs/client/internal/unity` | Internal, no semver guarantees |
+| `@elevenlabs/client/worklets/*`     | Public, semver-stable          |
+
+## Self-hosting AudioWorklets under a strict CSP
+
+By default, `Conversation` and `Scribe` load their `AudioWorklet` processors
+from `blob:`/`data:` URLs generated at runtime. `AudioWorklet.addModule()`
+requests are governed by the `script-src-elem` directive (falling back to
+`script-src`), so a strict CSP that only allows `script-src 'self'` will
+reject those URLs.
+
+To support strict CSPs, the raw processor sources are published as static
+assets under `@elevenlabs/client/worklets/*`. Copy the ones you need into
+your own static assets (e.g. via a build step or bundler copy plugin) and
+serve them same-origin, then point the SDK at them:
+
+```js
+import { Conversation } from "@elevenlabs/client";
+
+const conversation = await Conversation.startSession({
+  agentId: "agent_...",
+  workletPaths: {
+    rawAudioProcessor: "/vendor/elevenlabs/raw-audio-processor.js",
+    audioConcatProcessor: "/vendor/elevenlabs/audio-concat-processor.js",
+  },
+});
+```
+
+```js
+import { Scribe } from "@elevenlabs/client";
+
+const connection = Scribe.connect({
+  token: "...",
+  modelId: "scribe_v2_realtime",
+  microphone: {
+    workletPaths: {
+      scribeAudioProcessor: "/vendor/elevenlabs/scribe-audio-processor.js",
+    },
+  },
+});
+```
 
 ## Development
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,7 +12,8 @@
       "default": "./dist/index.js"
     },
     "./internal": "./dist/internal.js",
-    "./internal/unity": "./dist/internal/unity.js"
+    "./internal/unity": "./dist/internal/unity.js",
+    "./worklets/*": "./worklets/*"
   },
   "scripts": {
     "generate-version": "node ../../scripts/generate-version.mjs",
@@ -51,7 +52,8 @@
     "directory": "packages/client"
   },
   "files": [
-    "dist"
+    "dist",
+    "worklets"
   ],
   "publishConfig": {
     "access": "public",

--- a/packages/client/src/platform/web/scribeMicrophone.test.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.test.ts
@@ -95,6 +95,33 @@ describe("webScribeMicrophoneSetup", () => {
     expect(audioContext.close).toHaveBeenCalledOnce();
   });
 
+  it("forwards a custom workletPaths.scribeAudioProcessor to the loader", async () => {
+    installAudioEnvironment();
+    vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+    await webScribeMicrophoneSetup(
+      { workletPaths: { scribeAudioProcessor: "/vendor/scribe-processor.js" } },
+      vi.fn()
+    );
+
+    expect(loadScribeAudioProcessor).toHaveBeenCalledWith(
+      expect.anything(),
+      "/vendor/scribe-processor.js"
+    );
+  });
+
+  it("passes undefined to the loader when no workletPaths are provided", async () => {
+    installAudioEnvironment();
+    vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+    await webScribeMicrophoneSetup({}, vi.fn());
+
+    expect(loadScribeAudioProcessor).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined
+    );
+  });
+
   it("releases the partial pipeline when AudioContext resume fails", async () => {
     const resumeError = new Error("resume failed");
     const { audioContext, scribeNode, source, track } = installAudioEnvironment(

--- a/packages/client/src/platform/web/scribeMicrophone.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.ts
@@ -57,7 +57,10 @@ export const webScribeMicrophoneSetup: ScribeMicrophoneSetup = async (
     );
 
     // Load scribe worklet
-    await loadScribeAudioProcessor(audioContext.audioWorklet);
+    await loadScribeAudioProcessor(
+      audioContext.audioWorklet,
+      config.workletPaths?.scribeAudioProcessor
+    );
 
     // Set up audio pipeline
     source = audioContext.createMediaStreamSource(stream);

--- a/packages/client/src/scribe/microphone.ts
+++ b/packages/client/src/scribe/microphone.ts
@@ -12,6 +12,15 @@ export interface ScribeMicrophoneConfig {
   noiseSuppression?: boolean;
   autoGainControl?: boolean;
   channelCount?: number;
+  /**
+   * Allows self-hosting the Scribe audio worklet to avoid whitelisting
+   * blob: and data: URLs in the CSP script-src (or script-src-elem)
+   * directive. Point this at a same-origin copy of the processor shipped
+   * at `@elevenlabs/client/worklets/scribeAudioProcessor.js`.
+   */
+  workletPaths?: {
+    scribeAudioProcessor?: string;
+  };
 }
 
 export interface ScribeMicrophoneResult {

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -1077,6 +1077,45 @@ describe("Scribe", () => {
       server.close();
     });
 
+    it("forwards workletPaths.scribeAudioProcessor to the registered microphone setup", async () => {
+      const mockTrack = { enabled: true } as MediaStreamTrack;
+      const cleanup = vi.fn();
+
+      const mockSetup = vi.fn((_config, _onAudioData) =>
+        Promise.resolve({ mediaStreamTrack: mockTrack, cleanup })
+      );
+      setScribeMicrophoneSetup(mockSetup);
+
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123"
+      );
+      onTestFinished(() => server.close());
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        microphone: {
+          workletPaths: {
+            scribeAudioProcessor:
+              "/vendor/elevenlabs/scribe-audio-processor.js",
+          },
+        },
+      });
+      onTestFinished(() => connection.close());
+
+      await sleep(100);
+
+      expect(mockSetup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workletPaths: {
+            scribeAudioProcessor:
+              "/vendor/elevenlabs/scribe-audio-processor.js",
+          },
+        }),
+        expect.any(Function)
+      );
+    });
+
     it("releases the microphone when close() races the async mic setup", async () => {
       const mockTrack = { enabled: true } as MediaStreamTrack;
       const cleanup = vi.fn();

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -107,6 +107,16 @@ export interface MicrophoneOptions extends BaseOptions {
     noiseSuppression?: boolean;
     autoGainControl?: boolean;
     channelCount?: number;
+    /**
+     * Allows self-hosting the Scribe audio worklet to avoid whitelisting
+     * blob: and data: URLs in the CSP script-src (or script-src-elem)
+     * directive. Point this at a same-origin copy of the processor shipped
+     * at `@elevenlabs/client/worklets/scribeAudioProcessor.js`, e.g.
+     * `{ scribeAudioProcessor: "/vendor/elevenlabs/scribe-audio-processor.js" }`.
+     */
+    workletPaths?: {
+      scribeAudioProcessor?: string;
+    };
   };
   audioFormat?: never;
   sampleRate?: never;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Scribe.connect({ microphone: … })` loads its embedded `AudioWorklet` processor via `loadScribeAudioProcessor(audioContext.audioWorklet)`, which always falls back to a `blob:` URL (and then a `data:` URL) because no path is supplied. `AudioWorklet.addModule()` requests are governed by `script-src-elem` (falling back to `script-src`), so a strict CSP that only allows `script-src 'self'` rejects both fallbacks. There was no supported way to give Scribe a same-origin worklet URL, even though `createWorkletModuleLoader` already supports a CSP-friendly `path` argument and the `Conversation` API already exposes `workletPaths`.

## Changes

- `Scribe.connect({ microphone: { workletPaths: { scribeAudioProcessor } } })`: a new optional field on the microphone config, threaded through `ScribeMicrophoneConfig` → `webScribeMicrophoneSetup` → `loadScribeAudioProcessor(audioWorklet, path)`, mirroring the existing `AudioWorkletConfig.workletPaths` shape used by `Conversation`.
- Published the generated worklet processors (`rawAudioProcessor.js`, `audioConcatProcessor.js`, `scribeAudioProcessor.js`) as static package assets via a new `./worklets/*` export subpath and by including the `worklets` directory in the package's `files`. Bundlers/build steps can now copy `@elevenlabs/client/worklets/scribeAudioProcessor.js` into a same-origin static path and serve it under `script-src 'self'`.
- Documented the self-hosting story (`workletPaths` for both `Conversation` and `Scribe`, plus the new `./worklets/*` entrypoint) in `packages/client/README.md`.
- Added a changeset (minor bump for `@elevenlabs/client`).

## Usage

```js
import { Scribe } from "@elevenlabs/client";

const connection = Scribe.connect({
  token: "...",
  modelId: "scribe_v2_realtime",
  microphone: {
    workletPaths: {
      scribeAudioProcessor: "/vendor/elevenlabs/scribe-audio-processor.js",
    },
  },
});
```

Consumers copy `node_modules/@elevenlabs/client/worklets/scribeAudioProcessor.js` (or import it via the `@elevenlabs/client/worklets/scribeAudioProcessor.js` subpath) into their own static assets at build time.

## Testing

- Added unit tests verifying `webScribeMicrophoneSetup` forwards `workletPaths.scribeAudioProcessor` (or `undefined`) to `loadScribeAudioProcessor`.
- Added a unit test verifying `Scribe.connect({ microphone: { workletPaths } })` forwards the option to the registered microphone setup.
- Verified the new `./worklets/*` export subpath resolves to a real static file via Node's exports resolution.
- Ran the full `@elevenlabs/client` test suite (`pnpm exec vitest run`): 131/131 non-browser-mode tests pass (the 2 browser-mode test files require a Playwright Chromium binary that isn't installed in this sandbox — this is a pre-existing environment limitation unrelated to this change, confirmed present on the base branch as well).
- Ran `tsc --build --force` for `@elevenlabs/client`: no errors.
- The repo's pre-commit hook ran the full `turbo` build/check-types/lint pipeline across all packages: 29/29 tasks succeeded.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dfd5b26-af4b-463b-93d1-5437d575ff17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dfd5b26-af4b-463b-93d1-5437d575ff17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

