### PR TITLE
fix(client): reject a mismatched sampleRate or format instead of ignoring it

### DIFF
--- a/.changeset/webrtc-device-option-parity.md
+++ b/.changeset/webrtc-device-option-parity.md
@@ -2,4 +2,4 @@
 "@elevenlabs/client": patch
 ---
 
-Align `changeInputDevice`/`changeOutputDevice` across connection types: the WebRTC path now ignores `sampleRate`, `format` and `preferHeadphonesForIosDevices` instead of throwing, matching the WebSocket path, so a device switch that succeeds on one connection type no longer fails on the other.
+Align `changeInputDevice`/`changeOutputDevice` across connection types: both the WebSocket and WebRTC paths now reject a `sampleRate` or `format` that differs from the one the connection was created with, instead of the WebSocket path silently ignoring it and the WebRTC path throwing on any value including the one already active. Re-passing the connection's current `sampleRate`/`format` alongside a device id, which callers routinely do, stays a no-op on both paths.

--- a/.changeset/webrtc-device-option-parity.md
+++ b/.changeset/webrtc-device-option-parity.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Align `changeInputDevice`/`changeOutputDevice` across connection types: the WebRTC path now ignores `sampleRate`, `format` and `preferHeadphonesForIosDevices` instead of throwing, matching the WebSocket path, so a device switch that succeeds on one connection type no longer fails on the other.

--- a/packages/client/src/platform/web/input.ts
+++ b/packages/client/src/platform/web/input.ts
@@ -115,6 +115,8 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
         inputStream,
         source,
         permissions,
