### PR TITLE
Add webRtc.iceTransportPolicy session option for WebRTC connections

### DIFF
--- a/.changeset/rtc-config-passthrough.md
+++ b/.changeset/rtc-config-passthrough.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Add an optional `rtcConfig` session option, passed through to LiveKit's `room.connect()` as `RTCConfiguration` overrides for WebRTC connections. This allows, for example, forcing TURN relay candidates with `{ iceTransportPolicy: "relay" }` on networks that drop direct UDP flows, without patching the global `RTCPeerConnection`.

--- a/.changeset/rtc-config-passthrough.md
+++ b/.changeset/rtc-config-passthrough.md
@@ -2,4 +2,4 @@
 "@elevenlabs/client": minor
 ---
 
-Add an optional `rtcConfig` session option, passed through to LiveKit's `room.connect()` as `RTCConfiguration` overrides for WebRTC connections. This allows, for example, forcing TURN relay candidates with `{ iceTransportPolicy: "relay" }` on networks that drop direct UDP flows, without patching the global `RTCPeerConnection`.
+Add an optional `webRtc.iceTransportPolicy` session option for WebRTC connections. Set to `"relay"` to restrict ICE to TURN relay candidates, for networks that drop direct UDP flows, without patching the global `RTCPeerConnection`.

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -1,3 +1,4 @@
+import type { RoomConnectOptions } from "livekit-client";
 import type { IncomingSocketEvent, OutgoingSocketEvent } from "./events.js";
 import type { Mode } from "../BaseConversation.js";
 import type {
@@ -30,6 +31,11 @@ export type BaseSessionConfig = {
   origin?: string;
   authorization?: string;
   livekitUrl?: string;
+  /**
+   * RTCConfiguration overrides passed to LiveKit's `room.connect()`, e.g.
+   * `{ iceTransportPolicy: "relay" }`. WebRTC connections only.
+   */
+  rtcConfig?: RoomConnectOptions["rtcConfig"];
   overrides?: {
     agent?: {
       prompt?: ConversationConfigOverrideAgentPrompt;

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -1,4 +1,3 @@
-import type { RoomConnectOptions } from "livekit-client";
 import type { IncomingSocketEvent, OutgoingSocketEvent } from "./events.js";
 import type { Mode } from "../BaseConversation.js";
 import type {
@@ -31,11 +30,14 @@ export type BaseSessionConfig = {
   origin?: string;
   authorization?: string;
   livekitUrl?: string;
-  /**
-   * RTCConfiguration overrides passed to LiveKit's `room.connect()`, e.g.
-   * `{ iceTransportPolicy: "relay" }`. WebRTC connections only.
-   */
-  rtcConfig?: RoomConnectOptions["rtcConfig"];
+  webRtc?: {
+    /**
+     * ICE transport policy for the WebRTC connection. Set to "relay" to only
+     * use TURN relay candidates, e.g. on networks that drop direct UDP flows.
+     * Defaults to "all".
+     */
+    iceTransportPolicy?: "all" | "relay";
+  };
   overrides?: {
     agent?: {
       prompt?: ConversationConfigOverrideAgentPrompt;

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -131,7 +131,7 @@ describe("WebRTCConnection", () => {
     connection.close();
   });
 
-  it("passes rtcConfig through to room.connect", async () => {
+  it("passes webRtc.iceTransportPolicy through to room.connect", async () => {
     const mockRoom = new Room() as any;
     (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
       (event: string, callback: () => void) => {
@@ -148,19 +148,16 @@ describe("WebRTCConnection", () => {
       }
     );
 
-    const rtcConfig = {
-      iceTransportPolicy: "relay" as const,
-    };
     const connection = await WebRTCConnection.create({
       conversationToken: "test-token",
       connectionType: "webrtc",
-      rtcConfig,
+      webRtc: { iceTransportPolicy: "relay" },
     });
 
     expect(mockRoom.connect).toHaveBeenCalledWith(
       expect.any(String),
       "test-token",
-      { rtcConfig }
+      { rtcConfig: { iceTransportPolicy: "relay" } }
     );
 
     connection.close();

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -131,6 +131,41 @@ describe("WebRTCConnection", () => {
     connection.close();
   });
 
+  it("passes rtcConfig through to room.connect", async () => {
+    const mockRoom = new Room() as any;
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const rtcConfig = {
+      iceTransportPolicy: "relay" as RTCIceTransportPolicy,
+    };
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+      rtcConfig,
+    });
+
+    expect(mockRoom.connect).toHaveBeenCalledWith(
+      expect.any(String),
+      "test-token",
+      { rtcConfig }
+    );
+
+    connection.close();
+  });
+
   it("reconnects input analyser after unmuting", async () => {
     const mockRoom = new Room() as any;
 

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -149,7 +149,7 @@ describe("WebRTCConnection", () => {
     );
 
     const rtcConfig = {
-      iceTransportPolicy: "relay" as RTCIceTransportPolicy,
+      iceTransportPolicy: "relay" as const,
     };
     const connection = await WebRTCConnection.create({
       conversationToken: "test-token",

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -316,8 +316,9 @@ export class WebRTCConnection extends BaseConnection {
           });
 
       // Connect to the LiveKit room
+      const iceTransportPolicy = config.webRtc?.iceTransportPolicy;
       await room.connect(livekitUrl, conversationToken, {
-        rtcConfig: config.rtcConfig,
+        rtcConfig: iceTransportPolicy ? { iceTransportPolicy } : undefined,
       });
 
       // Wait for the Connected event to ensure isConnected is true

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -316,7 +316,9 @@ export class WebRTCConnection extends BaseConnection {
           });
 
       // Connect to the LiveKit room
-      await room.connect(livekitUrl, conversationToken);
+      await room.connect(livekitUrl, conversationToken, {
+        rtcConfig: config.rtcConfig,
+      });
 
       // Wait for the Connected event to ensure isConnected is true
       await new Promise<void>(resolve => {


### PR DESCRIPTION
Adds an optional `webRtc` object to the session config with a single primitive field, `iceTransportPolicy` (`"all" | "relay"`). Setting `"relay"` restricts ICE to TURN relay candidates, for networks that drop direct UDP flows mid-call. Until now the only way to control this was monkey-patching the global `RTCPeerConnection` before session start. When unset, connect behavior is unchanged.

The public API surface stays independent of livekit-client and free of DOM types; the mapping to livekit's `room.connect()` `rtcConfig` lives inside `WebRTCConnection`. The option flows to `@elevenlabs/react` and `@elevenlabs/react-native` automatically through the shared config types. livekit-client applies the policy to both the publisher and subscriber peer connections and keeps server-provided ICE servers.

## Testing

- unit tests
- build + lint across client, react, and react-native
