### PR TITLE
fix(client): key the worklet module cache by the requested source

### DIFF
--- a/.changeset/worklet-cache-path-key.md
+++ b/.changeset/worklet-cache-path-key.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Key the worklet module cache by the requested source as well as the worklet name, so a self-hosted `workletPaths` entry is no longer served an inlined `blob:` URL cached by an earlier load.

--- a/packages/client/src/platform/web/createWorkletModuleLoader.test.ts
+++ b/packages/client/src/platform/web/createWorkletModuleLoader.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The URL cache is module-level state, so every case works against a freshly
+// imported copy of the module rather than a cache left over from the last one.
+async function freshLoader(name = "rawAudioProcessor", source = "// worklet") {
+  vi.resetModules();
+  const { createWorkletModuleLoader } =
+    await import("./createWorkletModuleLoader.js");
+  return createWorkletModuleLoader(name, source);
+}
+
+function createWorklet() {
+  return { addModule: vi.fn().mockResolvedValue(undefined) };
+}
+
+let blobUrlCounter = 0;
+
+// These run in a real browser, so Blob/btoa are genuine. Only the object-URL
+// helpers are replaced, and by spying rather than stubbing the whole `URL`
+// global — overwriting it would take the `URL` constructor with it.
+beforeEach(() => {
+  blobUrlCounter = 0;
+  vi.spyOn(URL, "createObjectURL").mockImplementation(
+    () => `blob:mock-${++blobUrlCounter}`
+  );
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createWorkletModuleLoader", () => {
+  it("uses a self-hosted path even after an inlined load cached a blob", async () => {
+    const load = await freshLoader();
+    const worklet = createWorklet();
+
+    await load(worklet as unknown as AudioWorklet);
+    await load(worklet as unknown as AudioWorklet, "/vendor/raw.js");
+
+    expect(worklet.addModule).toHaveBeenNthCalledWith(1, "blob:mock-1");
+    expect(worklet.addModule).toHaveBeenNthCalledWith(2, "/vendor/raw.js");
+  });
+
+  it("does not serve one self-hosted path in place of another", async () => {
+    const load = await freshLoader();
+    const worklet = createWorklet();
+
+    await load(worklet as unknown as AudioWorklet, "/vendor/a.js");
+    await load(worklet as unknown as AudioWorklet, "/vendor/b.js");
+
+    expect(worklet.addModule).toHaveBeenNthCalledWith(1, "/vendor/a.js");
+    expect(worklet.addModule).toHaveBeenNthCalledWith(2, "/vendor/b.js");
+  });
+
+  it("still inlines a blob when no path is given after a path load", async () => {
+    const load = await freshLoader();
+    const worklet = createWorklet();
+
+    await load(worklet as unknown as AudioWorklet, "/vendor/raw.js");
+    await load(worklet as unknown as AudioWorklet);
+
+    expect(worklet.addModule).toHaveBeenNthCalledWith(1, "/vendor/raw.js");
+    expect(worklet.addModule).toHaveBeenNthCalledWith(2, "blob:mock-1");
+  });
+
+  // Controls: the cache must still do its job for repeated identical requests.
+
+  it("creates only one blob URL across repeated inlined loads", async () => {
+    const load = await freshLoader();
+    const worklet = createWorklet();
+
+    await load(worklet as unknown as AudioWorklet);
+    await load(worklet as unknown as AudioWorklet);
+    await load(worklet as unknown as AudioWorklet);
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(worklet.addModule).toHaveBeenCalledTimes(3);
+    expect(worklet.addModule).toHaveBeenLastCalledWith("blob:mock-1");
+  });
+
+  it("reuses the cached entry for a repeated identical path", async () => {
+    const load = await freshLoader();
+    const worklet = createWorklet();
+
+    await load(worklet as unknown as AudioWorklet, "/vendor/raw.js");
+    await load(worklet as unknown as AudioWorklet, "/vendor/raw.js");
+
+    expect(worklet.addModule).toHaveBeenCalledTimes(2);
+    expect(worklet.addModule).toHaveBeenNthCalledWith(2, "/vendor/raw.js");
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("keeps separate entries per worklet name", async () => {
+    vi.resetModules();
+    const { createWorkletModuleLoader } =
+      await import("./createWorkletModuleLoader.js");
+    const loadRaw = createWorkletModuleLoader("rawAudioProcessor", "// raw");
+    const loadConcat = createWorkletModuleLoader(
+      "audioConcatProcessor",
+      "// concat"
+    );
+    const worklet = createWorklet();
+
+    await loadRaw(worklet as unknown as AudioWorklet, "/vendor/raw.js");
+    await loadConcat(worklet as unknown as AudioWorklet, "/vendor/concat.js");
+
+    expect(worklet.addModule).toHaveBeenNthCalledWith(1, "/vendor/raw.js");
+    expect(worklet.addModule).toHaveBeenNthCalledWith(2, "/vendor/concat.js");
+  });
+
+  it("reports the requested path when loading from it fails", async () => {
+    const load = await freshLoader();
+    const worklet = {
+      addModule: vi.fn().mockRejectedValue(new Error("blocked by CSP")),
+    };
+
+    await expect(
+      load(worklet as unknown as AudioWorklet, "/vendor/raw.js")
+    ).rejects.toThrow(
+      "Failed to load the rawAudioProcessor worklet module from path: /vendor/raw.js"
+    );
+  });
+
+  it("does not cache a path that failed to load", async () => {
+    const load = await freshLoader();
+    const failing = {
+      addModule: vi.fn().mockRejectedValue(new Error("blocked by CSP")),
+    };
+    await expect(
+      load(failing as unknown as AudioWorklet, "/vendor/raw.js")
+    ).rejects.toThrow();
+
+    const worklet = createWorklet();
+    await load(worklet as unknown as AudioWorklet, "/vendor/raw.js");
+
+    expect(worklet.addModule).toHaveBeenCalledWith("/vendor/raw.js");
+  });
+});

--- a/packages/client/src/platform/web/createWorkletModuleLoader.ts
+++ b/packages/client/src/platform/web/createWorkletModuleLoader.ts
@@ -1,8 +1,17 @@
 const URLCache = new Map<string, string>();
 
+// The cache has to distinguish "the caller asked for this specific path" from
+// "the caller asked us to inline the source", and one self-hosted path from
+// another. Keying on the name alone lets whichever call happens to land first
+// answer every later call, whatever it asked for.
+function cacheKey(name: string, path?: string) {
+  return path ? `${name} ${path}` : name;
+}
+
 export function createWorkletModuleLoader(name: string, sourceCode: string) {
   return async (worklet: AudioWorklet, path?: string) => {
-    const cachedUrl = URLCache.get(name);
+    const key = cacheKey(name, path);
+    const cachedUrl = URLCache.get(key);
     if (cachedUrl) {
       return worklet.addModule(cachedUrl);
     }
@@ -11,7 +20,7 @@ export function createWorkletModuleLoader(name: string, sourceCode: string) {
     if (path) {
       try {
         await worklet.addModule(path);
-        URLCache.set(name, path);
+        URLCache.set(key, path);
         return;
       } catch (error) {
         throw new Error(
@@ -24,7 +33,7 @@ export function createWorkletModuleLoader(name: string, sourceCode: string) {
     const blobURL = URL.createObjectURL(blob);
     try {
       await worklet.addModule(blobURL);
-      URLCache.set(name, blobURL);
+      URLCache.set(key, blobURL);
       return;
     } catch {
       URL.revokeObjectURL(blobURL);
@@ -37,7 +46,7 @@ export function createWorkletModuleLoader(name: string, sourceCode: string) {
       const base64 = btoa(sourceCode);
       const moduleURL = `data:application/javascript;base64,${base64}`;
       await worklet.addModule(moduleURL);
-      URLCache.set(name, moduleURL);
+      URLCache.set(key, moduleURL);
     } catch (error) {
       throw new Error(
         `Failed to load the ${name} worklet module. Make sure the browser supports AudioWorklets. If you are using a strict CSP, you may need to self-host the worklet files.`


### PR DESCRIPTION
## The problem

`createWorkletModuleLoader` caches the resolved module URL under the worklet's **name** only:

```ts
const cachedUrl = URLCache.get(name);
if (cachedUrl) {
  return worklet.addModule(cachedUrl);
}
```

The `path` argument is never part of the key, so whichever call lands first decides what every later call gets — regardless of what that later call asked for.

The consequence that matters is for `workletPaths`, which exists so an app under a strict CSP can avoid `blob:` and `data:` in `script-src`:

```ts
await load(worklet);                      // no path → caches "blob:…" under "rawAudioProcessor"
await load(worklet, "/vendor/raw.js");    // cache hit → loads the blob, not the path
```

The second call is correctly configured and is silently served the `blob:` URL it was specifically configured to avoid — the CSP-safe path is defeated for the rest of the document's lifetime. `rawAudioProcessor` is loaded from more than one place (`input.ts` on the WebSocket path, `webAudioAdapter.ts` on the WebRTC one), so the ordering that triggers this is a normal sequence of sessions on one page, not a contrived one.

Two self-hosted paths collide the same way: after `load(worklet, "/vendor/a.js")`, a later `load(worklet, "/vendor/b.js")` adds `/vendor/a.js`.

## The fix

Include the requested source in the cache key — the path when one is given, the name alone for the inlined case:

```ts
function cacheKey(name: string, path?: string) {
  return path ? `${name} ${path}` : name;
}
```

Entries stay separate per requested source, and all three write sites store under the same computed key. Repeated identical requests still hit the cache exactly as before; only requests that differ now get their own entry.

## Verification

Eight new tests in a new `createWorkletModuleLoader.test.ts`. The cache is module-level state, so each case re-imports the module via `vi.resetModules()` rather than sharing a cache.

Fail-first was done by reverting `cacheKey` to returning `name` — the current behaviour — giving **3 failed / 5 passed**.

The three failures are exactly the three bug cases (blob-then-path, path-A-then-path-B, path-then-blob). The five passes are controls that must hold in **both** states, and they are the reason to believe this is a narrow fix rather than a cache that has been quietly disabled:

- repeated inlined loads still create exactly **one** blob URL (`URL.createObjectURL` called once across three loads)
- a repeated identical path reuses its entry and never falls through to the blob branch
- separate worklet names keep separate entries
- a failing path still reports the path it tried, and is not cached

`URL.createObjectURL`/`revokeObjectURL` are spied rather than stubbed via `vi.stubGlobal("URL", …)`, which would replace the `URL` constructor and break the module graph.

Full `@elevenlabs/client` suite: **202 passed / 16 files**, up from 194 by exactly the eight added. Prettier, eslint and `tsc --build` clean.

## Note

This is the follow-up I flagged as out of scope in #943, which fixes the *other* half — the WebRTC path not passing `workletPaths` to the loader at all. The two are independent and touch different files; this one stands on its own, and neither depends on the other landing first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted caching fix in web audio worklet loading with new unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **AudioWorklet** loading when apps mix default inlined loads with CSP-friendly **`workletPaths`**: the module-level URL cache no longer keys only on worklet name, so a later self-hosted path is not replaced by an earlier **`blob:`** (or **`data:`**) URL cached under the same name.
> 
> `createWorkletModuleLoader` now uses a **`cacheKey(name, path?)`** (`name` for inlined, `name + path` when a path is passed) for lookups and all cache writes. Repeated identical requests still share one entry; failed path loads are still not cached.
> 
> Adds **`createWorkletModuleLoader.test.ts`** (eight cases, fresh module import per test) and a patch changeset for **`@elevenlabs/client`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86dbc205e88f51a6fb80cfa032c22ef061ad62d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->