### PR TITLE
refactor(client): inject platform setup hints from the entry point

### DIFF
--- a/.changeset/platform-setup-hint.md
+++ b/.changeset/platform-setup-hint.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Resolve React Native via the `react-native` export condition instead of sniffing globals, and let platform entry points inject the setup guidance shown when nothing is registered.

--- a/examples/react-native-expo/metroResolution.test.cjs
+++ b/examples/react-native-expo/metroResolution.test.cjs
@@ -1,0 +1,68 @@
+// Which @elevenlabs/client entry point Metro picks, per platform, using this
+// app's own Metro and metro.config.js. Metro has no public resolve-only API,
+// so this drives the resolver its bundler uses internally.
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { test, before, after } = require("node:test");
+
+const appRoot = __dirname;
+const repoRoot = path.resolve(appRoot, "../..");
+
+// The Metro this app bundles with, not a copy of our own.
+const metroRoot = path.dirname(
+  require.resolve("metro/package.json", {
+    paths: [require.resolve("expo/package.json", { paths: [appRoot] })],
+  })
+);
+const Metro = require(metroRoot);
+const DependencyGraph = require(
+  path.join(metroRoot, "src/node-haste/DependencyGraph")
+).default;
+
+// A bare "@elevenlabs/client" import as @elevenlabs/react-native makes it.
+const origin = require.resolve("@elevenlabs/react-native", {
+  paths: [appRoot],
+});
+
+let graph;
+
+before(async () => {
+  const config = await Metro.loadConfig({
+    cwd: appRoot,
+    config: path.join(appRoot, "metro.config.js"),
+  });
+  graph = new DependencyGraph(config, { watch: false });
+  await graph.ready();
+});
+
+after(() => graph.end());
+
+function resolveClient(platform) {
+  const { filePath } = graph.resolveDependency(
+    origin,
+    {
+      name: "@elevenlabs/client",
+      data: { key: "test", isESMImport: true, asyncType: null, locs: [] },
+    },
+    platform,
+    { dev: true, customResolverOptions: {} }
+  );
+  return path.relative(repoRoot, filePath);
+}
+
+for (const platform of ["ios", "android"]) {
+  test(`${platform} resolves the React Native entry point`, () => {
+    assert.equal(
+      resolveClient(platform),
+      "packages/client/dist/platform/react-native/index.js"
+    );
+  });
+}
+
+test("web resolves the browser entry point", () => {
+  assert.equal(
+    resolveClient("web"),
+    "packages/client/dist/platform/web/index.js"
+  );
+});

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -10,7 +10,8 @@
     "web": "expo start --web",
     "build:android": "expo prebuild --platform android",
     "build:ios": "expo prebuild --platform ios",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "node --test"
   },
   "dependencies": {
     "@config-plugins/react-native-webrtc": "^15.0.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,6 +8,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "unpkg": "./dist/lib.iife.js",
+      "react-native": "./dist/platform/react-native/index.js",
       "browser": "./dist/platform/web/index.js",
       "default": "./dist/index.js"
     },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,8 +8,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "unpkg": "./dist/lib.iife.js",
-      "react-native": "./dist/platform/react-native/index.js",
       "browser": "./dist/platform/web/index.js",
+      "react-native": "./dist/platform/react-native/index.js",
       "default": "./dist/index.js"
     },
     "./internal": "./dist/internal.js",

--- a/packages/client/src/internal.ts
+++ b/packages/client/src/internal.ts
@@ -20,6 +20,7 @@ export {
   MIN_VOICE_FREQUENCY,
   MAX_VOICE_FREQUENCY,
 } from "./utils/volumeProvider.js";
