### PR TITLE
fix(scribe): let a microphone-setup failure be retried

### DIFF
--- a/.changeset/scribe-retry-after-mic-failure.md
+++ b/.changeset/scribe-retry-after-mic-failure.md
@@ -1,0 +1,21 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react": patch
+---
+
+Fix a microphone-setup failure wedging `useScribe`, so a denied or dismissed
+permission prompt can be retried without remounting.
+
+A microphone-mode session whose `getUserMedia` call rejects can never send
+audio, but the socket was left open holding that session. `useScribe` kept its
+connection ref, and every later `connect()` short-circuited on `"Already
+connected"`. The failed setup now closes the connection, which releases the
+stranded socket and lets the hook's existing close handling clear the ref.
+`onError` still fires first; the session then ends as `disconnected` with the
+error preserved.
+
+The hook's close handler also nulled its ref for whichever connection reported
+a close, so a late close from a replaced socket tore down the session that had
+replaced it — the race a consumer hit when working around the above with
+disconnect-then-reconnect. A close is now ignored when a newer connection owns
+the ref, while an explicit `disconnect()` still reports normally.

--- a/packages/client/src/scribe/scribe.test.ts
+++ b/packages/client/src/scribe/scribe.test.ts
@@ -1077,6 +1077,42 @@ describe("Scribe", () => {
       server.close();
     });
 
+    it("closes the connection when microphone setup fails", async () => {
+      setScribeMicrophoneSetup(
+        vi.fn(() => Promise.reject(new Error("Permission denied")))
+      );
+
+      const server = new Server(
+        "wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id=scribe_v2_realtime&token=sutkn_123"
+      );
+      onTestFinished(() => server.close());
+      const clientPromise = new Promise<Client>((resolve, reject) => {
+        server.on("connection", socket => resolve(socket));
+        server.on("error", reject);
+        setTimeout(() => reject(new Error("timeout")), 5000);
+      });
+
+      const connection = Scribe.connect({
+        token: TEST_TOKEN,
+        modelId: TEST_MODEL_ID,
+        microphone: {},
+      });
+
+      const onError = vi.fn();
+      const onClose = vi.fn();
+      connection.on(RealtimeEvents.ERROR, onError);
+      connection.on(RealtimeEvents.CLOSE, onClose);
+
+      await clientPromise;
+      await sleep(100);
+
+      expect(onError).toHaveBeenCalledTimes(1);
+
+      // Without a microphone the session can only ever be silent, so the
+      // socket must not be left open holding it.
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
     it("forwards workletPaths.scribeAudioProcessor to the registered microphone setup", async () => {
       const mockTrack = { enabled: true } as MediaStreamTrack;
       const cleanup = vi.fn();

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -312,6 +312,13 @@ export class ScribeRealtime {
     } catch (error) {
       console.error("Failed to start microphone streaming:", error);
       connection._emitError(error);
+
+      // A microphone-mode session that never acquired a microphone can never
+      // send audio, so the socket is stranded: it holds a session open that
+      // will only ever be silent. Close it so the failure ends the connection
+      // the way any other terminal one does, and consumers tracking CLOSE can
+      // start a fresh session instead of waiting on this one.
+      connection.close();
     }
   }
 }

--- a/packages/react/src/scribe.test.tsx
+++ b/packages/react/src/scribe.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AudioFormat, Scribe } from "@elevenlabs/client";
+import { AudioFormat, RealtimeEvents, Scribe } from "@elevenlabs/client";
 import type { RealtimeConnection } from "@elevenlabs/client";
 import { useScribe } from "./scribe.js";
 
@@ -110,5 +110,77 @@ describe("useScribe", () => {
         enableLogging: false,
       })
     );
+  });
+
+  describe("close handling", () => {
+    const SESSION = {
+      token: "test-token",
+      modelId: "scribe_v2_realtime",
+      microphone: {},
+    };
+
+    function closeHandlerFor(connection: RealtimeConnection) {
+      return vi
+        .mocked(connection.on)
+        .mock.calls.find(([event]) => event === RealtimeEvents.CLOSE)?.[1] as
+        | (() => void)
+        | undefined;
+    }
+
+    it("ignores a close from a connection that has been replaced", async () => {
+      const first = createMockConnection();
+      const second = createMockConnection();
+      vi.mocked(Scribe.connect)
+        .mockReturnValueOnce(first)
+        .mockReturnValueOnce(second);
+
+      const onDisconnect = vi.fn();
+      const { result } = renderHook(() => useScribe({ onDisconnect }));
+
+      await act(async () => {
+        await result.current.connect(SESSION);
+      });
+      act(() => {
+        result.current.disconnect();
+      });
+      await act(async () => {
+        await result.current.connect(SESSION);
+      });
+
+      expect(Scribe.connect).toHaveBeenCalledTimes(2);
+
+      // The replaced socket only closes now. It must not tear down the
+      // session that took its place.
+      act(() => {
+        closeHandlerFor(first)?.();
+      });
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+      expect(result.current.status).not.toBe("disconnected");
+    });
+
+    it("still reports a close for the current connection after disconnect()", async () => {
+      const connection = createMockConnection();
+      vi.mocked(Scribe.connect).mockReturnValue(connection);
+
+      const onDisconnect = vi.fn();
+      const { result } = renderHook(() => useScribe({ onDisconnect }));
+
+      await act(async () => {
+        await result.current.connect(SESSION);
+      });
+
+      // disconnect() releases the ref before the socket's close arrives, so
+      // the close still belongs to this session.
+      act(() => {
+        result.current.disconnect();
+      });
+      act(() => {
+        closeHandlerFor(connection)?.();
+      });
+
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      expect(result.current.status).toBe("disconnected");
+    });
   });
 });