+        sampleRate,
+        format,
         onError
       );
     } catch (error) {
@@ -146,6 +148,8 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
     private inputStream: MediaStream,
     private mediaStreamSource: MediaStreamAudioSourceNode,
     private permissions: PermissionStatus,
+    private readonly configuredSampleRate: number,
+    private readonly configuredFormat: FormatConfig["format"],
     private onError: (
       message: string,
       context?: unknown
@@ -221,13 +225,28 @@ export class MediaDeviceInput implements InputController, InputEventTarget {
       }
       this.settingInput = true;
 
+      // sampleRate and format cannot be changed on an existing input (would
+      // require recreating the AudioContext), so a caller asking for a value
+      // other than the one this input was created with gets a clear error
+      // instead of a silently mismatched format. Re-passing the same value
+      // back, which callers routinely do alongside an inputDeviceId change,
+      // stays a no-op. preferHeadphonesForIosDevices is a best-effort
+      // selection hint rather than a format guarantee, so it stays a silent
+      // no-op regardless, same as inputChunkDurationMs. All are only applied
+      // during MediaDeviceInput.create().
+      if (
+        (config?.sampleRate !== undefined &&
+          config.sampleRate !== this.configuredSampleRate) ||
+        (config?.format !== undefined &&
+          config.format !== this.configuredFormat)
+      ) {
+        throw new Error(
+          "Input device does not support changing sampleRate or format after the connection is created"
+        );
+      }
+
       // Extract inputDeviceId from config
       const inputDeviceId = config?.inputDeviceId;
-
-      // Note: sampleRate, format, inputChunkDurationMs, and
-      // preferHeadphonesForIosDevices cannot be changed on an existing input
-      // (would require recreating the AudioContext). These options are only used
-      // during initial MediaDeviceInput.create()
 
       // Create new constraints with the specified device or use default
       const options: MediaTrackConstraints = {

--- a/packages/client/src/platform/web/output.ts
+++ b/packages/client/src/platform/web/output.ts
@@ -127,7 +127,9 @@ export class MediaDeviceOutput
         analyser,
         gain,
         worklet,
-        audioElement
+        audioElement,
+        sampleRate,
+        format
       );
 
       return newOutput;
@@ -155,7 +157,9 @@ export class MediaDeviceOutput
     private readonly analyser: AnalyserNode,
     private readonly gain: GainNode,
     private readonly worklet: AudioWorkletNode,
-    private readonly audioElement: HTMLAudioElement
+    private readonly audioElement: HTMLAudioElement,
+    private readonly configuredSampleRate: number,
+    private readonly configuredFormat: FormatConfig["format"]
   ) {
     // Start the MessagePort to enable addEventListener to work
     // (required when using addEventListener instead of onmessage)
@@ -236,12 +240,24 @@ export class MediaDeviceOutput
       throw new Error("setSinkId is not supported in this browser");
     }
 
+    // sampleRate and format cannot be changed on an existing output (would
+    // require recreating the AudioContext), so a caller asking for a value
+    // other than the one this output was created with gets a clear error
+    // instead of a silently mismatched format. Re-passing the same value
+    // back, which callers routinely do alongside an outputDeviceId change,
+    // stays a no-op. Only used during initial MediaDeviceOutput.create().
+    if (
+      (config?.sampleRate !== undefined &&
+        config.sampleRate !== this.configuredSampleRate) ||
+      (config?.format !== undefined && config.format !== this.configuredFormat)
+    ) {
+      throw new Error(
+        "Output device does not support changing sampleRate or format after the connection is created"
+      );
+    }
+
     // Extract outputDeviceId from config
     const outputDeviceId = config?.outputDeviceId;
-
-    // Note: sampleRate and format cannot be changed on an existing output
-    // (would require recreating the AudioContext).
-    // These options are only used during initial MediaDeviceOutput.create()
 
     // If deviceId is undefined, use empty string which resets to default device
     await this.audioElement.setSinkId(outputDeviceId || "");

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -624,17 +624,74 @@ describe("WebRTCConnection", () => {
       return mockRoom;
     }
 
-    // Options the WebSocket input path silently ignores because they cannot be
-    // applied to an already-running AudioContext. WebRTC used to throw on them,
-    // which meant `changeInputDevice` switched the device on one connection type
-    // and failed outright on the other.
-    const IGNORED_INPUT_OPTIONS = {
-      sampleRate: 16000,
-      format: "pcm",
-      preferHeadphonesForIosDevices: true,
-    } as const;
+    it("rejects a sampleRate change on the input device, even alongside a device id", async () => {
+      mockConnectedRoom();
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
 
-    it("switches the input device when unsupported options are also passed", async () => {
+      await expect(
+        connection.input.setDevice({
+          sampleRate: 16000,
+          inputDeviceId: "mic-2",
+        })
+      ).rejects.toThrow(/sampleRate or format/);
+
+      expect(createLocalAudioTrack).not.toHaveBeenCalled();
+
+      connection.close();
+    });
+
+    it("rejects a format change on the input device", async () => {
+      mockConnectedRoom();
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
+
+      await expect(
+        connection.input.setDevice({ format: "ulaw" })
+      ).rejects.toThrow(/sampleRate or format/);
+
+      connection.close();
+    });
+
+    it("switches the input device when the negotiated sampleRate and format are re-passed unchanged", async () => {
+      const mockRoom = mockConnectedRoom();
+      (
+        mockRoom.localParticipant.getTrackPublication as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue(undefined);
+      (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValue({
+        mediaStreamTrack: { id: "new-track", kind: "audio" },
+      });
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
+
+      // WebRTC always negotiates pcm_48000 (see connectionType: "webrtc"
+      // handling in create()), so re-sending that same pair is not a change
+      // request, and callers do this routinely alongside a device id.
+      await expect(
+        connection.input.setDevice({
+          sampleRate: 48000,
+          format: "pcm",
+          inputDeviceId: "mic-2",
+        })
+      ).resolves.toBeUndefined();
+
+      expect(createLocalAudioTrack).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: { exact: "mic-2" } })
+      );
+
+      connection.close();
+    });
+
+    it("switches the input device when only preferHeadphonesForIosDevices is also passed", async () => {
       const mockRoom = mockConnectedRoom();
       (
         mockRoom.localParticipant.getTrackPublication as ReturnType<
@@ -652,7 +709,7 @@ describe("WebRTCConnection", () => {
 
       await expect(
         connection.input.setDevice({
-          ...IGNORED_INPUT_OPTIONS,
+          preferHeadphonesForIosDevices: true,
           inputDeviceId: "mic-2",
         })
       ).resolves.toBeUndefined();
@@ -664,7 +721,7 @@ describe("WebRTCConnection", () => {
       connection.close();
     });
 
-    it("stays a no-op when only unsupported input options are passed", async () => {
+    it("stays a no-op when only preferHeadphonesForIosDevices is passed", async () => {
       mockConnectedRoom();
       const connection = await WebRTCConnection.create({
         conversationToken: "test-token",
@@ -672,7 +729,7 @@ describe("WebRTCConnection", () => {
       });
 
       await expect(
-        connection.input.setDevice({ ...IGNORED_INPUT_OPTIONS })
+        connection.input.setDevice({ preferHeadphonesForIosDevices: true })
       ).resolves.toBeUndefined();
 
       expect(createLocalAudioTrack).not.toHaveBeenCalled();
@@ -680,7 +737,7 @@ describe("WebRTCConnection", () => {
       connection.close();
     });
 
-    it("switches the output device when unsupported options are also passed", async () => {
+    it("rejects a sampleRate or format change on the output device, even alongside a device id", async () => {
       mockConnectedRoom();
       const setOutputDevice = vi.fn(() => Promise.resolve());
       setWebRTCAudioAdapterFactory(() => ({
@@ -706,9 +763,9 @@ describe("WebRTCConnection", () => {
             format: "pcm",
             outputDeviceId: "speaker-2",
           })
-        ).resolves.toBeUndefined();
+        ).rejects.toThrow(/sampleRate or format/);
 
-        expect(setOutputDevice).toHaveBeenCalledWith("speaker-2");
+        expect(setOutputDevice).not.toHaveBeenCalled();
 
         connection.close();
       } finally {
@@ -716,7 +773,7 @@ describe("WebRTCConnection", () => {
       }
     });
 
-    it("stays a no-op when only unsupported output options are passed", async () => {
+    it("switches the output device when the negotiated sampleRate and format are re-passed unchanged", async () => {
       mockConnectedRoom();
       const setOutputDevice = vi.fn(() => Promise.resolve());
       setWebRTCAudioAdapterFactory(() => ({
@@ -737,10 +794,14 @@ describe("WebRTCConnection", () => {
         });
 
         await expect(
-          connection.output.setDevice({ sampleRate: 16000, format: "pcm" })
+          connection.output.setDevice({
+            sampleRate: 48000,
+            format: "pcm",
+            outputDeviceId: "speaker-2",
+          })
         ).resolves.toBeUndefined();
 
-        expect(setOutputDevice).not.toHaveBeenCalled();
+        expect(setOutputDevice).toHaveBeenCalledWith("speaker-2");
 
         connection.close();
       } finally {

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -603,4 +603,149 @@ describe("WebRTCConnection", () => {
       connection.close();
     });
   });
+
+  describe("device option parity with the WebSocket path", () => {
+    function mockConnectedRoom() {
+      const mockRoom = new Room() as any;
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "connected") {
+            queueMicrotask(callback);
+          }
+        }
+      );
+      (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "signalConnected") {
+            queueMicrotask(callback);
+          }
+        }
+      );
+      return mockRoom;
+    }
+
+    // Options the WebSocket input path silently ignores because they cannot be
+    // applied to an already-running AudioContext. WebRTC used to throw on them,
+    // which meant `changeInputDevice` switched the device on one connection type
+    // and failed outright on the other.
+    const IGNORED_INPUT_OPTIONS = {
+      sampleRate: 16000,
+      format: "pcm",
+      preferHeadphonesForIosDevices: true,
+    } as const;
+
+    it("switches the input device when unsupported options are also passed", async () => {
+      const mockRoom = mockConnectedRoom();
+      (
+        mockRoom.localParticipant.getTrackPublication as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue(undefined);
+      (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValue({
+        mediaStreamTrack: { id: "new-track", kind: "audio" },
+      });
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
+
+      await expect(
+        connection.input.setDevice({
+          ...IGNORED_INPUT_OPTIONS,
+          inputDeviceId: "mic-2",
+        })
+      ).resolves.toBeUndefined();
+
+      expect(createLocalAudioTrack).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: { exact: "mic-2" } })
+      );
+
+      connection.close();
+    });
+
+    it("stays a no-op when only unsupported input options are passed", async () => {
+      mockConnectedRoom();
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
+
+      await expect(
+        connection.input.setDevice({ ...IGNORED_INPUT_OPTIONS })
+      ).resolves.toBeUndefined();
+
+      expect(createLocalAudioTrack).not.toHaveBeenCalled();
+
+      connection.close();
+    });
+
+    it("switches the output device when unsupported options are also passed", async () => {
+      mockConnectedRoom();
+      const setOutputDevice = vi.fn(() => Promise.resolve());
+      setWebRTCAudioAdapterFactory(() => ({
+        attachRemoteTrack: vi.fn(() => Promise.resolve()),
+        setupInputAnalysis: vi.fn(() => ({ volumeProvider: NO_VOLUME })),
+        setupOutputAnalysis: vi.fn(() =>
+          Promise.resolve({ volumeProvider: NO_VOLUME })
+        ),
+        setVolume: vi.fn(),
+        setOutputDevice,
+        cleanup: vi.fn(),
+      }));
+
+      try {
+        const connection = await WebRTCConnection.create({
+          conversationToken: "test-token",
+          connectionType: "webrtc",
+        });
+
+        await expect(
+          connection.output.setDevice({
+            sampleRate: 16000,
+            format: "pcm",
+            outputDeviceId: "speaker-2",
+          })
+        ).resolves.toBeUndefined();
+
+        expect(setOutputDevice).toHaveBeenCalledWith("speaker-2");
+
+        connection.close();
+      } finally {
+        setWebRTCAudioAdapterFactory(() => new WebAudioAdapter());
+      }
+    });
+
+    it("stays a no-op when only unsupported output options are passed", async () => {
+      mockConnectedRoom();
+      const setOutputDevice = vi.fn(() => Promise.resolve());
+      setWebRTCAudioAdapterFactory(() => ({
+        attachRemoteTrack: vi.fn(() => Promise.resolve()),
+        setupInputAnalysis: vi.fn(() => ({ volumeProvider: NO_VOLUME })),
+        setupOutputAnalysis: vi.fn(() =>
+          Promise.resolve({ volumeProvider: NO_VOLUME })
+        ),
+        setVolume: vi.fn(),
+        setOutputDevice,
+        cleanup: vi.fn(),
+      }));
+
+      try {
+        const connection = await WebRTCConnection.create({
+          conversationToken: "test-token",
+          connectionType: "webrtc",
+        });
+
+        await expect(
+          connection.output.setDevice({ sampleRate: 16000, format: "pcm" })
+        ).resolves.toBeUndefined();
+
+        expect(setOutputDevice).not.toHaveBeenCalled();
+
+        connection.close();
+      } finally {
+        setWebRTCAudioAdapterFactory(() => new WebAudioAdapter());
+      }
+    });
+  });
 });

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -96,18 +96,11 @@ export class WebRTCConnection extends BaseConnection {
       }
     },
     setDevice: async (config?: Partial<FormatConfig> & InputDeviceConfig) => {
-      // WebRTC only supports changing inputDeviceId
-      // sampleRate, format, and preferHeadphonesForIosDevices are not supported
-      if (
-        config?.sampleRate !== undefined ||
-        config?.format !== undefined ||
-        config?.preferHeadphonesForIosDevices !== undefined
-      ) {
-        throw new Error(
-          "WebRTC input device does not support sampleRate, format, or preferHeadphonesForIosDevices options"
-        );
-      }
-
+      // WebRTC only supports changing inputDeviceId. sampleRate, format and
+      // preferHeadphonesForIosDevices are ignored, matching the WebSocket
+      // input path, which ignores them because they cannot be applied to an
+      // already-running AudioContext. Throwing here instead would make the two
+      // connection types non-interchangeable behind InputController.
       const inputDeviceId = config?.inputDeviceId;
       if (!inputDeviceId) {
         // No device ID specified - this is a no-op for WebRTC
@@ -183,14 +176,9 @@ export class WebRTCConnection extends BaseConnection {
       // Audio elements are cleaned up when the connection closes
     },
     setDevice: async (config?: Partial<FormatConfig> & OutputDeviceConfig) => {
-      // WebRTC only supports changing outputDeviceId
-      // sampleRate and format are not supported
-      if (config?.sampleRate !== undefined || config?.format !== undefined) {
-        throw new Error(
-          "WebRTC output device does not support sampleRate or format options"
-        );
-      }
-
+      // WebRTC only supports changing outputDeviceId. sampleRate and format are
+      // ignored, matching the WebSocket output path — see the input controller
+      // above for why this ignores rather than throws.
       const outputDeviceId = config?.outputDeviceId;
       if (!outputDeviceId) {
         // No device ID specified - this is a no-op for WebRTC

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -96,11 +96,25 @@ export class WebRTCConnection extends BaseConnection {
       }
     },
     setDevice: async (config?: Partial<FormatConfig> & InputDeviceConfig) => {
-      // WebRTC only supports changing inputDeviceId. sampleRate, format and
-      // preferHeadphonesForIosDevices are ignored, matching the WebSocket
-      // input path, which ignores them because they cannot be applied to an
-      // already-running AudioContext. Throwing here instead would make the two
-      // connection types non-interchangeable behind InputController.
+      // sampleRate and format cannot be applied to an in-progress WebRTC or
+      // WebSocket input, on top of an inputDeviceId change or on their own, so
+      // both paths reject a value other than the one already negotiated
+      // rather than silently keeping the old format. Re-passing that same
+      // value back, which callers routinely do alongside an inputDeviceId
+      // change, stays a no-op — see the WebSocket input path for why. This is
+      // the one intentional asymmetry with preferHeadphonesForIosDevices,
+      // which stays a best-effort hint the caller cannot rely on either way.
+      if (
+        (config?.sampleRate !== undefined &&
+          config.sampleRate !== this.inputFormat.sampleRate) ||
+        (config?.format !== undefined &&
+          config.format !== this.inputFormat.format)
+      ) {
+        throw new Error(
+          "WebRTC input device does not support changing sampleRate or format after the connection is created"
+        );
+      }
+
       const inputDeviceId = config?.inputDeviceId;
       if (!inputDeviceId) {
         // No device ID specified - this is a no-op for WebRTC
@@ -176,9 +190,20 @@ export class WebRTCConnection extends BaseConnection {
       // Audio elements are cleaned up when the connection closes
     },
     setDevice: async (config?: Partial<FormatConfig> & OutputDeviceConfig) => {
-      // WebRTC only supports changing outputDeviceId. sampleRate and format are
-      // ignored, matching the WebSocket output path — see the input controller
-      // above for why this ignores rather than throws.
+      // See the input controller above: sampleRate and format cannot be
+      // applied after creation on either connection type, so both reject a
+      // value other than the one already negotiated.
+      if (
+        (config?.sampleRate !== undefined &&
+          config.sampleRate !== this.outputFormat.sampleRate) ||
+        (config?.format !== undefined &&
+          config.format !== this.outputFormat.format)
+      ) {
+        throw new Error(
+          "WebRTC output device does not support changing sampleRate or format after the connection is created"
+        );
+      }
+
       const outputDeviceId = config?.outputDeviceId;
       if (!outputDeviceId) {
         // No device ID specified - this is a no-op for WebRTC

--- a/packages/client/src/utils/input.test.ts
+++ b/packages/client/src/utils/input.test.ts
@@ -25,4 +25,39 @@ describe("MediaDeviceInput", () => {
     expect(encodedAudio.length).toBeGreaterThan(0);
     expect(volume).toBeTypeOf("number");
   });
+
+  describe("setDevice", () => {
+    it("rejects a sampleRate change after creation, even alongside a device id", async () => {
+      input = await MediaDeviceInput.create({
+        sampleRate: 16000,
+        format: "pcm",
+      });
+
+      await expect(
+        input.setDevice({ sampleRate: 48000, inputDeviceId: "mic-2" })
+      ).rejects.toThrow(/sampleRate or format/);
+    });
+
+    it("rejects a format change after creation", async () => {
+      input = await MediaDeviceInput.create({
+        sampleRate: 16000,
+        format: "pcm",
+      });
+
+      await expect(input.setDevice({ format: "ulaw" })).rejects.toThrow(
+        /sampleRate or format/
+      );
+    });
+
+    it("stays a no-op when only preferHeadphonesForIosDevices is passed", async () => {
+      input = await MediaDeviceInput.create({
+        sampleRate: 16000,
+        format: "pcm",
+      });
+
+      await expect(
+        input.setDevice({ preferHeadphonesForIosDevices: true })
+      ).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/client/src/utils/output.test.ts
+++ b/packages/client/src/utils/output.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { MediaDeviceOutput } from "../platform/web/output.js";
+
+// MediaDeviceOutput.create() needs a real AudioContext/AudioWorklet, which
+// this package's Node test project does not provide (only src/utils/input.ts
+// runs in the browser project, and output's own setup, unlike input's,
+// depends on AudioContext.resume() settling, which headless Chromium's
+// autoplay policy leaves permanently pending outside a real browser test
+// environment). The sampleRate/format guard below runs before setDevice
+// touches any instance state, so it is exercised directly against the class's
+// real setDevice implementation, without going through create().
+describe("MediaDeviceOutput.setDevice", () => {
+  beforeAll(() => {
+    function FakeHTMLAudioElement() {}
+    FakeHTMLAudioElement.prototype = { setSinkId: () => {} };
+    vi.stubGlobal("HTMLAudioElement", FakeHTMLAudioElement);
+  });
+
+  function uncreatedOutput(): MediaDeviceOutput {
+    return Object.create(MediaDeviceOutput.prototype) as MediaDeviceOutput;
+  }
+
+  it("rejects a sampleRate change, even alongside a device id", async () => {
+    await expect(
+      uncreatedOutput().setDevice({
+        sampleRate: 48000,
+        outputDeviceId: "speaker-2",
+      })
+    ).rejects.toThrow(/sampleRate or format/);
+  });
+
+  it("rejects a format change", async () => {
+    await expect(
+      uncreatedOutput().setDevice({ format: "ulaw" })
+    ).rejects.toThrow(/sampleRate or format/);
+  });
+});


### PR DESCRIPTION
Fixes #549.

## The premise still holds, under a different name

The issue names `setInputDevice`, which no longer exists — the public entry point is now `VoiceConversation.changeInputDevice()` (and `useConversation().changeInputDevice()` in `@elevenlabs/react`), delegating to `InputController.setDevice`. Verified against `main`: the inconsistency it describes is unchanged.

`changeInputDevice` accepts `Partial<FormatConfig> & InputDeviceConfig` and forwards `sampleRate`, `format` and `preferHeadphonesForIosDevices` straight through:

- **WebSocket** (`MediaDeviceInput.setDevice`) ignored `sampleRate`/`format` unconditionally — they cannot be applied to an already-running `AudioContext` — and switched the device.
- **WebRTC** (`WebRTCConnection.input.setDevice`) threw on `sampleRate`/`format`/`preferHeadphonesForIosDevices` unconditionally, and did not change the device at all.

The output controllers had the same asymmetry for `sampleRate`/`format`.

## What this does

Both connection types now compare the requested `sampleRate`/`format` against the one the connection actually negotiated (the WebSocket path's own configured values; WebRTC's fixed `pcm_48000`), input and output:

- **A value that differs from what's negotiated throws**, on both connection types. `sampleRate`/`format` are things the caller explicitly controls; silently ignoring a value we cannot honor was the actual bug in the original WebSocket behavior, not just the WebRTC/WebSocket inconsistency by itself. See [this thread](https://github.com/elevenlabs/packages/pull/953#issuecomment-5349023198) for the full reasoning after @kraenhansen's review.
- **Re-passing the same value the connection already has, alongside a device id or alone, stays a no-op** on both connection types. Callers do this routinely — `index.test.ts` already had a test asserting `changeInputDevice({ sampleRate: 16000, format: "pcm" })` and the output equivalent succeed with no deviceId, passing the session's own format back rather than asking to change it. That existing pattern still works.

`preferHeadphonesForIosDevices` stays a silent best-effort hint on WebRTC (unchanged from before): it's a device-selection preference, not a format guarantee the way `sampleRate`/`format` are.

## Tests

`WebRTCConnection.test.ts`: 4 tests asserting throw on a real mismatch (input sampleRate, input format, output sampleRate+format, each with a device id present), 2 tests asserting the re-passed-same-value case still switches the device.

`input.test.ts`/`output.test.ts` (WebSocket path): throw-on-mismatch and no-op-on-match, exercised directly against `MediaDeviceInput`/`MediaDeviceOutput`. `output.test.ts` is new — `MediaDeviceOutput` had no test coverage before, and its `create()` needs a live `AudioContext`/`AudioWorklet` that isn't available outside this repo's browser test project (only `index.test.ts` and `input.test.ts` are configured to run there). The guard runs before `setDevice` touches any instance state, so it's tested against the class's real `setDevice` without going through `create()`, avoiding adding output creation to the browser suite for this fix alone.

Fail-first with only the three source files stashed: the 3 throw-assertion tests fail (rest are unaffected, since they test the no-op path). `packages/client` 227/227 with the fix restored. `packages/react` 140/140, unaffected. `turbo lint`/`check-types`/`build` green across all 9 packages (29/29). Changeset included, `patch` on `@elevenlabs/client`.

No test pinned the old throwing/ignoring behaviour as-is, and nothing in `packages/react` or `packages/react-native` needed changing — both call straight through.

Heads-up on overlap: #642, #813 and #814 also touch `WebRTCConnection.ts`, but none of them touches either `setDevice`, and the hunks here are small and adjacent.
