### PR TITLE
[Widget] Render agent rich content

### DIFF
--- a/.changeset/rich-content-widget.md
+++ b/.changeset/rich-content-widget.md
@@ -9,3 +9,5 @@ user's own turn; a link button opens its url in a new tab.
 Properties are validated before rendering, so a malformed or unrecognised
 component shows a short notice instead of breaking the transcript, and a
 component stays where it arrived with no message moved across it.
+
+Validation is built on `zod/mini`, which adds roughly 5 KB gzipped.

--- a/.changeset/rich-content-widget.md
+++ b/.changeset/rich-content-widget.md
@@ -1,0 +1,11 @@
+---
+"@elevenlabs/convai-widget-core": minor
+---
+
+Render rich content components the agent sends, inline in the transcript,
+starting with quick reply buttons. A message button sends its text as the
+user's own turn; a link button opens its url in a new tab.
+
+Properties are validated before rendering, so a malformed or unrecognised
+component shows a short notice instead of breaking the transcript, and a
+component stays where it arrived with no message moved across it.

--- a/packages/convai-widget-core/package.json
+++ b/packages/convai-widget-core/package.json
@@ -70,7 +70,8 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/convai-widget-core/src/components/Button.tsx
+++ b/packages/convai-widget-core/src/components/Button.tsx
@@ -1,5 +1,9 @@
 import { ComponentChildren } from "preact";
-import { ButtonHTMLAttributes, forwardRef } from "preact/compat";
+import {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  forwardRef,
+} from "preact/compat";
 import { cn } from "../utils/cn";
 import { Signalish } from "../utils/signalish";
 import { Icon, IconName } from "./Icon";
