### PR TITLE
fix(client): fail WebRTC setup when the initiation payload cannot be published

### DIFF
--- a/.changeset/webrtc-required-init-publish.md
+++ b/.changeset/webrtc-required-init-publish.md
@@ -1,0 +1,15 @@
+---
+"@elevenlabs/client": patch
+---
+
+Fail WebRTC session setup when the conversation initiation payload cannot be
+published, instead of resolving onto a session the server never initialized.
+
+`WebRTCConnection.create()` sent `conversation_initiation_client_data` through
+the same best-effort path as ordinary messages, which returns early when the
+room is no longer connected and swallows a `publishData()` rejection. Setup
+could therefore succeed, and `onConnect` fire, while the room and microphone
+stayed live for a conversation that was never initialized. The mandatory
+initiation send now surfaces those failures so the existing `create()` error
+path disconnects the room and reports the failure to the caller. Mid-session
+sends remain best effort.

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -498,4 +498,109 @@ describe("WebRTCConnection", () => {
       setWebRTCAudioAdapterFactory(() => new WebAudioAdapter());
     }
   });
+
+  describe("conversation initiation payload", () => {
+    let mockRoom: any;
+
+    beforeEach(() => {
+      mockRoom = new Room() as any;
+
+      (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "signalConnected") {
+            queueMicrotask(callback);
+          }
+        }
+      );
+      (
+        mockRoom.localParticipant.getTrackPublication as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue(undefined);
+    });
+
+    it("fails setup when the initiation payload cannot be published", async () => {
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "connected") {
+            queueMicrotask(callback);
+          }
+        }
+      );
+      (
+        mockRoom.localParticipant.publishData as ReturnType<typeof vi.fn>
+      ).mockRejectedValueOnce(new Error("publish failed"));
+
+      await expect(
+        WebRTCConnection.create({
+          conversationToken: "test-token",
+          connectionType: "webrtc",
+        })
+      ).rejects.toThrow("publish failed");
+
+      // create()'s catch must tear the room down so the caller does not keep
+      // a live room and microphone for a conversation that never started.
+      expect(mockRoom.disconnect).toHaveBeenCalled();
+    });
+
+    it("fails setup when the room disconnects before the payload is sent", async () => {
+      let connectionStateChanged: ((state: string) => void) | undefined;
+
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: (state?: unknown) => void) => {
+          if (event === "connected") {
+            queueMicrotask(callback);
+          }
+          if (event === "connectionStateChanged") {
+            connectionStateChanged = callback as (state: string) => void;
+          }
+        }
+      );
+
+      // create() reads the microphone publication immediately before sending
+      // the initiation payload, so dropping the room here lands the
+      // connection in the state the send has to reject on.
+      (
+        mockRoom.localParticipant.getTrackPublication as ReturnType<
+          typeof vi.fn
+        >
+      ).mockImplementation(() => {
+        connectionStateChanged?.("disconnected");
+        return undefined;
+      });
+
+      await expect(
+        WebRTCConnection.create({
+          conversationToken: "test-token",
+          connectionType: "webrtc",
+        })
+      ).rejects.toThrow("room not connected");
+
+      expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled();
+    });
+
+    it("keeps mid-session sends best effort when publishing fails", async () => {
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "connected") {
+            queueMicrotask(callback);
+          }
+        }
+      );
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
+
+      (
+        mockRoom.localParticipant.publishData as ReturnType<typeof vi.fn>
+      ).mockRejectedValueOnce(new Error("publish failed"));
+
+      const message: PongEvent = { type: "pong", event_id: 1 };
+      await expect(connection.sendMessage(message)).resolves.toBeUndefined();
+
+      connection.close();
+    });
+  });
 });

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -364,7 +364,11 @@ export class WebRTCConnection extends BaseConnection {
         message: overridesEvent,
       });
 