--- a/packages/react/src/scribe.ts
+++ b/packages/react/src/scribe.ts
@@ -477,6 +477,13 @@ export function useScribe(options: ScribeHookOptions = {}): UseScribeReturn {
         });
 
         connection.on(RealtimeEvents.CLOSE, () => {
+          // A socket that has already been replaced must not tear down the
+          // session that replaced it. A null ref still runs: disconnect()
+          // clears it before this fires, and that close is this session's.
+          if (connectionRef.current && connectionRef.current !== connection) {
+            return;
+          }
+
           setStatus("disconnected");
           setIsMuted(false);
           connectionRef.current = null;


### PR DESCRIPTION
Fixes #938.

## Problem

When `getUserMedia` rejects (user denies or dismisses the permission prompt), `ScribeRealtime.streamFromMicrophone` emits the error but leaves the socket open. A microphone-mode session that never acquired a microphone can only ever be silent, so that socket is stranded holding a session that will never produce audio.

`useScribe` keeps `connectionRef.current` pointing at it, and every later `connect()` short-circuits on `console.warn("Already connected")`. The consuming app's mic UI stays wedged until a full unmount.

## Fix

**`packages/client` — close the connection on that terminal failure.** This is the root cause: it releases the stranded socket, and the hook's existing `CLOSE` handling already clears the ref, so a retry works with no new hook state. `onError` still fires first, so consumers keep the error they get today.

I deliberately did **not** clear the ref from the hook's `ERROR` handler as the issue suggests. `RealtimeEvents.ERROR` is also emitted for recoverable conditions — `commit_throttled`, `rate_limited`, `queue_overflow`, `input_error` — so releasing the ref there would orphan a live, healthy socket and let a second one open alongside it. Closing at the one site that is genuinely terminal keeps `ERROR` semantics untouched.

**`packages/react` — guard the `CLOSE` handler.** It nulled `connectionRef.current` for whichever connection reported a close, without checking that connection was still the current one, so a late close from a replaced socket tore down the session that replaced it. That is exactly the race a consumer hits working around the wedge with disconnect-then-reconnect.

The guard is `if (connectionRef.current && connectionRef.current !== connection) return;` rather than a plain `!==`. `disconnect()` releases the ref synchronously, before the socket's close arrives, so a plain `!==` would swallow `onDisconnect` on the ordinary disconnect path. The null case has to keep running.

## Behaviour change worth a ruling

A microphone-setup failure now ends as `status: "disconnected"` with `error` populated, where it previously stopped at `"error"` with the socket still open. `onError` fires first either way. That reads correct to me — the session really is over — but it is a visible change, so flagging it rather than burying it.

## Tests

| Test | Package | Without this change |
|---|---|---|
| `closes the connection when microphone setup fails` | client | fails — `CLOSE` never fires |
| `ignores a close from a connection that has been replaced` | react | fails — stale close calls `onDisconnect` |
| `still reports a close for the current connection after disconnect()` | react | fails against a plain `!==` guard |

The third exists specifically to pin the `connectionRef.current &&` clause; I verified it fails when that clause is dropped.

Full suites: `@elevenlabs/client` 180 passing (179 before), `@elevenlabs/react` 140 passing (138 before). `lint:es`, `lint:prettier` and `check-types` clean. Changeset included per `agents.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time connection lifecycle and hook status transitions on mic failure and reconnect races; behavior is intentional but visible to consumers tracking status vs errors.
> 
> **Overview**
> Fixes **`useScribe`** getting stuck after a denied or dismissed mic permission prompt, so **`connect()`** can be retried without remounting.
> 
> In **`@elevenlabs/client`**, when microphone setup fails (`getUserMedia` rejects), the client still emitted **`onError`** but left the WebSocket open. **`useScribe`** kept **`connectionRef`**, so later **`connect()`** hit **"Already connected"**. The client now **`close()`**s the connection after the error so the session ends and the hook’s existing **`CLOSE`** handling clears the ref.
> 
> In **`@elevenlabs/react`**, the **`CLOSE`** handler cleared state for any connection that closed, so a **late close from a replaced socket** (e.g. disconnect then reconnect) could tear down the active session. Closes are ignored when **`connectionRef`** points at a newer connection; **`disconnect()`** still runs teardown when the ref is already null.
> 
> **Visible behavior:** a mic-setup failure now tends to end as **`disconnected`** with **`error`** set (after **`onError`**), not **`error`** with an open socket. Tests cover mic-failure close, stale-close ignore, and post-**`disconnect()`** close handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93744972d8c8ae75e012567e9d41b5d3cfdb78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
