### PR TITLE
fix(client): pass workletPaths through on the WebRTC connection path

### DIFF
--- a/.changeset/webrtc-worklet-paths.md
+++ b/.changeset/webrtc-worklet-paths.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Pass `workletPaths` through on the WebRTC connection path, so self-hosted AudioWorklet files are used for output capture instead of falling back to `blob:`/`data:` URLs under a strict CSP.

--- a/packages/client/src/WebRTCAudioAdapter.ts
+++ b/packages/client/src/WebRTCAudioAdapter.ts
@@ -1,4 +1,5 @@
 import type { RemoteAudioTrack } from "livekit-client";
+import type { AudioWorkletConfig } from "./BaseConversation.js";
 import type { FormatConfig } from "./utils/BaseConnection.js";
 import type { VolumeProvider } from "./utils/volumeProvider.js";
 
@@ -39,11 +40,14 @@ export interface WebRTCAudioAdapter {
   /**
    * Set up output volume analysis and raw audio capture from a remote track.
    * @param onAudioData Called with captured audio data for the `onAudio` callback.
+   * @param workletPaths Optional self-hosted worklet paths, so implementations
+   * that load an AudioWorklet can avoid `blob:`/`data:` URLs under a strict CSP.
    */
   setupOutputAnalysis(
     track: RemoteAudioTrack,
     format: FormatConfig,
-    onAudioData: (audioData: ArrayBuffer, maxVolume: number) => void
+    onAudioData: (audioData: ArrayBuffer, maxVolume: number) => void,
+    workletPaths?: AudioWorkletConfig["workletPaths"]
   ): Promise<AnalysisResult>;
 
   /** Set playback volume (0-1) for all managed audio elements. */

--- a/packages/client/src/platform/web/webAudioAdapter.test.ts
+++ b/packages/client/src/platform/web/webAudioAdapter.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./rawAudioProcessor.generated.js", () => ({
+  loadRawAudioProcessor: vi.fn(),
+}));
+
+import type { RemoteAudioTrack } from "livekit-client";
+import type { FormatConfig } from "../../utils/BaseConnection.js";
+import { loadRawAudioProcessor } from "./rawAudioProcessor.generated.js";
+import { WebAudioAdapter } from "./webAudioAdapter.js";
+
+const OUTPUT_FORMAT: FormatConfig = { format: "pcm", sampleRate: 48000 };
+
+function installAudioEnvironment() {
+  const analyser = {
+    fftSize: 0,
+    smoothingTimeConstant: 0,
+    frequencyBinCount: 1024,
+    connect: vi.fn(),
+    getByteFrequencyData: vi.fn(),
+  };
+  const source = { connect: vi.fn() };
+  const worklet = {
+    port: {
+      onmessage: null,
+      postMessage: vi.fn(),
+    },
+  };
+  const audioContext = {
+    audioWorklet: {},
+    close: vi.fn().mockResolvedValue(undefined),
+    createAnalyser: vi.fn(() => analyser),
+    createMediaStreamSource: vi.fn(() => source),
+    sampleRate: 48000,
+  };
+
+  vi.stubGlobal(
+    "AudioContext",
+    vi.fn(function MockAudioContext() {
+      return audioContext;
+    })
+  );
+  vi.stubGlobal(
+    "MediaStream",
+    vi.fn(function MockMediaStream() {
+      return {};
+    })
+  );
+  vi.stubGlobal(
+    "AudioWorkletNode",
+    vi.fn(function MockAudioWorkletNode() {
+      return worklet;
+    })
+  );
+
+  return { analyser, audioContext, source, worklet };
+}
+
+const track = { mediaStreamTrack: {} } as unknown as RemoteAudioTrack;
+
+describe("WebAudioAdapter.setupOutputAnalysis", () => {
+  afterEach(() => {
+    vi.mocked(loadRawAudioProcessor).mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards a custom workletPaths.rawAudioProcessor to the loader", async () => {
+    installAudioEnvironment();
+    vi.mocked(loadRawAudioProcessor).mockResolvedValueOnce(undefined);
+
+    await new WebAudioAdapter().setupOutputAnalysis(
+      track,
+      OUTPUT_FORMAT,
+      vi.fn(),
+      { rawAudioProcessor: "/vendor/raw-audio-processor.js" }
+    );
+
+    expect(loadRawAudioProcessor).toHaveBeenCalledWith(
+      expect.anything(),
+      "/vendor/raw-audio-processor.js"
+    );
+  });
+
+  it("passes undefined to the loader when no workletPaths are provided", async () => {
+    installAudioEnvironment();
+    vi.mocked(loadRawAudioProcessor).mockResolvedValueOnce(undefined);
+
+    await new WebAudioAdapter().setupOutputAnalysis(
+      track,
+      OUTPUT_FORMAT,
+      vi.fn()
+    );
+
+    expect(loadRawAudioProcessor).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined
+    );
+  });
+
+  it("passes undefined when workletPaths carries only unrelated processors", async () => {
+    installAudioEnvironment();
+    vi.mocked(loadRawAudioProcessor).mockResolvedValueOnce(undefined);
+
+    await new WebAudioAdapter().setupOutputAnalysis(
+      track,
+      OUTPUT_FORMAT,
+      vi.fn(),
+      { audioConcatProcessor: "/vendor/audio-concat-processor.js" }
+    );
+
+    expect(loadRawAudioProcessor).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined
+    );
+  });
+
+  it("still wires the capture graph when a custom worklet path is used", async () => {
+    const { analyser, source, worklet } = installAudioEnvironment();
+    vi.mocked(loadRawAudioProcessor).mockResolvedValueOnce(undefined);
+
+    const result = await new WebAudioAdapter().setupOutputAnalysis(
+      track,
+      OUTPUT_FORMAT,
+      vi.fn(),
+      { rawAudioProcessor: "/vendor/raw-audio-processor.js" }
+    );
+
+    expect(source.connect).toHaveBeenCalledWith(analyser);
+    expect(analyser.connect).toHaveBeenCalledWith(worklet);
+    expect(worklet.port.postMessage).toHaveBeenCalledWith({
+      type: "setFormat",
+      format: OUTPUT_FORMAT.format,
+      sampleRate: OUTPUT_FORMAT.sampleRate,
+    });
+    expect(result.analyser).toBe(analyser);
+  });
+});

