### PR TITLE
fix(build): point generate-worklets turbo outputs at the real path

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -64,7 +64,7 @@
     },
     "generate-worklets": {
       "inputs": ["scripts/generateWorklets.js", "worklets/**/*.js"],
-      "outputs": ["src/utils/*.generated.ts"]
+      "outputs": ["src/platform/web/*.generated.ts"]
     }
   }
 }


### PR DESCRIPTION
## The problem

The `generate-worklets` task declares outputs that no longer exist:

```json
"generate-worklets": {
  "inputs": ["scripts/generateWorklets.js", "worklets/**/*.js"],
  "outputs": ["src/utils/*.generated.ts"]
}
```

`packages/client/scripts/generateWorklets.js` writes to `src/platform/web` (`const webDir = path.join(__dirname, '../src/platform/web')`), producing `rawAudioProcessor.generated.ts`, `audioConcatProcessor.generated.ts` and `scribeAudioProcessor.generated.ts` there. Nothing has ever been written to `src/utils/`.

Turbo already says so on every run that executes the task:

```
WARNING  no output files found for task @elevenlabs/client#generate-worklets. Please check your `outputs` key in `turbo.json`
```

Because the glob matches nothing, the task is cached with **zero recorded outputs**. A cache hit then restores nothing while still reporting success, so any state where the generated files are absent but the inputs are unchanged — a cleaned tree, a pruned checkout, CI restoring a warm cache — survives the "successful" task and fails later in the build.

## Reproduction

With the current config, priming the cache, deleting the generated files, and re-running:

```
@elevenlabs/client:generate-worklets: cache hit, replaying logs 9c4d96addf1fd6ff
 Tasks:    1 successful, 1 total
```

Files restored: **0**. `tsc --build` in `packages/client` then fails:

```
src/platform/web/input.ts(1,39): error TS2307: Cannot find module './rawAudioProcessor.generated.js' or its corresponding type declarations.
src/platform/web/output.ts(1,42): error TS2307: Cannot find module './audioConcatProcessor.generated.js' or its corresponding type declarations.
src/platform/web/scribeMicrophone.ts(7,42): error TS2307: Cannot find module './scribeAudioProcessor.generated.js' or its corresponding type declarations.
src/platform/web/webAudioAdapter.ts(7,39): error TS2307: Cannot find module './rawAudioProcessor.generated.js' or its corresponding type declarations.
src/platform/web/scribeMicrophone.test.ts(7,42): error TS2307: Cannot find module './scribeAudioProcessor.generated.js' or its corresponding type declarations.
```

The task reported success; the build disagreed.

## The fix

Point `outputs` at the directory the script actually writes to.

Same sequence after the change — prime, delete, re-run:

```
@elevenlabs/client:generate-worklets: cache hit, replaying logs 175fb232202213fb
 Tasks:    1 successful, 1 total
```

Files restored: **3**, byte-identical to the committed ones, and `tsc --build` is clean. The `no output files found` warning is gone.

## Notes

The generated files are committed, so a plain clone is unaffected — this only bites when they're missing or stale while the inputs still hash the same, which is exactly the case caching is supposed to cover.

No Changeset: this changes no published package's contents, only the build cache's bookkeeping.

`generate-version` (`src/version.ts`) and `generate-types` (`generated/**`) were checked against their scripts and are both correct; `generate-worklets` was the only stale path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-cache configuration only; no runtime or published package behavior changes.
> 
> **Overview**
> Updates the `generate-worklets` task in `turbo.json` so **`outputs`** is `src/platform/web/*.generated.ts` instead of `src/utils/*.generated.ts`, matching where `generateWorklets.js` actually writes.
> 
> That fixes Turbo reporting **no output files**, caching the task with **zero artifacts**, and **cache hits** that skip restoring the three `*.generated.ts` files—so clean trees or pruned checkouts could pass `generate-worklets` and then fail `tsc` on missing worklet modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 785c90378e61760a629a40427a96d4e4e6529352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->