@@ -12,9 +16,6 @@ const VARIANT_CLASSES = {
     "text-base-primary border border-base-border bg-base hover:bg-base-hover active:bg-base-active",
   ghost:
     "text-base-primary border border-base bg-base hover:bg-base-hover hover:border-base-hover active:bg-base-active active:border-base-active",
-  // Accent coloured but not filled. Reserves solid accent for what the user
-  // actually said, so a tappable suggestion is never mistaken for their own
-  // message bubble.
   outline:
     "text-accent border border-accent bg-base hover:bg-base-hover active:bg-base-active",
   "md-button":
@@ -23,38 +24,19 @@ const VARIANT_CLASSES = {
 
 export type ButtonVariant = keyof typeof VARIANT_CLASSES;
 
-/**
- * The classes Button puts on its own element, for the rare caller that has to
- * render something other than a <button> — an anchor, say — and still look
- * identical. Exported as a function rather than the class strings themselves
- * so layout and variant can only ever be changed in one place.
- */
-export function buttonClassName(
-  variant: ButtonVariant = "secondary",
-  className?: string
-) {
-  return cn(
-    "h-9 flex px-2.5 text-sm items-center transition-[colors,opacity] justify-center rounded-button duration-200 focus-ring overflow-hidden select-none",
-    VARIANT_CLASSES[variant],
-    className
-  );
-}
-
-/** Matches the label Button wraps its children in. */
-export function buttonLabelClassName(variant?: ButtonVariant) {
-  return cn(
-    "block whitespace-nowrap max-w-64 truncate",
-    variant === "md-button" ? "pl-1.5" : "px-1.5"
-  );
-}
+type LinkAttributes = Pick<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href" | "download"
+>;
 
 export interface BaseButtonProps
-  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  extends ButtonHTMLAttributes<HTMLButtonElement>, LinkAttributes {
   iconClassName?: string;
   variant?: keyof typeof VARIANT_CLASSES;
   disabledStyle?: boolean;
   truncate?: boolean;
   icon?: IconName;
+  as?: "button" | "a";
 }
 
 interface TextButtonProps extends BaseButtonProps {
@@ -70,6 +52,7 @@ export type ButtonProps = TextButtonProps | IconButtonProps;
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(
     {
+      as = "button",
       variant = "secondary",
       children,
       icon,
@@ -83,20 +66,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const hasIcon = !!icon;
     const iconOnly = hasIcon && !children;
 
-    return (
-      <button
-        ref={ref}
-        className={buttonClassName(
-          variant,
-          cn(
-            "disabled:opacity-50 disabled:pointer-events-none",
-            iconOnly && "min-w-9",
-            className
-          )
-        )}
-        type="button"
-        {...props}
-      >
+    const content = (
+      <>
         {icon && (
           <Icon
             className={cn(
@@ -109,8 +80,49 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           />
         )}
         <SizeTransition visible={!!children} dep={children}>
-          <span className={buttonLabelClassName(variant)}>{children}</span>
+          <span
+            className={cn(
+              "block whitespace-nowrap max-w-64 truncate",
+              variant === "md-button" ? "pl-1.5" : "px-1.5"
+            )}
+          >
+            {children}
+          </span>
         </SizeTransition>
+      </>
+    );
+
+    const classes = cn(
+      "h-9 flex px-2.5 text-sm items-center transition-[colors,opacity] justify-center rounded-button duration-200 focus-ring overflow-hidden select-none",
+      VARIANT_CLASSES[variant],
+      iconOnly && "min-w-9",
+      className
+    );
+
+    if (as === "a") {
+      return (
+        <a
+          {...(props as unknown as AnchorHTMLAttributes<HTMLAnchorElement>)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={classes}
+        >
+          {content}
+        </a>
+      );
+    }
+
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "disabled:opacity-50 disabled:pointer-events-none",
+          classes
+        )}
+        type="button"
+        {...props}
+      >
+        {content}
       </button>
     );
   }

--- a/packages/convai-widget-core/src/components/Button.tsx
+++ b/packages/convai-widget-core/src/components/Button.tsx
@@ -12,9 +12,41 @@ const VARIANT_CLASSES = {
     "text-base-primary border border-base-border bg-base hover:bg-base-hover active:bg-base-active",
   ghost:
     "text-base-primary border border-base bg-base hover:bg-base-hover hover:border-base-hover active:bg-base-active active:border-base-active",
+  // Accent coloured but not filled. Reserves solid accent for what the user
+  // actually said, so a tappable suggestion is never mistaken for their own
+  // message bubble.
+  outline:
+    "text-accent border border-accent bg-base hover:bg-base-hover active:bg-base-active",
   "md-button":
     "text-base-primary border border-base-border bg-base hover:bg-base-hover active:bg-base-active text-sm h-6",
 };
+
+export type ButtonVariant = keyof typeof VARIANT_CLASSES;
+
+/**
+ * The classes Button puts on its own element, for the rare caller that has to
+ * render something other than a <button> — an anchor, say — and still look
+ * identical. Exported as a function rather than the class strings themselves
+ * so layout and variant can only ever be changed in one place.
+ */
+export function buttonClassName(
+  variant: ButtonVariant = "secondary",
+  className?: string
+) {
+  return cn(
+    "h-9 flex px-2.5 text-sm items-center transition-[colors,opacity] justify-center rounded-button duration-200 focus-ring overflow-hidden select-none",
+    VARIANT_CLASSES[variant],
+    className
+  );
+}
+
+/** Matches the label Button wraps its children in. */
+export function buttonLabelClassName(variant?: ButtonVariant) {
+  return cn(
+    "block whitespace-nowrap max-w-64 truncate",
+    variant === "md-button" ? "pl-1.5" : "px-1.5"
+  );
+}
 
 export interface BaseButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -54,12 +86,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         ref={ref}
-        className={cn(
-          "h-9 flex px-2.5 text-sm items-center transition-[colors,opacity] justify-center rounded-button duration-200 focus-ring overflow-hidden select-none",
-          "disabled:opacity-50 disabled:pointer-events-none",
-          VARIANT_CLASSES[variant],
-          iconOnly && "min-w-9",
-          className
+        className={buttonClassName(
+          variant,
+          cn(
+            "disabled:opacity-50 disabled:pointer-events-none",
+            iconOnly && "min-w-9",
+            className
+          )
         )}
         type="button"
         {...props}
@@ -76,14 +109,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           />
         )}
         <SizeTransition visible={!!children} dep={children}>
-          <span
-            className={cn(
-              "block whitespace-nowrap max-w-64 truncate",
-              variant === "md-button" ? "pl-1.5" : "px-1.5"
-            )}
-          >
-            {children}
-          </span>
+          <span className={buttonLabelClassName(variant)}>{children}</span>
         </SizeTransition>
       </button>
     );

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -65,6 +65,14 @@ export type TranscriptEntry =
       conversationIndex: number;
     }
   | {
+      type: "rich_content";
+      component: string;
+      props: unknown;
+      conversationIndex: number;
+      eventId: number;
+      richContentId: string;
+    }
+  | {
       type: "disconnection";
       role: Role;
       message?: undefined;
@@ -368,6 +376,24 @@ function useConversationSetup() {
                   toolCallId: tool_call_id,
                   eventId: event_id,
                   isError: is_error,
+                  conversationIndex: conversationIndex.peek(),
+                },
+              ];
+            },
+            onRichContent: ({
+              component,
+              props,
+              event_id,
+              rich_content_id,
+            }) => {
+              transcript.value = [
+                ...transcript.peek(),
+                {
+                  type: "rich_content",
+                  component,
+                  props,
+                  eventId: event_id,
+                  richContentId: rich_content_id,
                   conversationIndex: conversationIndex.peek(),
                 },
               ];

--- a/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
+++ b/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
@@ -1,0 +1,58 @@
+import {
+  Button,
+  buttonClassName,
+  buttonLabelClassName,
+} from "../components/Button";
+import { useConversation } from "../contexts/conversation";
+
+export interface MessageButton {
+  type: "message";
+  label: string;
+  message: string;
+}
+
+export interface LinkButton {
+  type: "link";
+  label: string;
+  link: string;
+}
+
+export type RichContentButton = MessageButton | LinkButton;
+
+export interface ButtonGroupProps {
+  buttons: RichContentButton[];
+}
+
+export function ButtonGroup({ buttons }: ButtonGroupProps) {
+  const { sendUserMessage, status } = useConversation();
+  const disabled = status.value !== "connected";
+
+  if (buttons.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {buttons.map((button, index) =>
+        button.type === "link" ? (
+          <a
+            key={index}
+            href={button.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={buttonClassName("outline")}
+          >
+            <span className={buttonLabelClassName()}>{button.label}</span>
+          </a>
+        ) : (
+          <Button
+            key={index}
+            variant="outline"
+            disabled={disabled}
+            onClick={() => sendUserMessage(button.message)}
+          >
+            {button.label}
+          </Button>
+        )
+      )}
+    </div>
+  );
+}

--- a/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
+++ b/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
@@ -1,8 +1,4 @@
-import {
-  Button,
-  buttonClassName,
-  buttonLabelClassName,
-} from "../components/Button";
+import { Button } from "../components/Button";
 import { useConversation } from "../contexts/conversation";
 
 export interface MessageButton {
@@ -33,15 +29,9 @@ export function ButtonGroup({ buttons }: ButtonGroupProps) {
     <div className="flex flex-wrap gap-2">
       {buttons.map((button, index) =>
         button.type === "link" ? (
-          <a
-            key={index}
-            href={button.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={buttonClassName("outline")}
-          >
-            <span className={buttonLabelClassName()}>{button.label}</span>
-          </a>
+          <Button key={index} as="a" variant="outline" href={button.link}>
+            {button.label}
+          </Button>
         ) : (
           <Button
             key={index}

--- a/packages/convai-widget-core/src/rich-content/RichContentRenderer.tsx
+++ b/packages/convai-widget-core/src/rich-content/RichContentRenderer.tsx
@@ -1,0 +1,44 @@
+import { ComponentChildren } from "preact";
+import { useTextContents } from "../contexts/text-contents";
+import { ButtonGroupProps, ButtonGroup } from "./ButtonGroup";
+import { parseButtonGroupProps } from "./validate";
+
+interface RichContentRendererProps {
+  component: string;
+  props: unknown;
+}
+
+interface RichContentComponentEntry {
+  parseProps: (raw: unknown) => unknown | null;
+  render: (props: unknown) => ComponentChildren;
+}
+
+const RICH_CONTENT_COMPONENTS: Record<string, RichContentComponentEntry> = {
+  buttons: {
+    parseProps: parseButtonGroupProps,
+    render: props => <ButtonGroup {...(props as ButtonGroupProps)} />,
+  },
+};
+
+export function RichContentRenderer({
+  component,
+  props,
+}: RichContentRendererProps) {
+  const entry = RICH_CONTENT_COMPONENTS[component];
+  const parsed = entry?.parseProps(props);
+  if (entry && parsed) {
+    return entry.render(parsed);
+  }
+  
+  return <RichContentUnavailable />;
+}
+
+function RichContentUnavailable() {
+  const text = useTextContents();
+
+  return (
+    <div className="rounded-bubble border border-base-border bg-base px-3 py-2.5 text-xs text-base-subtle">
+      {text.rich_content_unavailable}
+    </div>
+  );
+}

--- a/packages/convai-widget-core/src/rich-content/validate.test.ts
+++ b/packages/convai-widget-core/src/rich-content/validate.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { parseButtonGroupProps } from "./validate";
+
+const parseButtons = (buttons: unknown) => parseButtonGroupProps({ buttons });
+
+describe("button parsing", () => {
+  it("keeps only the buttons that can do something on press", () => {
+    expect(
+      parseButtons([
+        { type: "message", label: "Ask more", message: "Tell me more" },
+        { label: "No message" },
+        { message: "No label" },
+        { type: "webhook", label: "Unknown type" },
+        "not an object",
+      ])
+    ).toEqual({
+      buttons: [
+        { type: "message", label: "Ask more", message: "Tell me more" },
+      ],
+    });
+  });
+
+  it("defaults a button with no type to a message button", () => {
+    // The sender states the type, but a button without one is unambiguous
+    // when it carries a message, so it is read as such rather than dropped.
+    expect(
+      parseButtons([{ label: "Ask more", message: "Tell me more" }])
+    ).toEqual({
+      buttons: [
+        { type: "message", label: "Ask more", message: "Tell me more" },
+      ],
+    });
+  });
+
+  it("keeps a link button", () => {
+    const button = {
+      type: "link",
+      label: "Read the docs",
+      link: "https://cdn.test/docs",
+    };
+
+    expect(parseButtons([button])).toEqual({ buttons: [button] });
+  });
+
+  it.each<{ description: string; link: string }>([
+    { description: "plain http", link: "http://cdn.test/a" },
+    { description: "javascript", link: "javascript:alert(1)" },
+    { description: "a bare path", link: "/local/a" },
+    { description: "a data url", link: "data:text/html,<script>" },
+  ])("drops a link pointing at $description", ({ link }) => {
+    expect(parseButtons([{ type: "link", label: "Bad", link }])).toBeNull();
+  });
+
+  it("keeps a long link whole rather than clipping it to the text limit", () => {
+    // Signed urls run well past the text limit. Clipping one would leave its
+    // scheme intact, so it would pass the check and reach the browser as a
+    // dead link instead of being dropped.
+    const button = {
+      type: "link",
+      label: "Long",
+      link: `https://cdn.test/${"a".repeat(600)}?signature=abc`,
+    };
+
+    expect(parseButtons([button])).toEqual({ buttons: [button] });
+  });
+
+  it("drops a link longer than the url limit", () => {
+    const link = `https://cdn.test/${"a".repeat(2048)}`;
+
+    expect(parseButtons([{ type: "link", label: "Huge", link }])).toBeNull();
+  });
+
+  it("trims text and caps its length", () => {
+    const parsed = parseButtons([
+      { label: `  ${"a".repeat(600)}  `, message: " Tell me more " },
+    ]);
+
+    expect(parsed?.buttons).toEqual([
+      { type: "message", label: "a".repeat(500), message: "Tell me more" },
+    ]);
+  });
+
+  it("caps the number of buttons", () => {
+    const parsed = parseButtons(
+      Array.from({ length: 6 }, (_, i) => ({
+        label: `Label ${i}`,
+        message: `Message ${i}`,
+      }))
+    );
+
+    expect(parsed?.buttons).toHaveLength(3);
+  });
+});
+
+describe("parseButtonGroupProps", () => {
+  it.each<{ description: string; input: unknown }>([
+    { description: "null", input: null },
+    { description: "an array", input: [{ buttons: [] }] },
+    { description: "missing buttons", input: {} },
+    { description: "buttons that are not an array", input: { buttons: {} } },
+    {
+      description: "buttons that all lack a label or message",
+      input: { buttons: [{ label: "No message" }, { message: "No label" }] },
+    },
+  ])("rejects $description", ({ input }) => {
+    expect(parseButtonGroupProps(input)).toBeNull();
+  });
+});

--- a/packages/convai-widget-core/src/rich-content/validate.test.ts
+++ b/packages/convai-widget-core/src/rich-content/validate.test.ts
@@ -32,6 +32,24 @@ describe("button parsing", () => {
     });
   });
 
+  it("reads an explicitly null type as a message button", () => {
+    // Absent optional fields serialize to null, not undefined, so a null type
+    // has to be treated the same as a missing one.
+    expect(
+      parseButtons([{ type: null, label: "Ask more", message: "Tell me more" }])
+    ).toEqual({
+      buttons: [
+        { type: "message", label: "Ask more", message: "Tell me more" },
+      ],
+    });
+  });
+
+  it("drops a label that is not a finite number", () => {
+    expect(
+      parseButtons([{ label: Infinity, message: "Tell me more" }])
+    ).toBeNull();
+  });
+
   it("keeps a link button", () => {
     const button = {
       type: "link",

--- a/packages/convai-widget-core/src/rich-content/validate.ts
+++ b/packages/convai-widget-core/src/rich-content/validate.ts
@@ -1,0 +1,76 @@
+import type { ButtonGroupProps, RichContentButton } from "./ButtonGroup";
+
+const MAX_BUTTONS = 3;
+const MAX_TEXT_LENGTH = 500;
+const MAX_URL_LENGTH = 2048;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseText(value: unknown): string | undefined {
+  let text: string;
+  if (typeof value === "string") {
+    text = value;
+  } else if (typeof value === "number" && Number.isFinite(value)) {
+    text = String(value);
+  } else {
+    return undefined;
+  }
+
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, MAX_TEXT_LENGTH);
+}
+
+function isHttpsUrl(raw: string): boolean {
+  return /^https:\/\//i.test(raw);
+}
+
+function parseLink(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const raw = value.trim();
+  if (!raw || raw.length > MAX_URL_LENGTH) return undefined;
+  return isHttpsUrl(raw) ? raw : undefined;
+}
+
+function parseButton(
+  item: Record<string, unknown>
+): RichContentButton | undefined {
+  const label = parseText(item.label);
+  if (!label) return undefined;
+
+  const type = item.type ?? "message";
+  if (type === "link") {
+    const link = parseLink(item.link);
+    return link ? { type: "link", label, link } : undefined;
+  }
+  if (type === "message") {
+    const message = parseText(item.message);
+    return message ? { type: "message", label, message } : undefined;
+  }
+  return undefined;
+}
+
+function parseButtons(value: unknown): RichContentButton[] {
+  if (!Array.isArray(value)) return [];
+
+  const buttons: RichContentButton[] = [];
+  for (const item of value) {
+    if (buttons.length >= MAX_BUTTONS) break;
+    if (!isRecord(item)) continue;
+
+    const button = parseButton(item);
+    if (button) buttons.push(button);
+  }
+  return buttons;
+}
+
+export function parseButtonGroupProps(value: unknown): ButtonGroupProps | null {
+  if (!isRecord(value)) return null;
+
+  const buttons = parseButtons(value.buttons);
+  if (buttons.length === 0) return null;
+
+  return { buttons };
+}

--- a/packages/convai-widget-core/src/rich-content/validate.ts
+++ b/packages/convai-widget-core/src/rich-content/validate.ts
@@ -1,76 +1,66 @@
+import * as z from "zod/mini";
 import type { ButtonGroupProps, RichContentButton } from "./ButtonGroup";
 
 const MAX_BUTTONS = 3;
 const MAX_TEXT_LENGTH = 500;
 const MAX_URL_LENGTH = 2048;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+const Text = z.pipe(
+  z.pipe(
+    z.union([z.string(), z.number()]),
+    z.transform(value => String(value).trim())
+  ),
+  z.string().check(
+    z.minLength(1),
+    z.overwrite(text => text.slice(0, MAX_TEXT_LENGTH))
+  )
+);
 
-function parseText(value: unknown): string | undefined {
-  let text: string;
-  if (typeof value === "string") {
-    text = value;
-  } else if (typeof value === "number" && Number.isFinite(value)) {
-    text = String(value);
-  } else {
-    return undefined;
-  }
+const Link = z.pipe(
+  z.pipe(
+    z.string(),
+    z.transform(value => value.trim())
+  ),
+  z.string().check(z.maxLength(MAX_URL_LENGTH), z.regex(/^https:\/\//i))
+);
 
-  const trimmed = text.trim();
-  if (!trimmed) return undefined;
-  return trimmed.slice(0, MAX_TEXT_LENGTH);
-}
+const MessageButton = z.pipe(
+  z.object({
+    type: z.nullish(z.literal("message")),
+    label: Text,
+    message: Text,
+  }),
+  z.transform(
+    (button): RichContentButton => ({
+      type: "message",
+      label: button.label,
+      message: button.message,
+    })
+  )
+);
 
-function isHttpsUrl(raw: string): boolean {
-  return /^https:\/\//i.test(raw);
-}
+const LinkButton = z.object({
+  type: z.literal("link"),
+  label: Text,
+  link: Link,
+});
 
-function parseLink(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const raw = value.trim();
-  if (!raw || raw.length > MAX_URL_LENGTH) return undefined;
-  return isHttpsUrl(raw) ? raw : undefined;
-}
-
-function parseButton(
-  item: Record<string, unknown>
-): RichContentButton | undefined {
-  const label = parseText(item.label);
-  if (!label) return undefined;
-
-  const type = item.type ?? "message";
-  if (type === "link") {
-    const link = parseLink(item.link);
-    return link ? { type: "link", label, link } : undefined;
-  }
-  if (type === "message") {
-    const message = parseText(item.message);
-    return message ? { type: "message", label, message } : undefined;
-  }
-  return undefined;
-}
-
-function parseButtons(value: unknown): RichContentButton[] {
-  if (!Array.isArray(value)) return [];
-
-  const buttons: RichContentButton[] = [];
-  for (const item of value) {
-    if (buttons.length >= MAX_BUTTONS) break;
-    if (!isRecord(item)) continue;
-
-    const button = parseButton(item);
-    if (button) buttons.push(button);
-  }
-  return buttons;
-}
+const Button = z.union([MessageButton, LinkButton]);
 
 export function parseButtonGroupProps(value: unknown): ButtonGroupProps | null {
-  if (!isRecord(value)) return null;
+  const parsed = z.safeParse(
+    z.object({ buttons: z.array(z.unknown()) }),
+    value
+  );
+  if (!parsed.success) return null;
 
-  const buttons = parseButtons(value.buttons);
-  if (buttons.length === 0) return null;
+  const buttons: RichContentButton[] = [];
+  for (const item of parsed.data.buttons) {
+    if (buttons.length >= MAX_BUTTONS) break;
 
-  return { buttons };
+    const button = z.safeParse(Button, item);
+    if (button.success) buttons.push(button.data);
+  }
+
+  return buttons.length > 0 ? { buttons } : null;
 }

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -156,6 +156,7 @@ export const DefaultTextContents = {
   file_too_large: "File size exceeds the maximum limit.",
   file_limit_reached: "Maximum number of files for this conversation reached.",
   typing_indicator: "Agent is typing ...",
+  rich_content_unavailable: "This content could not be displayed",
 };
 
 export const TextKeys = Object.keys(

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -50,6 +50,20 @@ function toolRes(
   };
 }
 
+function richContent(
+  id = "buttons_1",
+  opts: { eventId?: number } = {}
+): Extract<TranscriptEntry, { type: "rich_content" }> {
+  return {
+    type: "rich_content",
+    component: "buttons",
+    props: { buttons: [{ label: id, message: id }] },
+    conversationIndex: 0,
+    eventId: opts.eventId ?? 2,
+    richContentId: `rc_${id}`,
+  };
+}
+
 /** Default config — no status, transcript enabled */
 const defaults: DisplayTranscriptConfig = {
   showAgentStatus: false,
@@ -580,6 +594,119 @@ describe("buildDisplayTranscript", () => {
         type: "typing_indicator",
         conversationIndex: 0,
       });
+    });
+  });
+
+  describe("rich content", () => {
+    it("keeps components where they arrived, in arrival order", () => {
+      const input = [
+        msg("user", "show me some options"),
+        msg("agent", "Two options", { eventId: 2 }),
+        richContent("a"),
+        richContent("b"),
+        msg("user", "thanks"),
+        msg("agent", "Anything else?", { eventId: 4 }),
+      ];
+      const result = build(input);
+
+      expect(result).toHaveLength(6);
+      expect(result[1]).toMatchObject({ message: "Two options" });
+      expect(result[2]).toMatchObject({ richContentId: "rc_a" });
+      expect(result[3]).toMatchObject({ richContentId: "rc_b" });
+      expect(result[4]).toMatchObject({ message: "thanks" });
+      expect(result[5]).toMatchObject({ message: "Anything else?" });
+    });
+
+    it("keeps a component above the reply even when a placeholder precedes it", () => {
+      // The placeholder survives only because it carries the status badge.
+      const input = [
+        msg("agent", "", { eventId: 2 }),
+        toolReq(2),
+        toolRes(2),
+        richContent(),
+        msg("agent", "Here you go", { eventId: 2 }),
+      ];
+      const result = build(input, { showAgentStatus: true });
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toMatchObject({ message: "", toolStatus: "success" });
+      expect(result[1]).toMatchObject({ type: "rich_content" });
+      expect(result[2]).toMatchObject({ message: "Here you go" });
+    });
+
+    it("drops the placeholder a component follows when there is no badge", () => {
+      // With no status to show, nothing keeps the empty placeholder.
+      const input = [
+        msg("agent", "", { eventId: 2 }),
+        richContent(),
+        msg("agent", "Here you go", { eventId: 2 }),
+      ];
+      const result = build(input);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ type: "rich_content" });
+      expect(result[1]).toMatchObject({ message: "Here you go" });
+    });
+
+    it("places components above the reply for a real captured turn", () => {
+      // Replays the order the backend produces: empty text windows while the
+      // model calls the tool, a component per call, then the reply that
+      // introduces them.
+      const input = [
+        msg("user", "show me some options"),
+        msg("agent", "", { eventId: 2 }),
+        toolRes(2),
+        msg("agent", "", { eventId: 2 }),
+        richContent("a", { eventId: 2 }),
+        toolRes(2),
+        richContent("b", { eventId: 2 }),
+        toolRes(2),
+        msg("agent", "Here are some options.", { eventId: 2 }),
+      ];
+
+      for (const showAgentStatus of [false, true]) {
+        const result = build(input, { showAgentStatus });
+
+        expect(result).toHaveLength(4);
+        expect(result[0]).toMatchObject({ role: "user" });
+        expect(result[1]).toMatchObject({ richContentId: "rc_a" });
+        expect(result[2]).toMatchObject({ richContentId: "rc_b" });
+        expect(result[3]).toMatchObject({ message: "Here are some options." });
+      }
+    });
+
+    it("leaves the tool status badge on the first bubble of the turn", () => {
+      const input = [
+        msg("agent", "Running the tool now.", { eventId: 2 }),
+        toolReq(2),
+        toolRes(2),
+        richContent(),
+        msg("agent", "Tool completed successfully", { eventId: 2 }),
+      ];
+      const result = build(input, { showAgentStatus: true });
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toMatchObject({
+        message: "Running the tool now.",
+        toolStatus: "success",
+      });
+      expect(result[1]).toMatchObject({ type: "rich_content" });
+      expect(result[2]).toMatchObject({
+        message: "Tool completed successfully",
+      });
+      expect(result[2]).not.toHaveProperty("toolStatus");
+    });
+
+    it("places a component before an appended typing indicator", () => {
+      const input = [
+        msg("agent", "Here you go", { eventId: 2 }),
+        richContent(),
+      ];
+      const result = build(input, { showTypingIndicator: true });
+
+      expect(result).toHaveLength(3);
+      expect(result[1]).toMatchObject({ type: "rich_content" });
+      expect(result[2]).toMatchObject({ type: "typing_indicator" });
     });
   });
 });

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -44,6 +44,14 @@ export type DisplayTranscriptEntry =
   | {
       type: "typing_indicator";
       conversationIndex: number;
+    }
+  | {
+      type: "rich_content";
+      component: string;
+      props: unknown;
+      conversationIndex: number;
+      eventId: number;
+      richContentId: string;
     };
 
 export interface DisplayTranscriptConfig {

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -19,6 +19,7 @@ import { stripAudioTags } from "../utils/stripAudioTags";
 import { WidgetStreamdown } from "../markdown";
 import { isImageMimeType } from "./useFileUpload";
 import { ShimmeringText } from "../components/ShimmeringText";
+import { RichContentRenderer } from "../rich-content/RichContentRenderer";
 
 interface TranscriptMessageProps {
   entry: DisplayTranscriptEntry;
@@ -275,6 +276,18 @@ function TypingIndicatorMessage() {
   );
 }
 
+function RichContentMessage({
+  entry,
+}: {
+  entry: Extract<DisplayTranscriptEntry, { type: "rich_content" }>;
+}) {
+  return (
+    <div className="pe-8">
+      <RichContentRenderer component={entry.component} props={entry.props} />
+    </div>
+  );
+}
+
 function getMessageComponent(entry: DisplayTranscriptEntry) {
   if (entry.type === "disconnection") {
     return <DisconnectionMessage entry={entry} />;
@@ -287,6 +300,9 @@ function getMessageComponent(entry: DisplayTranscriptEntry) {
   }
   if (entry.type === "typing_indicator") {
     return <TypingIndicatorMessage />;
+  }
+  if (entry.type === "rich_content") {
+    return <RichContentMessage entry={entry} />;
   }
   if (entry.role === "agent") {
     return <AgentMessageBubble entry={entry} />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.10.5
@@ -9749,10 +9752,10 @@ packages:
     engines: {node: '>=14.16'}
 
   npm-bundled@1.1.2:
-    resolution: {integrity: sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==}
+    resolution: {integrity: sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==, tarball: https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz}
 
   npm-bundled@2.0.1:
-    resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
+    resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==, tarball: https://registry.npmjs.org/npm-bundled/-/npm-bundled-2.0.1.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   npm-bundled@5.0.0:
@@ -9760,11 +9763,11 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-install-checks@5.0.0:
-    resolution: {integrity: sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==}
+    resolution: {integrity: sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==, tarball: https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-5.0.0.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   npm-install-checks@6.3.0:
-    resolution: {integrity: sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==}
+    resolution: {integrity: sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==, tarball: https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   npm-install-checks@8.0.0:
@@ -9772,14 +9775,14 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-normalize-package-bin@1.0.1:
-    resolution: {integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==}
+    resolution: {integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==, tarball: https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz}
 
   npm-normalize-package-bin@2.0.0:
-    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
+    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==, tarball: https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   npm-normalize-package-bin@3.0.1:
-    resolution: {integrity: sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==}
+    resolution: {integrity: sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==, tarball: https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   npm-normalize-package-bin@5.0.0:
@@ -9795,15 +9798,15 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-package-arg@9.1.2:
-    resolution: {integrity: sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==}
+    resolution: {integrity: sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==, tarball: https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.1.2.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   npm-packlist@10.0.4:
-    resolution: {integrity: sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==}
+    resolution: {integrity: sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==, tarball: https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-packlist@5.1.3:
-    resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
+    resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==, tarball: https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.1.3.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     hasBin: true
 
@@ -9812,15 +9815,15 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-pick-manifest@7.0.2:
-    resolution: {integrity: sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==}
+    resolution: {integrity: sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==, tarball: https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-7.0.2.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   npm-pick-manifest@9.1.0:
-    resolution: {integrity: sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==}
+    resolution: {integrity: sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==, tarball: https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz}
     engines: {node: ^16.14.0 || >=18.0.0}
 
   npm-registry-fetch@13.3.1:
-    resolution: {integrity: sha512-eukJPi++DKRTjSBRcDZSDDsGqRK3ehbxfFUcgaRd0Yp6kRwOwh2WVn0r+8rMB4nnuzvAk6rQVzl6K5CkYOmnvw==}
+    resolution: {integrity: sha512-eukJPi++DKRTjSBRcDZSDDsGqRK3ehbxfFUcgaRd0Yp6kRwOwh2WVn0r+8rMB4nnuzvAk6rQVzl6K5CkYOmnvw==, tarball: https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-13.3.1.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   npm-registry-fetch@19.1.1:
@@ -9978,7 +9981,7 @@ packages:
       - which
 
   npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==, tarball: https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 


### PR DESCRIPTION
Adds the widget-side consumer of the `onRichContent` SDK callback (#912). Adds rich content rendering to the chat widget. The agent can display components inline in the transcript starting with quick reply buttons. It's inert on merge, since nothing on the server emits the event yet.

Starting with buttons rather than cards, for two reasons:
- ButtonGroup is the primitive other components build on. A card or carousel renders its own buttons through the same component.
- Going through the customer analysis, clickable links and guided options came up far more often than product cards.

<img width="405" height="555" alt="Screenshot 2026-08-12 at 2 39 13 PM" src="https://github.com/user-attachments/assets/8f48f2df-7c8b-4931-8062-bfcb839d7289" />

## Button types

| Type | Behaviour |
|---|---|
| `message` | Sends its text as the user's own turn |
| `link` | Opens its url in a new tab |

Max 3 buttons per row. Buttons that can run actions directly to follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New user-facing transcript paths and outbound links/message sends, mitigated by strict https-only link validation and safe fallbacks for bad payloads.
> 
> **Overview**
> Adds **inline rich content** in the convai widget transcript, wired from the SDK **`onRichContent`** callback into new **`rich_content`** transcript entries and display rows.
> 
> The first supported component is **`buttons`**: **message** buttons call **`sendUserMessage`** with the payload text; **link** buttons use an extended **`Button`** (`as="a"`, **`outline`**, `target="_blank"`). Props are validated with **`zod/mini`** (caps, trimming, **https-only** links); unknown or invalid payloads show **`rich_content_unavailable`** instead of breaking the UI.
> 
> Display transcript behavior is covered by new tests so rich content stays in **arrival order** relative to agent replies, tool-status placeholders, and the typing indicator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73cdfb92f79f3344ad538df3527bf22019ba53fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->