### PR TITLE
[Widget] Fix language dropdown position

### DIFF
--- a/.changeset/lucky-moons-anchor.md
+++ b/.changeset/lucky-moons-anchor.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix the language dropdown being positioned away from its trigger when the widget is embedded inside a CSS container-query element (`container-type: inline-size`). Floating UI treats such an ancestor as a containing block for `position: fixed` descendants while browsers do not, so the dropdown was offset by the ancestor's position on the page. The widget's overlay root now establishes a containing block of its own, making the dropdown position independent of the host page's ancestor styles.

--- a/packages/convai-widget-core/src/styles/index.css
+++ b/packages/convai-widget-core/src/styles/index.css
@@ -10,6 +10,7 @@
   position: fixed;
   inset: 0;
   z-index: 1000;
+  transform: translate(0);
 
   @apply text-base-primary text-md;
   font-family:


### PR DESCRIPTION
The language dropdown rendered detached from its trigger when the widget was embedded inside a CSS container-query element. Floating UI treats a container-type ancestor as a containing block for fixed descendants while browsers don't. Adding `transform: translate(0)` to `:host` gives the widget its own containing block making the position independent of the embedding page.

Before:
<img width="362" height="187" alt="Screenshot 2026-08-13 at 11 19 08 AM" src="https://github.com/user-attachments/assets/66547cc3-7662-4ab6-93ed-0330f8c527fb" />

After:
<img width="275" height="140" alt="Screenshot 2026-08-13 at 11 19 30 AM" src="https://github.com/user-attachments/assets/857804aa-1c99-4766-9872-3d0e3d2cb287" />