+export { setPlatformSetupHint } from "./platform/diagnostics.js";
 export { setWebRTCAudioAdapterFactory } from "./WebRTCAudioAdapter.js";
 export type {
   WebRTCAudioAdapter,

--- a/packages/client/src/platform/VoiceSessionSetup.test.ts
+++ b/packages/client/src/platform/VoiceSessionSetup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 vi.mock("livekit-client", () => ({
   Room: vi.fn(),
@@ -77,10 +77,6 @@ describe("setupWebRTCSession", () => {
 });
 
 describe("ensureSetupStrategy", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("returns the registered strategy", async () => {
     const { ensureSetupStrategy, setSetupStrategy } = await freshModule();
     const strategy = vi.fn();
@@ -89,45 +85,21 @@ describe("ensureSetupStrategy", () => {
     expect(ensureSetupStrategy()).toBe(strategy);
   });
 
-  it("points a browser user at the platform entry point", async () => {
+  it("points at the platform entry point when none is registered", async () => {
     const { ensureSetupStrategy } = await freshModule();
 
     expect(() => ensureSetupStrategy()).toThrow(
-      'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
+      'No voice session setup strategy registered. Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
     );
   });
 
-  it("points a React Native user at @elevenlabs/react-native", async () => {
-    vi.stubGlobal("navigator", { product: "ReactNative" });
+  it("uses the hint the entry point injected", async () => {
     const { ensureSetupStrategy } = await freshModule();
+    const { setPlatformSetupHint } = await import("./diagnostics.js");
+    setPlatformSetupHint("Do the platform-specific thing.");
 
     expect(() => ensureSetupStrategy()).toThrow(
-      "@elevenlabs/client in React Native without importing @elevenlabs/react-native"
+      "No voice session setup strategy registered. Do the platform-specific thing."
     );
-  });
-
-  it("detects React Native via the Hermes global too", async () => {
-    vi.stubGlobal("HermesInternal", {});
-    const { ensureSetupStrategy } = await freshModule();
-
-    expect(() => ensureSetupStrategy()).toThrow(
-      "@elevenlabs/client in React Native without importing @elevenlabs/react-native"
-    );
-  });
-
-  it("does not mention React Native in a browser-like environment", async () => {
-    vi.stubGlobal("navigator", { product: "Gecko" });
-    const { ensureSetupStrategy } = await freshModule();
-
-    expect(() => ensureSetupStrategy()).not.toThrow("React Native");
-  });
-
-  it("never throws the browser message once a strategy is registered in React Native", async () => {
-    vi.stubGlobal("navigator", { product: "ReactNative" });
-    const { ensureSetupStrategy, setSetupStrategy } = await freshModule();
-    const strategy = vi.fn();
-    setSetupStrategy(strategy);
-
-    expect(ensureSetupStrategy()).toBe(strategy);
   });
 });

--- a/packages/client/src/platform/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/VoiceSessionSetup.ts
@@ -4,6 +4,7 @@ import type { InputController } from "../InputController.js";
 import type { OutputController } from "../OutputController.js";
 import type { PlaybackEventTarget } from "../OutputController.js";
 import { WebRTCConnection } from "../utils/WebRTCConnection.js";
+import { missingRegistrationError } from "./diagnostics.js";
 
 export type VoiceSessionSetupResult = {
   connection: BaseConnection;
@@ -31,43 +32,12 @@ export function setSetupStrategy(strategy: VoiceSessionSetupStrategy) {
   setupStrategy = strategy;
 }
 
-/**
- * Detects a React Native runtime.
- *
- * `navigator.product === "ReactNative"` is the long-standing signal; Hermes,
- * the default engine on modern React Native, exposes a `HermesInternal` global.
- * Either is enough, and both are absent in a browser.
- */
-function isReactNativeEnvironment(): boolean {
-  const globals = globalThis as {
-    navigator?: { product?: string };
-    HermesInternal?: unknown;
-  };
-  return (
-    globals.navigator?.product === "ReactNative" ||
-    globals.HermesInternal != null
-  );
-}
-
-/**
- * Returns the registered setup strategy, or throws explaining how to register
- * one. On React Native the fix is to import `@elevenlabs/react-native`, which
- * polyfills the WebRTC globals, configures the native audio session and
- * registers its own strategy — pointing at the browser entry point there would
- * be actively wrong.
- */
+/** Returns the registered setup strategy, or throws explaining how to register one. */
 export function ensureSetupStrategy(): VoiceSessionSetupStrategy {
   if (setupStrategy) {
     return setupStrategy;
   }
-  throw new Error(
-    isReactNativeEnvironment()
-      ? "No voice session setup strategy registered. It looks like you're using " +
-          "@elevenlabs/client in React Native without importing @elevenlabs/react-native. " +
-          'Add `import "@elevenlabs/react-native";` before any other ElevenLabs imports.'
-      : "No voice session setup strategy registered. " +
-          'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
-  );
+  throw missingRegistrationError("voice session setup strategy");
 }
 
 /**

--- a/packages/client/src/platform/diagnostics.test.ts
+++ b/packages/client/src/platform/diagnostics.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("livekit-client", () => ({
+  Room: vi.fn(),
+  RoomEvent: {},
+  Track: { Kind: { Audio: "audio" }, Source: { Microphone: "microphone" } },
+  ConnectionState: {},
+  createLocalAudioTrack: vi.fn(),
+}));
+
+// The hint is module-level state with no reset, so each case works against a
+// freshly imported copy of the module.
+async function freshModule() {
+  vi.resetModules();
+  return import("./diagnostics.js");
+}
+
+describe("missingRegistrationError", () => {
+  it("names the subject and the default entry point", async () => {
+    const { missingRegistrationError } = await freshModule();
+
+    expect(missingRegistrationError("widget factory").message).toBe(
+      'No widget factory registered. Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).'
+    );
+  });
+
+  it("uses an injected hint instead", async () => {
+    const { missingRegistrationError, setPlatformSetupHint } =
+      await freshModule();
+    setPlatformSetupHint("Do the platform-specific thing.");
+
+    expect(missingRegistrationError("widget factory").message).toBe(
+      "No widget factory registered. Do the platform-specific thing."
+    );
+  });
+});
+
+describe("the React Native entry point", () => {
+  it("points at @elevenlabs/react-native", async () => {
+    vi.resetModules();
+    await import("./react-native/index.js");
+    const { missingRegistrationError } = await import("./diagnostics.js");
+
+    expect(missingRegistrationError("voice session setup strategy").message)
+      .toMatchInlineSnapshot(`
+        "No voice session setup strategy registered. It looks like you're using @elevenlabs/client in React Native without importing @elevenlabs/react-native. Add \`import "@elevenlabs/react-native";\` before any other ElevenLabs imports."
+      `);
+  });
+});

--- a/packages/client/src/platform/diagnostics.ts
+++ b/packages/client/src/platform/diagnostics.ts
@@ -1,0 +1,23 @@
+/**
+ * Guidance for errors raised when nothing registered a platform
+ * implementation. Injected by the platform entry points at import time, so
+ * the core never has to detect the runtime it is executing in.
+ */
+
+const DEFAULT_SETUP_HINT =
+  'Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).';
+
+let setupHint = DEFAULT_SETUP_HINT;
+
+/**
+ * Replaces the remediation advice in "nothing registered" errors with
+ * something the platform entry point knows to be actionable.
+ */
+export function setPlatformSetupHint(hint: string): void {
+  setupHint = hint;
+}
+
+/** @param subject - What is missing, e.g. "voice session setup strategy". */
+export function missingRegistrationError(subject: string): Error {
+  return new Error(`No ${subject} registered. ${setupHint}`);
+}

--- a/packages/client/src/platform/react-native/index.ts
+++ b/packages/client/src/platform/react-native/index.ts
@@ -1,0 +1,14 @@
+// React Native bundlers resolve @elevenlabs/client here via the "react-native"
+// export condition. The implementations themselves live in
+// @elevenlabs/react-native — it polyfills the WebRTC globals, configures the
+// native audio session and registers the setup strategy — so all this entry
+// point can do is say so if the app never imported it.
+import { setPlatformSetupHint } from "../diagnostics.js";
+
+setPlatformSetupHint(
+  "It looks like you're using @elevenlabs/client in React Native without " +
+    'importing @elevenlabs/react-native. Add `import "@elevenlabs/react-native";` ' +
+    "before any other ElevenLabs imports."
+);
+
+export * from "../../index.js";

--- a/packages/client/src/scribe/microphone.ts
+++ b/packages/client/src/scribe/microphone.ts
@@ -6,6 +6,8 @@
  * their own implementation via `setScribeMicrophoneSetup`.
  */
 
+import { missingRegistrationError } from "../platform/diagnostics.js";
+
 export interface ScribeMicrophoneConfig {
   deviceId?: MediaDeviceConstraint;
   echoCancellation?: boolean;
@@ -54,11 +56,7 @@ export function setScribeMicrophoneSetup(setup: ScribeMicrophoneSetup): void {
 
 export function getScribeMicrophoneSetup(): ScribeMicrophoneSetup {
   if (!microphoneSetup) {
-    throw new Error(
-      "No Scribe microphone implementation registered. " +
-        "Import '@elevenlabs/client/platform/web' or provide a custom " +
-        "implementation via setScribeMicrophoneSetup()."
-    );
+    throw missingRegistrationError("Scribe microphone implementation");
   }
   return microphoneSetup;
 }


### PR DESCRIPTION
Closes #954

## The problem

#944 landed the right error message via the wrong mechanism: `isReactNativeEnvironment()` sniffed `navigator.product` and `HermesInternal` from inside the platform-agnostic core. `navigator.product` is a legacy field, Hermes is neither guaranteed nor exclusive to React Native, and every future platform would have added another branch to a core module that has no business knowing what it runs on.

The module graph already carries this information. `@elevenlabs/react-native` has resolved itself through the `"react-native"` export condition since it shipped — the core just wasn't using the same signal.

## The fix

`@elevenlabs/client` gains a `"react-native"` export condition pointing at a new entry point that injects the remediation advice and re-exports the core:

```jsonc
".": {
  "types": "./dist/index.d.ts",
  "unpkg": "./dist/lib.iife.js",
  "browser": "./dist/platform/web/index.js",
  "react-native": "./dist/platform/react-native/index.js",  // new

  "default": "./dist/index.js"
}
```

`platform/diagnostics.ts` holds the injected hint and builds the error; `setPlatformSetupHint()` joins the existing injection points (`setSetupStrategy`, `setWebRTCAudioAdapterFactory`, `setScribeMicrophoneSetup`) and is exported from `/internal` so any platform package can supply its own. The React Native entry point registers no implementation — those genuinely live in `@elevenlabs/react-native` — so all it does is make the failure say so.

Both "nothing registered" errors now route through it, as #954 asked:

- `ensureSetupStrategy()` — voice session setup
- `getScribeMicrophoneSetup()` — Scribe microphone

The default hint is the browser wording, unchanged word for word, so a browser app that hits either guard sees what it saw before. The Scribe message loses its trailing `setScribeMicrophoneSetup()` mention (an `/internal` API) in exchange for naming the right package on React Native.

Net effect on the core: `isReactNativeEnvironment()` and the branching message are gone, −68 lines, and adding a platform is now adding an entry point rather than editing a conditional.

## Verification

**Resolution, end to end** — built `dist`, then resolved the real package under each condition (Node and Metro run the same exports algorithm; `"react-native"` is in Metro's default `unstable_conditionNames`):

```
$ node --conditions=react-native -e 'Conversation.startSession({agentId: "x", connectionType: "webrtc"})'
No voice session setup strategy registered. It looks like you're using @elevenlabs/client in React Native
without importing @elevenlabs/react-native. Add `import "@elevenlabs/react-native";` before any other ElevenLabs imports.

$ node -e '…same…'   # default condition
No voice session setup strategy registered. Import the platform-specific entry point (e.g. @elevenlabs/client via the "browser" export).
```

That is the behaviour #604 asked for, now with no globals involved — and the browser message is byte-identical to before.

**Tests** — the four global-stubbing cases in `VoiceSessionSetup.test.ts` are deleted (nothing left to stub) and replaced by two that assert the default and injected hints. New `platform/diagnostics.test.ts` covers `missingRegistrationError` and imports the React Native entry point for real, snapshotting the message it produces.

Full `@elevenlabs/client` suite: **215 passed / 18 files**. `turbo build lint check-types`: **31 tasks green** across all 9 packages.

## Metro

Node's `--conditions` is the same algorithm bundlers implement, but it can't tell you which conditions a bundler *asserts* — and Bugbot flagged exactly that gap, arguing Metro asserts `react-native` even on web ([thread](https://github.com/elevenlabs/packages/pull/955#discussion_r3812729748)). It doesn't; Expo 56 / Metro 0.84.4 sets `unstable_conditionNames: []` with `unstable_conditionsByPlatform: {ios: ["react-native"], web: ["browser"], …}`, so each platform asserts exactly one of the two.

`examples/react-native-expo/metroResolution.test.cjs` now pins that down instead of arguing about it: it loads the example app's own `metro.config.js` (custom `resolveRequest` and all) into that app's own Metro, and asks the resolver which file `@elevenlabs/client` resolves to per platform.

| platform | resolves to |
| --- | --- |
| `ios`, `android` | `dist/platform/react-native/index.js` |
| `web` | `dist/platform/web/index.js` |

Fail-first: dropping the `react-native` condition from the exports map fails the ios and android cases and leaves web passing, which is the shape you'd want. `"browser"` is listed ahead of `"react-native"` — not because Metro needs it, but so a bundler that asserts both still picks web, matching the order `@elevenlabs/react-native` already uses.

Metro has no public resolve-only API, so the test reaches for the `DependencyGraph` its bundler uses internally; the alternative was transforming a full bundle per platform. It runs in ~6s via the example's new `test` script.

## Test plan

- [x] `react-native` condition resolves to the new entry point and yields the React Native message
- [x] `default` condition yields the unchanged browser message
- [x] Unit tests for default hint, injected hint, and the React Native entry point
- [x] `turbo build lint check-types` green across the workspace
- [x] Metro resolves the condition per platform, driven by the Expo example's real `metro.config.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

