### PR TITLE
fix(client): tell React Native users to import @elevenlabs/react-native

### DIFF
--- a/.changeset/react-native-setup-guard.md
+++ b/.changeset/react-native-setup-guard.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Point React Native users at `@elevenlabs/react-native` when no voice session setup strategy is registered, instead of suggesting the browser entry point.

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -13,7 +13,7 @@ import {
 } from "./BaseConversation.js";
 import type { InputController } from "./InputController.js";
 import type { OutputController } from "./OutputController.js";
-import { requireSetupStrategy } from "./platform/VoiceSessionSetup.js";
+import { ensureSetupStrategy } from "./platform/VoiceSessionSetup.js";
 import type { VoiceSessionSetupResult } from "./platform/VoiceSessionSetup.js";
 
 export class VoiceConversation extends BaseConversation {
@@ -37,7 +37,7 @@ export class VoiceConversation extends BaseConversation {
     try {
       // Platform-specific strategy handles wake lock, mic permission,
       // delay, connection creation, and input/output setup.
-      sessionSetup = await requireSetupStrategy()(fullOptions);
+      sessionSetup = await ensureSetupStrategy()(fullOptions);
 
       conversation = new VoiceConversation(
         fullOptions,

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -13,7 +13,7 @@ import {
 } from "./BaseConversation.js";
 import type { InputController } from "./InputController.js";
 import type { OutputController } from "./OutputController.js";
-import { setupStrategy } from "./platform/VoiceSessionSetup.js";
+import { requireSetupStrategy } from "./platform/VoiceSessionSetup.js";
 import type { VoiceSessionSetupResult } from "./platform/VoiceSessionSetup.js";
 
 export class VoiceConversation extends BaseConversation {
@@ -37,13 +37,7 @@ export class VoiceConversation extends BaseConversation {
     try {
       // Platform-specific strategy handles wake lock, mic permission,
       // delay, connection creation, and input/output setup.
-      if (!setupStrategy) {
-        throw new Error(
-          "No voice session setup strategy registered. " +
-            'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
-        );
-      }
-      sessionSetup = await setupStrategy(fullOptions);
+      sessionSetup = await requireSetupStrategy()(fullOptions);
 
       conversation = new VoiceConversation(
         fullOptions,

--- a/packages/client/src/platform/VoiceSessionSetup.test.ts
+++ b/packages/client/src/platform/VoiceSessionSetup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 vi.mock("livekit-client", () => ({
   Room: vi.fn(),
@@ -11,6 +11,13 @@ vi.mock("livekit-client", () => ({
 import { setupWebRTCSession } from "./VoiceSessionSetup.js";
 import { WebRTCConnection } from "../utils/WebRTCConnection.js";
 import { WebSocketConnection } from "../utils/WebSocketConnection.js";
+
+// `setupStrategy` is module-level state with no reset, so each case that cares
+// about it works against a freshly imported copy of the module.
+async function freshModule() {
+  vi.resetModules();
+  return import("./VoiceSessionSetup.js");
+}
 
 describe("setupWebRTCSession", () => {
   it("returns input/output from a WebRTCConnection", () => {
@@ -66,5 +73,61 @@ describe("setupWebRTCSession", () => {
     expect(() => setupWebRTCSession(undefined as any)).toThrow(
       "Received: undefined"
     );
+  });
+});
+
+describe("requireSetupStrategy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the registered strategy", async () => {
+    const { requireSetupStrategy, setSetupStrategy } = await freshModule();
+    const strategy = vi.fn();
+    setSetupStrategy(strategy);
+
+    expect(requireSetupStrategy()).toBe(strategy);
+  });
+
+  it("points a browser user at the platform entry point", async () => {
+    const { requireSetupStrategy } = await freshModule();
+
+    expect(() => requireSetupStrategy()).toThrow(
+      'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
+    );
+  });
+
+  it("points a React Native user at @elevenlabs/react-native", async () => {
+    vi.stubGlobal("navigator", { product: "ReactNative" });
+    const { requireSetupStrategy } = await freshModule();
+
+    expect(() => requireSetupStrategy()).toThrow(
+      "@elevenlabs/client in React Native without importing @elevenlabs/react-native"
+    );
+  });
+
+  it("detects React Native via the Hermes global too", async () => {
+    vi.stubGlobal("HermesInternal", {});
+    const { requireSetupStrategy } = await freshModule();
+
+    expect(() => requireSetupStrategy()).toThrow(
+      "@elevenlabs/client in React Native without importing @elevenlabs/react-native"
+    );
+  });
+
+  it("does not mention React Native in a browser-like environment", async () => {
+    vi.stubGlobal("navigator", { product: "Gecko" });
+    const { requireSetupStrategy } = await freshModule();
+
+    expect(() => requireSetupStrategy()).not.toThrow("React Native");
+  });
+
+  it("never throws the browser message once a strategy is registered in React Native", async () => {
+    vi.stubGlobal("navigator", { product: "ReactNative" });
+    const { requireSetupStrategy, setSetupStrategy } = await freshModule();
+    const strategy = vi.fn();
+    setSetupStrategy(strategy);
+
+    expect(requireSetupStrategy()).toBe(strategy);
   });
 });

--- a/packages/client/src/platform/VoiceSessionSetup.test.ts
+++ b/packages/client/src/platform/VoiceSessionSetup.test.ts
@@ -76,58 +76,58 @@ describe("setupWebRTCSession", () => {
   });
 });
 
-describe("requireSetupStrategy", () => {
+describe("ensureSetupStrategy", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
   it("returns the registered strategy", async () => {
-    const { requireSetupStrategy, setSetupStrategy } = await freshModule();
+    const { ensureSetupStrategy, setSetupStrategy } = await freshModule();
     const strategy = vi.fn();
     setSetupStrategy(strategy);
 
-    expect(requireSetupStrategy()).toBe(strategy);
+    expect(ensureSetupStrategy()).toBe(strategy);
   });
 
   it("points a browser user at the platform entry point", async () => {
-    const { requireSetupStrategy } = await freshModule();
+    const { ensureSetupStrategy } = await freshModule();
 
-    expect(() => requireSetupStrategy()).toThrow(
+    expect(() => ensureSetupStrategy()).toThrow(
       'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
     );
   });
 
   it("points a React Native user at @elevenlabs/react-native", async () => {
     vi.stubGlobal("navigator", { product: "ReactNative" });
-    const { requireSetupStrategy } = await freshModule();
+    const { ensureSetupStrategy } = await freshModule();
 
-    expect(() => requireSetupStrategy()).toThrow(
+    expect(() => ensureSetupStrategy()).toThrow(
       "@elevenlabs/client in React Native without importing @elevenlabs/react-native"
     );
   });
 
   it("detects React Native via the Hermes global too", async () => {
     vi.stubGlobal("HermesInternal", {});
-    const { requireSetupStrategy } = await freshModule();
+    const { ensureSetupStrategy } = await freshModule();
 
-    expect(() => requireSetupStrategy()).toThrow(
+    expect(() => ensureSetupStrategy()).toThrow(
       "@elevenlabs/client in React Native without importing @elevenlabs/react-native"
     );
   });
 
   it("does not mention React Native in a browser-like environment", async () => {
     vi.stubGlobal("navigator", { product: "Gecko" });
-    const { requireSetupStrategy } = await freshModule();
+    const { ensureSetupStrategy } = await freshModule();
 
-    expect(() => requireSetupStrategy()).not.toThrow("React Native");
+    expect(() => ensureSetupStrategy()).not.toThrow("React Native");
   });
 
   it("never throws the browser message once a strategy is registered in React Native", async () => {
     vi.stubGlobal("navigator", { product: "ReactNative" });
-    const { requireSetupStrategy, setSetupStrategy } = await freshModule();
+    const { ensureSetupStrategy, setSetupStrategy } = await freshModule();
     const strategy = vi.fn();
     setSetupStrategy(strategy);
 
-    expect(requireSetupStrategy()).toBe(strategy);
+    expect(ensureSetupStrategy()).toBe(strategy);
   });
 });

--- a/packages/client/src/platform/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/VoiceSessionSetup.ts
@@ -56,7 +56,7 @@ function isReactNativeEnvironment(): boolean {
  * registers its own strategy — pointing at the browser entry point there would
  * be actively wrong.
  */
-export function requireSetupStrategy(): VoiceSessionSetupStrategy {
+export function ensureSetupStrategy(): VoiceSessionSetupStrategy {
   if (setupStrategy) {
     return setupStrategy;
   }

--- a/packages/client/src/platform/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/VoiceSessionSetup.ts
@@ -32,6 +32,45 @@ export function setSetupStrategy(strategy: VoiceSessionSetupStrategy) {
 }
 
 /**
+ * Detects a React Native runtime.
+ *
+ * `navigator.product === "ReactNative"` is the long-standing signal; Hermes,
+ * the default engine on modern React Native, exposes a `HermesInternal` global.
+ * Either is enough, and both are absent in a browser.
+ */
+function isReactNativeEnvironment(): boolean {
+  const globals = globalThis as {
+    navigator?: { product?: string };
+    HermesInternal?: unknown;
+  };
+  return (
+    globals.navigator?.product === "ReactNative" ||
+    globals.HermesInternal != null
+  );
+}
+
+/**
+ * Returns the registered setup strategy, or throws explaining how to register
+ * one. On React Native the fix is to import `@elevenlabs/react-native`, which
+ * polyfills the WebRTC globals, configures the native audio session and
+ * registers its own strategy — pointing at the browser entry point there would
+ * be actively wrong.
+ */
+export function requireSetupStrategy(): VoiceSessionSetupStrategy {
+  if (setupStrategy) {
+    return setupStrategy;
+  }
+  throw new Error(
+    isReactNativeEnvironment()
+      ? "No voice session setup strategy registered. It looks like you're using " +
+          "@elevenlabs/client in React Native without importing @elevenlabs/react-native. " +
+          'Add `import "@elevenlabs/react-native";` before any other ElevenLabs imports.'
+      : "No voice session setup strategy registered. " +
+          'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
+  );
+}
+
+/**
  * Sets up a voice session for a WebRTC connection.
  * Platform-agnostic: extracts the input/output controllers that
  * WebRTCConnection already provides via LiveKit.


### PR DESCRIPTION
Fixes #604

## The problem

`@elevenlabs/client` is platform-agnostic and depends on `@elevenlabs/react-native` being imported first in a React Native app — that package polyfills the WebRTC globals via `registerGlobals()`, configures the native `AudioSession`, and registers a React Native `VoiceSessionSetupStrategy`.

There is already a guard for a missing strategy in `VoiceConversation.startSession`, but its message only describes the browser fix:

```
No voice session setup strategy registered. Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).
```

`src/index.ts` registers no strategy — only `platform/web/index.ts` does, at import time. So a React Native app that resolves the package's `default` export rather than `browser` hits exactly this error, and the message tells it to do the one thing that will not help: importing the browser entry point in React Native pulls in the web setup path instead of the native one. The correct action is `import "@elevenlabs/react-native"`.

## The fix

As suggested in the issue, the check runs when a voice session starts rather than at import time.

The inline guard moves into `platform/VoiceSessionSetup.ts` as `requireSetupStrategy()`, which returns the registered strategy or throws. When no strategy is registered *and* the runtime looks like React Native, it names `@elevenlabs/react-native`; otherwise the existing browser message is unchanged, word for word.

Environment detection uses both signals the issue mentions — `navigator.product === "ReactNative"` and the Hermes `HermesInternal` global — read off `globalThis` so neither access throws where the global is absent.

This only changes which *message* an already-throwing call produces. A session that would have started still starts, and a browser app that hits the guard sees exactly what it saw before.

Scoped deliberately to the voice path, where the React Native setup actually matters (WebRTC globals, audio session). `TextConversation` doesn't consult a setup strategy, so nothing there needed to change.

## Verification

Six new tests in the existing `platform/VoiceSessionSetup.test.ts`. `setupStrategy` is module-level state with no reset, so the cases that depend on it re-import the module through `vi.resetModules()` rather than trying to unset it.

Fail-first was done by neutralising `isReactNativeEnvironment()` to `return false` — the pre-fix behaviour, one message for everyone — rather than by stashing the whole module, which would only have produced import errors and proved nothing:

**2 failed / 10 passed**, and the two failures are exactly the React Native cases (`navigator.product` and the Hermes global). The other ten pass in both states, including the two that matter as controls: the browser message is unchanged, and a browser-like environment must *not* mention React Native.

Full `@elevenlabs/client` suite: **206 passed / 16 files**, up from 200 by exactly the six added. `turbo lint` and `check-types` green across all 9 packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes error messages when setup was already missing; successful voice sessions and browser guard text are unchanged.
> 
> **Overview**
> When a voice session starts without a registered setup strategy, the guard moves from `VoiceConversation` into **`ensureSetupStrategy()`** in `VoiceSessionSetup.ts`. Behavior is unchanged except for **which error text is thrown**.
> 
> If the runtime looks like React Native (`navigator.product === "ReactNative"` or a `HermesInternal` global), the message tells developers to add `import "@elevenlabs/react-native";` before other ElevenLabs imports instead of pointing at the browser export (which would be wrong on native). Browser and other environments still get the existing browser-entry-point message word for word.
> 
> `VoiceConversation.startSession` now calls `ensureSetupStrategy()(fullOptions)` instead of checking `setupStrategy` inline. Tests cover RN vs browser messaging, Hermes detection, and registered strategies via fresh module imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af4f1f730797c6bd8132f05326fda2d99bdcfc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->