### PR TITLE
feat(connection): add handlers to monitor incoming/outgoing messages

### DIFF
--- a/examples/agent-testbench/src/components/agent-page.tsx
+++ b/examples/agent-testbench/src/components/agent-page.tsx
@@ -40,6 +40,8 @@ const EVENT_METHOD_NAMES = [
   "onGuardrailTriggered",
   "onPing",
   "onDebug",
+  "onIncomingEvent",
+  "onOutgoingEvent",
 ] satisfies (keyof PartialOptions)[];
 
 export function AgentPage({ agent }: AgentPageProps) {

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -10,6 +10,7 @@ import type { BaseConnection } from "./utils/BaseConnection.js";
 const noopConnection = {
   conversationId: "test-conversation-id",
   onMessage: () => {},
+  onOutgoingMessage: () => {},
   onDisconnect: () => {},
   onModeChange: () => {},
   close: () => {},
@@ -781,6 +782,26 @@ describe("BaseConversation", () => {
       expect(onCanSendFeedbackChange).toHaveBeenLastCalledWith({
         canSendFeedback: false,
       });
+    });
+  });
+
+  describe("message events", () => {
+    it("calls onIncomingEvent with the incoming message payload", async () => {
+      const onIncomingEvent = vi.fn();
+      const conversation = TestConversation.create({
+        onIncomingEvent,
+      });
+
+      const message = {
+        type: "ping",
+        ping_event: {
+          event_id: 1,
+        },
+      } as const;
+
+      await conversation.receiveMessage(message);
+
+      expect(onIncomingEvent).toHaveBeenCalledWith(message);
     });
   });
 });

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -160,6 +160,7 @@ export abstract class BaseConversation {
     this.connection.onMessage(this.onMessage);
     this.connection.onDisconnect(this.endSessionWithDetails);
     this.connection.onModeChange(mode => this.updateMode(mode));
+    this.connection.onOutgoingMessage(this.onOutgoingMessage);
   }
 
   protected markConnected() {
@@ -471,6 +472,8 @@ export abstract class BaseConversation {
   }
 
   private onMessage = async (parsedEvent: IncomingSocketEvent) => {
+    this.options.onIncomingEvent?.(parsedEvent);
+
     switch (parsedEvent.type) {
       case "interruption": {
         this.handleInterruption(parsedEvent);
@@ -613,6 +616,10 @@ export abstract class BaseConversation {
       this.options.onError(message, context);
     }
   }
+
+  private onOutgoingMessage = (event: any) => {
+    this.options.onOutgoingEvent?.(event);
+  };
 
   public getId() {
     return this.connection.conversationId;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -157,6 +157,14 @@ export type Callbacks = {
   onPing?: (props: Ping["ping_event"]) => void;
   // internal debug events, not to be used
   onDebug?: (props: any) => void;
+  /**
+   * Called for every incoming event received from the server.
+   */
+  onIncomingEvent?: (props: any) => void;
+  /**
+   * Called for every outgoing event sent to the server.
+   */
+  onOutgoingEvent?: (props: any) => void;
 };
 
 /**
@@ -191,4 +199,6 @@ export const CALLBACK_KEYS = [
   "onExternalAgentConnected",
   "onPing",
   "onDebug",
+  "onIncomingEvent",
+  "onOutgoingEvent",
 ] as const satisfies readonly (keyof Callbacks)[];

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -25,6 +25,7 @@ export type FormatConfig = {
 
 export type OnDisconnectCallback = (details: DisconnectionDetails) => void;
 export type OnMessageCallback = (event: IncomingSocketEvent) => void;
+export type OnOutgoingMessageCallback = (event: any) => void;
 
 export type BaseSessionConfig = {
   origin?: string;
@@ -170,11 +171,13 @@ export abstract class BaseConnection {
   public abstract readonly outputFormat: FormatConfig;
 
   protected queue: IncomingSocketEvent[] = [];
+  protected outgoingQueue: OutgoingSocketEvent[] = [];
   protected disconnectionDetails: DisconnectionDetails | null = null;
   protected onDisconnectCallback: OnDisconnectCallback | null = null;
   protected onMessageCallback: OnMessageCallback | null = null;
   protected onModeChangeCallback: ((mode: Mode) => void) | null = null;
   protected onDebug?: (info: unknown) => void;
+  protected onOutgoingMessageCallback: OnOutgoingMessageCallback | null = null;
 
   constructor(config: { onDebug?: (info: unknown) => void } = {}) {
     this.onDebug = config.onDebug;
@@ -217,6 +220,20 @@ export abstract class BaseConnection {
     this.onModeChangeCallback = callback;
   }
 
+  public onOutgoingMessage(callback: OnOutgoingMessageCallback) {
+    this.onOutgoingMessageCallback = callback;
+    const queue = this.outgoingQueue;
+    this.outgoingQueue = [];
+
+    if (queue.length > 0) {
+      // Make sure the queue is flushed after the constructors finishes and
+      // classes are initialized.
+      queueMicrotask(() => {
+        queue.forEach(callback);
+      });
+    }
+  }
+
   protected updateMode(mode: Mode) {
     this.onModeChangeCallback?.(mode);
   }
@@ -233,6 +250,14 @@ export abstract class BaseConnection {
       this.onMessageCallback(parsedEvent);
     } else {
       this.queue.push(parsedEvent);
+    }
+  }
+
+  protected handleOutgoingMessage(event: any) {
+    if (this.onOutgoingMessageCallback) {
+      this.onOutgoingMessageCallback(event);
+    } else {
+      this.outgoingQueue.push(event);
     }
   }
 }

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -64,6 +64,7 @@ import { WebRTCConnection } from "./WebRTCConnection.js";
 import { Room, createLocalAudioTrack } from "livekit-client";
 import { setWebRTCAudioAdapterFactory } from "../WebRTCAudioAdapter.js";
 import { WebAudioAdapter } from "../platform/web/webAudioAdapter.js";
+import type { PongEvent } from "./events.js";
 
 describe("WebRTCConnection", () => {
   beforeEach(() => {
@@ -375,4 +376,22 @@ describe("WebRTCConnection", () => {
       }
     }
   );
+
+  it("properly reports sent messages", async () => {
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+    const message: PongEvent = {
+      type: "pong",
+      event_id: 1,
+    };
+
+    const listener = vi.fn();
+    connection.onOutgoingMessage(listener);
+    connection.sendMessage(message);
+    connection.close();
+
+    expect(listener).toHaveBeenCalledWith(message);
+  });
 });

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -518,6 +518,7 @@ export class WebRTCConnection extends BaseConnection {
       return;
     }
 
+    this.handleOutgoingMessage(message);
     try {
       const encoder = new TextEncoder();
       const data = encoder.encode(JSON.stringify(message));

--- a/packages/client/src/utils/WebSocketConnection.test.ts
+++ b/packages/client/src/utils/WebSocketConnection.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { WebSocketConnection } from "./WebSocketConnection.js";
+import type { PongEvent } from "./events.js";
 
 type EventHandler = (event: any) => void;
 
@@ -212,5 +213,20 @@ describe("WebSocketConnection", () => {
     connection.addListener(listener);
 
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("properly reports sent messages", async () => {
+    const connection = await createConnection();
+    const listener = vi.fn();
+    const message: PongEvent = {
+      type: "pong",
+      event_id: 1,
+    };
+
+    connection.onOutgoingMessage(listener);
+    connection.sendMessage(message);
+    connection.close();
+
+    expect(listener).toHaveBeenCalledWith(message);
   });
 });

--- a/packages/client/src/utils/WebSocketConnection.ts
+++ b/packages/client/src/utils/WebSocketConnection.ts
@@ -237,6 +237,7 @@ export class WebSocketConnection
   }
 
   public sendMessage(message: OutgoingSocketEvent) {
+    this.handleOutgoingMessage(message);
     this.socket.send(JSON.stringify(message));
   }
 

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -48,6 +48,8 @@ export type HookCallbacks = Pick<
   | "onAgentTyping"
   | "onExternalAgentConnected"
   | "onPing"
+  | "onIncomingEvent"
+  | "onOutgoingEvent"
 >;
 
 export type HookOptions = Partial<


### PR DESCRIPTION
Linear issue: [AWF-256](https://linear.app/elevenlabs/issue/AWF-256/add-callbacks-for-incomingoutcoming-messages-to-elevenlabsclient)

Added `onIncomingEvent` and `onOutgoingEvent` handlers that will be called every time a message is being received or being sent, regardless of the message type. This will make monitoring the payloads easier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive observability callbacks on the message path; existing dispatch and send behavior are unchanged aside from optional listener invocation.
> 
> **Overview**
> Adds **`onIncomingEvent`** and **`onOutgoingEvent`** conversation callbacks so apps can observe every socket payload without relying on type-specific handlers or `onDebug`.
> 
> **Incoming:** `BaseConversation` invokes `onIncomingEvent` with the raw parsed event before the existing `switch` dispatch, so it runs for all server messages (including ones that only hit `onDebug` today).
> 
> **Outgoing:** `BaseConnection` gains `onOutgoingMessage` with the same early-registration queue flush pattern as incoming messages. `WebSocketConnection` and `WebRTCConnection` call `handleOutgoingMessage` when `sendMessage` runs (WebRTC still skips `user_audio_chunk` on the wire, unchanged). `BaseConversation` forwards those to `onOutgoingEvent`.
> 
> The React hook surface, `CALLBACK_KEYS`, and the agent testbench event spy list include the new callbacks. Unit tests cover incoming forwarding and outgoing reporting on both transports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b85e4a62ab46aaa443452016541f396a98cb52b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->