--- a/packages/client/src/platform/web/webAudioAdapter.ts
+++ b/packages/client/src/platform/web/webAudioAdapter.ts
@@ -1,4 +1,5 @@
 import type { RemoteAudioTrack } from "livekit-client";
+import type { AudioWorkletConfig } from "../../BaseConversation.js";
 import type { FormatConfig } from "../../utils/BaseConnection.js";
 import type {
   WebRTCAudioAdapter,
@@ -74,7 +75,8 @@ export class WebAudioAdapter implements WebRTCAudioAdapter {
   async setupOutputAnalysis(
     track: RemoteAudioTrack,
     format: FormatConfig,
-    onAudioData: (audioData: ArrayBuffer, maxVolume: number) => void
+    onAudioData: (audioData: ArrayBuffer, maxVolume: number) => void,
+    workletPaths?: AudioWorkletConfig["workletPaths"]
   ): Promise<AnalysisResult> {
     // Clean up previous audio capture context
     if (this.audioCaptureContext) {
@@ -101,7 +103,10 @@ export class WebAudioAdapter implements WebRTCAudioAdapter {
       audioContext.sampleRate
     );
 
-    await loadRawAudioProcessor(audioContext.audioWorklet);
+    await loadRawAudioProcessor(
+      audioContext.audioWorklet,
+      workletPaths?.rawAudioProcessor
+    );
     const worklet = new AudioWorkletNode(audioContext, "rawAudioProcessor");
 
     // Configure the processor and set up the message listener

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -64,6 +64,7 @@ import { WebRTCConnection } from "./WebRTCConnection.js";
 import { Room, createLocalAudioTrack } from "livekit-client";
 import { setWebRTCAudioAdapterFactory } from "../WebRTCAudioAdapter.js";
 import { WebAudioAdapter } from "../platform/web/webAudioAdapter.js";
+import { NO_VOLUME } from "./volumeProvider.js";
 import type { PongEvent } from "./events.js";
 
 describe("WebRTCConnection", () => {
@@ -393,5 +394,76 @@ describe("WebRTCConnection", () => {
     connection.close();
 
     expect(listener).toHaveBeenCalledWith(message);
+  });
+
+  it.each([
+    {
+      name: "forwards configured workletPaths to the audio adapter",
+      workletPaths: { rawAudioProcessor: "/vendor/raw-audio-processor.js" },
+    },
+    {
+      name: "passes undefined to the audio adapter when none are configured",
+      workletPaths: undefined,
+    },
+  ])("$name", async ({ workletPaths }) => {
+    const mockRoom = new Room() as any;
+    const handlers = new Map<string, (...args: any[]) => unknown>();
+
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: (...args: any[]) => unknown) => {
+        handlers.set(event, callback);
+        if (event === "connected") {
+          queueMicrotask(callback as () => void);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const setupOutputAnalysis = vi.fn(() =>
+      Promise.resolve({ volumeProvider: NO_VOLUME })
+    );
+    setWebRTCAudioAdapterFactory(() => ({
+      attachRemoteTrack: vi.fn(() => Promise.resolve()),
+      setupInputAnalysis: vi.fn(() => ({ volumeProvider: NO_VOLUME })),
+      setupOutputAnalysis,
+      setVolume: vi.fn(),
+      setOutputDevice: vi.fn(() => Promise.resolve()),
+      cleanup: vi.fn(),
+    }));
+
+    try {
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+        ...(workletPaths ? { workletPaths } : {}),
+      });
+
+      const onTrackSubscribed = handlers.get("trackSubscribed");
+      expect(onTrackSubscribed).toBeDefined();
+
+      await onTrackSubscribed?.(
+        { kind: "audio", mediaStreamTrack: { id: "agent-track" } },
+        {},
+        { identity: "agent-abc" }
+      );
+
+      expect(setupOutputAnalysis).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Function),
+        workletPaths
+      );
+
+      connection.close();
+    } finally {
+      // Restore the default web adapter for any later test in this file.
+      setWebRTCAudioAdapterFactory(() => new WebAudioAdapter());
+    }
   });
 });

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -36,6 +36,7 @@ import {
   createAudioAdapter,
   type WebRTCAudioAdapter,
 } from "../WebRTCAudioAdapter.js";
+import type { AudioWorkletConfig } from "../BaseConversation.js";
 
 const DEFAULT_LIVEKIT_WS_URL = "wss://livekit.rtc.elevenlabs.io";
 const HTTPS_API_ORIGIN = "https://api.elevenlabs.io";
@@ -46,9 +47,10 @@ function convertWssToHttps(origin: string): string {
   return origin.replace(/^wss:\/\//, "https://");
 }
 
-export type WebRTCConnectionConfig = SessionConfig & {
-  onDebug?: (info: unknown) => void;
-};
+export type WebRTCConnectionConfig = SessionConfig &
+  Pick<AudioWorkletConfig, "workletPaths"> & {
+    onDebug?: (info: unknown) => void;
+  };
 
 /** @deprecated Use {@link WebRTCConnectionConfig} instead. */
 export type ConnectionConfig = WebRTCConnectionConfig;
@@ -64,6 +66,7 @@ export class WebRTCConnection extends BaseConnection {
   private outputDeviceId: string | null = null;
 
   private audioAdapter: WebRTCAudioAdapter | null;
+  private workletPaths: AudioWorkletConfig["workletPaths"];
 
   private inputAnalyser: unknown = undefined;
   private inputVolumeProvider: VolumeProvider = NO_VOLUME;
@@ -216,7 +219,10 @@ export class WebRTCConnection extends BaseConnection {
     conversationId: string,
     inputFormat: FormatConfig,
     outputFormat: FormatConfig,
-    config: { onDebug?: (info: unknown) => void } = {}
+    config: {
+      onDebug?: (info: unknown) => void;
+      workletPaths?: AudioWorkletConfig["workletPaths"];
+    } = {}
   ) {
     super(config);
     this.room = room;
@@ -224,6 +230,7 @@ export class WebRTCConnection extends BaseConnection {
     this.inputFormat = inputFormat;
     this.outputFormat = outputFormat;
     this.audioAdapter = createAudioAdapter();
+    this.workletPaths = config.workletPaths;
 
     this.setupRoomEventListeners();
   }
@@ -598,7 +605,8 @@ export class WebRTCConnection extends BaseConnection {
       const result = await this.audioAdapter.setupOutputAnalysis(
         track,
         this.outputFormat,
-        onAudioData
+        onAudioData,
+        this.workletPaths
       );
 
       this.outputVolumeProvider = result.volumeProvider;


### PR DESCRIPTION
Fixes #649

## The problem

`workletPaths` exists so apps under a strict CSP can self-host the AudioWorklet files instead of allowing `blob:` and `data:` in `script-src`. It works on the WebSocket path and is ignored on the WebRTC path.

`WebAudioAdapter.setupOutputAnalysis` — the WebRTC output-capture path that backs the `onAudio` callback — called the loader with no path:

```ts
await loadRawAudioProcessor(audioContext.audioWorklet);
```

while `MediaDeviceInput.create` on the WebSocket path passes one:

```ts
await loadRawAudioProcessor(context.audioWorklet, workletPaths?.rawAudioProcessor);
```

`createWorkletModuleLoader` already prefers a path when given one, so the abstraction was in place — the WebRTC path just never reached it. Concretely: a session started with `conversationToken` (or any `connectionType: "webrtc"`) plus `workletPaths.rawAudioProcessor` still constructs a `Blob`, calls `URL.createObjectURL`, and loads the worklet from a `blob:` URL. Under `script-src 'self'` that load is refused and output capture fails; the only escape is to weaken the CSP.

The config was reaching `createConnection` at runtime — `VoiceSessionSetup` passes the full `Options` object — it was simply never read on this path.

### One extra consequence worth flagging

`createWorkletModuleLoader` caches by worklet **name**, not by URL:

```ts
const cachedUrl = URLCache.get(name);
if (cachedUrl) return worklet.addModule(cachedUrl);
```

Both paths load the worklet named `rawAudioProcessor`. So a WebRTC session that fell back to a blob cached that blob URL under `rawAudioProcessor`, and a *later* WebSocket session in the same document — one that does pass `workletPaths` — got the cached `blob:` URL instead of its own path. The CSP-safe path was defeated for the rest of the page lifetime, not just for the WebRTC session. This PR removes the source of that poisoned entry; I've left the cache keying itself alone as a separate concern.

## The fix

Thread `workletPaths` from the connection config to the adapter:

- `WebRTCConnection` accepts `workletPaths` in its config, stores it, and passes it to `setupOutputAnalysis`. This matches how `onDebug` already reaches `WebRTCConnectionConfig` without being part of `SessionConfig`.
- `WebRTCAudioAdapter.setupOutputAnalysis` takes an optional fourth `workletPaths` argument.
- `WebAudioAdapter` forwards `workletPaths?.rawAudioProcessor` to `loadRawAudioProcessor`.

The new parameter is optional, so any existing adapter implementation still satisfies the interface. The React Native adapter needs no change — it does no worklet loading.

Output playback on WebRTC goes through `HTMLAudioElement` and input goes through LiveKit, so `rawAudioProcessor` in `setupOutputAnalysis` is the only worklet load on this path. `audioConcatProcessor` and `libsampleratePath` are WebSocket-only and untouched.

## Verification

Six new tests, four in `webAudioAdapter.test.ts` and two in `WebRTCConnection.test.ts`.

Both halves were checked fail-first by stashing only the source file:

- Stashing `webAudioAdapter.ts` → **3 failed / 1 passed**. The one that passes is the control asserting the capture graph is still wired the same way (`source → analyser → worklet`, `setFormat` posted, analyser returned) — it must hold in both states, and it does.
- Stashing `WebRTCConnection.ts` → **2 failed / 9 passed**, i.e. exactly the two new connection-level tests fail and every existing test in that file still passes.

The negative cases are deliberate: one asserts `undefined` is forwarded when no `workletPaths` are configured, and one asserts `undefined` when `workletPaths` carries only `audioConcatProcessor`, so the change can't silently pass the wrong processor's path.

Full `@elevenlabs/client` suite: **200 passed / 16 files**, up from 194 by exactly the six added. `turbo lint` and `check-types` pass across all 9 packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, optional config threading on the WebRTC audio-capture path with backward-compatible adapter API and focused tests; no auth or data-model changes.
> 
> **Overview**
> **WebRTC sessions now honor `workletPaths` for remote output capture**, matching behavior that already existed on the WebSocket path. Apps with a strict CSP can self-host `rawAudioProcessor` instead of loading it from `blob:`/`data:` URLs when using `connectionType: "webrtc"`.
> 
> `WebRTCConnectionConfig` accepts optional `workletPaths`, stores them on the connection, and passes them into `WebRTCAudioAdapter.setupOutputAnalysis`. The web `WebAudioAdapter` forwards `workletPaths?.rawAudioProcessor` to `loadRawAudioProcessor` when wiring the output capture graph for the `onAudio` callback.
> 
> Six tests cover adapter forwarding (including unrelated processor keys), unchanged capture wiring, and connection-level propagation when an agent audio track is subscribed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ee4da73e17829a36404c588b0ba6894abd8b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->