-      await connection.sendMessage(overridesEvent);
+      // The conversation cannot start without this payload, so a failed
+      // publish has to fail setup. Otherwise create() resolves onto a live
+      // room and microphone that the server never initialized a conversation
+      // for, and the caller reports a connected session that can never speak.
+      await connection.sendRequiredMessage(overridesEvent);
 
       return connection;
     } catch (error) {
@@ -530,10 +534,7 @@ export class WebRTCConnection extends BaseConnection {
 
     this.handleOutgoingMessage(message);
     try {
-      const encoder = new TextEncoder();
-      const data = encoder.encode(JSON.stringify(message));
-
-      await this.room.localParticipant.publishData(data, { reliable: true });
+      await this.publishMessage(message);
     } catch (error) {
       this.debug({
         type: "send_message_error",
@@ -544,6 +545,28 @@ export class WebRTCConnection extends BaseConnection {
       });
       console.error("Failed to send message via WebRTC:", error);
     }
+  }
+
+  /**
+   * Sends a message the session cannot proceed without, surfacing failures to
+   * the caller instead of absorbing them the way {@link sendMessage} does.
+   */
+  private async sendRequiredMessage(message: OutgoingSocketEvent) {
+    if (!this.isConnected || !this.room.localParticipant) {
+      throw new Error(
+        "Cannot send message: room not connected or no local participant"
+      );
+    }
+
+    this.handleOutgoingMessage(message);
+    await this.publishMessage(message);
+  }
+
+  private async publishMessage(message: OutgoingSocketEvent) {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(JSON.stringify(message));
+
+    await this.room.localParticipant.publishData(data, { reliable: true });
   }
 
   // Get the room instance for advanced usage


### PR DESCRIPTION
Fixes #916.

## Problem

`WebRTCConnection.create()` sends the mandatory `conversation_initiation_client_data` through `sendMessage()`, which is best effort in two ways:

- it returns early, with only a `console.warn`, when the room is no longer connected
- it catches and swallows a `localParticipant.publishData()` rejection

Either case lets `create()` resolve. `Conversation.startSession()` then fires `onConnect` and the caller reports a connected session, while the LiveKit room and the microphone stay live for a conversation the server never initialized — audible to the user as a session that connects and then never speaks.

## Fix

Send the initiation payload through a path that surfaces those failures instead of absorbing them. `create()`'s existing `catch` already calls `room.disconnect()` and rethrows, so the caller's normal connection-error handling recovers with no new error plumbing.

Ordinary mid-session sends are unchanged and stay best effort — that distinction is the point, so it has its own test.

## Tests

Three added to `WebRTCConnection.test.ts`, driving the mocked LiveKit `Room` so connect and mic setup succeed and only the initiation send fails:

| Test | Without this change |
|---|---|
| `fails setup when the initiation payload cannot be published` | fails — `create()` resolves |
| `fails setup when the room disconnects before the payload is sent` | fails — `create()` resolves |
| `keeps mid-session sends best effort when publishing fails` | passes — guards against over-fixing |

The first also asserts `room.disconnect()` ran, so a failed setup cannot leave the room and microphone live.

Full `@elevenlabs/client` suite: 182 passing (179 before). `lint:es`, `lint:prettier` and `tsc --build` clean. Changeset included per `agents.md`.

## Note

No conflict with #934, which is also in this file — it changes `room.connect()` around line 318, while this touches the initiation send and `sendMessage`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebRTC session bootstrap and connection error semantics; behavior change is intentional but affects when callers see connected vs failed sessions.
> 
> **Overview**
> **WebRTC `create()` no longer reports success when mandatory `conversation_initiation_client_data` never reaches the server.** That payload is sent through `sendRequiredMessage()` instead of best-effort `sendMessage()`, so a disconnected room or a failed `publishData()` rejects setup and flows through the existing `catch` that calls `room.disconnect()` and rethrows.
> 
> Ordinary mid-session data messages still use `sendMessage()` (warn/return or log and swallow errors). Publishing is factored into shared `publishMessage()` used by both paths.
> 
> Tests cover publish failure during setup (including `disconnect`), disconnect before send without calling `publishData`, and unchanged best-effort behavior after a successful `create()`. Patch changeset for `@elevenlabs/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4eec6b2d562e04a3db421596968c60e63d647fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
