### PR TITLE
Wire up the context_usage server event via a new onContextUsage callback

### DIFF
--- a/.changeset/context-usage-callback.md
+++ b/.changeset/context-usage-callback.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": patch
+---
+
+Add support for the `context_usage` server event via a new `onContextUsage` callback. The event is emitted after each completed agent turn and reports `{ event_id, model, context_tokens, context_limit_tokens }`, where `context_tokens` is the prompt size of the turn's last LLM generation and `context_limit_tokens` is that model's maximum context window — useful for surfacing how close a long conversation is to the context limit.

--- a/examples/agent-testbench/src/components/agent-page.tsx
+++ b/examples/agent-testbench/src/components/agent-page.tsx
@@ -39,6 +39,7 @@ const EVENT_METHOD_NAMES = [
   "onAudioAlignment",
   "onGuardrailTriggered",
   "onPing",
+  "onContextUsage",
   "onDebug",
   "onIncomingEvent",
   "onOutgoingEvent",

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -428,6 +428,61 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("context_usage events", () => {
+    const contextUsageEvent = {
+      type: "context_usage" as const,
+      context_usage_event: {
+        event_id: 12,
+        model: "gemini-2.0-flash-001",
+        context_tokens: 4321,
+        context_limit_tokens: 1048576,
+      },
+    };
+
+    it("calls onContextUsage with the usage payload", async () => {
+      const onContextUsage = vi.fn();
+      const onDebug = vi.fn();
+      const conversation = TestConversation.create({
+        onContextUsage,
+        onDebug,
+      });
+
+      await conversation.receiveMessage(contextUsageEvent);
+
+      expect(onContextUsage).toHaveBeenCalledWith({
+        event_id: 12,
+        model: "gemini-2.0-flash-001",
+        context_tokens: 4321,
+        context_limit_tokens: 1048576,
+      });
+      expect(onDebug).not.toHaveBeenCalled();
+    });
+
+    it("sends nothing back to the server", async () => {
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      const conversation = TestConversation.create(
+        { onContextUsage: vi.fn() },
+        connection
+      );
+
+      await conversation.receiveMessage(contextUsageEvent);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when no callback is provided", async () => {
+      const conversation = TestConversation.create({});
+
+      await expect(
+        conversation.receiveMessage(contextUsageEvent)
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("agent_tool_response_full_payload events", () => {
     const basePayload = {
       tool_name: "lookup_kb",

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -15,6 +15,7 @@ import type {
   AgentResponseCorrectionEvent,
   AgentTypingEvent,
   ClientToolCallEvent,
+  ContextUsageEvent,
   ExternalAgentConnectedEvent,
   IncomingSocketEvent,
   InternalTentativeAgentResponseEvent,
@@ -290,6 +291,12 @@ export abstract class BaseConversation {
     }
   }
 
+  protected handleContextUsage(event: ContextUsageEvent) {
+    if (this.options.onContextUsage) {
+      this.options.onContextUsage(event.context_usage_event);
+    }
+  }
+
   protected async handleClientToolCall(event: ClientToolCallEvent) {
     if (
       Object.prototype.hasOwnProperty.call(
@@ -528,6 +535,11 @@ export abstract class BaseConversation {
         // consumers can, for example, warn when latency is high enough to
         // degrade the experience.
         this.handlePing(parsedEvent);
+        return;
+      }
+
+      case "context_usage": {
+        this.handleContextUsage(parsedEvent);
         return;
       }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -33,6 +33,7 @@ export type {
   IncomingSocketEvent,
   VadScoreEvent,
   PingEvent,
+  ContextUsageEvent,
   AudioAlignmentEvent,
 } from "./utils/events.js";
 export type {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -14,6 +14,7 @@ import type {
   AgentResponseCorrection,
   AgentChatResponsePartClientEvent,
   AgentReasoningResponsePartClientEvent,
+  ContextUsageClientEvent,
   Ping,
   RichContentClientEvent,
 } from "@elevenlabs/types";
@@ -155,6 +156,16 @@ export type Callbacks = {
    * estimate is available yet.
    */
   onPing?: (props: Ping["ping_event"]) => void;
+  /**
+   * Called when the server reports LLM context-window usage, which happens
+   * after each completed agent turn. Receives `{ event_id, model,
+   * context_tokens, context_limit_tokens }`, where `context_tokens` is the
+   * prompt size of the turn's last LLM generation and `context_limit_tokens`
+   * is that model's maximum context window.
+   */
+  onContextUsage?: (
+    props: ContextUsageClientEvent["context_usage_event"]
+  ) => void;
   // internal debug events, not to be used
   onDebug?: (props: any) => void;
   /**
@@ -198,6 +209,7 @@ export const CALLBACK_KEYS = [
   "onAgentTyping",
   "onExternalAgentConnected",
   "onPing",
+  "onContextUsage",
   "onDebug",
   "onIncomingEvent",
   "onOutgoingEvent",

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -10,6 +10,7 @@ import type {
   Audio,
   AgentToolRequestClientEvent,
   ClientToolCallMessage,
+  ContextUsageClientEvent,
   ConversationMetadata,
   ErrorMessage,
   ExternalAgentConnectedClientEvent,
@@ -35,6 +36,7 @@ export type InternalTentativeAgentResponseEvent =
   TentativeAgentResponseInternal;
 export type ConfigEvent = ConversationMetadata;
 export type PingEvent = Ping;
+export type ContextUsageEvent = ContextUsageClientEvent;
 export type ClientToolCallEvent = ClientToolCallMessage;
 export type VadScoreEvent = VadScore;
 export type MCPToolCallClientEvent = McpToolCall;
@@ -65,6 +67,7 @@ export type IncomingSocketEvent =
   | InternalTentativeAgentResponseEvent
   | ConfigEvent
   | PingEvent
+  | ContextUsageEvent
   | ClientToolCallEvent
   | VadScoreEvent
   | MCPToolCallClientEvent

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -48,6 +48,7 @@ export type HookCallbacks = Pick<
   | "onAgentTyping"
   | "onExternalAgentConnected"
   | "onPing"
+  | "onContextUsage"
   | "onIncomingEvent"
   | "onOutgoingEvent"
 >;

--- a/packages/react/src/conversation/useConversation.test.tsx
+++ b/packages/react/src/conversation/useConversation.test.tsx
@@ -350,4 +350,29 @@ describe("useConversation", () => {
       typeof (opts as MockStartSessionOptions).onConversationCreated
     ).toBe("function");
   });
+
+  it("forwards context_usage events to a hook-level onContextUsage", async () => {
+    const onContextUsage = vi.fn();
+    mockStartSessionWithLifecycle();
+
+    const { result } = renderHook(
+      () => useConversation({ agentId: "hook-agent-id", onContextUsage }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      result.current.startSession();
+    });
+
+    const [[opts]] = vi.mocked(Conversation.startSession).mock.calls;
+    const usage = {
+      event_id: 12,
+      model: "gemini-2.0-flash-001",
+      context_tokens: 4321,
+      context_limit_tokens: 1048576,
+    };
+    (opts as MockStartSessionOptions).onContextUsage?.(usage);
+
+    expect(onContextUsage).toHaveBeenCalledWith(usage);
+  });
 });

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -186,6 +186,7 @@ export type ConversationConfigOverrideConversationClientEventsItem =
   | "mcp_connection_status"
   | "vad_score"
   | "ping"
+  | "context_usage"
   | "asr_initiation_metadata"
   | "guardrail_triggered"
   | "internal_turn_probability"
@@ -519,6 +520,18 @@ export interface PingEvent {
   ping_ms?: number | null;
 }
 
+export interface ContextUsage {
+  type: "context_usage";
+  context_usage_event: ContextUsageEvent;
+}
+
+export interface ContextUsageEvent {
+  event_id: number;
+  model: string;
+  context_tokens: number;
+  context_limit_tokens: number;
+}
+
 export interface AsrInitiationMetadata {
   type: "asr_initiation_metadata";
   asr_initiation_metadata_event: Record<string, any>;
@@ -688,6 +701,11 @@ export interface McpConnectionStatusClientEvent {
 export interface VadScoreClientEvent {
   type: "vad_score";
   vad_score_event: VadScoreEvent;
+}
+
+export interface ContextUsageClientEvent {
+  type: "context_usage";
+  context_usage_event: ContextUsageEvent;
 }
 
 export interface AsrInitiationMetadataEvent {

--- a/packages/types/generated/types/incoming.ts
+++ b/packages/types/generated/types/incoming.ts
@@ -14,6 +14,7 @@ export type {
   CommittedTranscriptEntitiesMessage,
   CommittedTranscriptMessage,
   CommittedTranscriptWithTimestampsMessage,
+  ContextUsageClientEvent,
   ConversationInitiationMetadataEvent,
   ErrorClientEvent,
   ExternalAgentConnectedClientEvent,

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -64,6 +64,7 @@ channels:
           - $ref: "#/components/messages/MCPConnectionStatusMessage"
           - $ref: "#/components/messages/VADScore"
           - $ref: "#/components/messages/Ping"
+          - $ref: "#/components/messages/ContextUsage"
           - $ref: "#/components/messages/ASRInitiationMetadata"
           - $ref: "#/components/messages/GuardrailTriggered"
           - $ref: "#/components/messages/InternalTurnProbability"
@@ -318,6 +319,14 @@ components:
       payload:
         $ref: "#/components/schemas/PingPayload"
 
+    ContextUsage:
+      name: ContextUsageClientEvent
+      title: Context Usage
+      summary: LLM context-window usage reported after each completed agent turn
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/ContextUsagePayload"
+
     ASRInitiationMetadata:
       name: ASRInitiationMetadataEvent
       title: ASR Initiation Metadata
@@ -398,6 +407,7 @@ components:
         - mcp_connection_status
         - vad_score
         - ping
+        - context_usage
         - asr_initiation_metadata
         - guardrail_triggered
         - internal_turn_probability
@@ -965,6 +975,16 @@ components:
         ping_event:
           $ref: "#/components/schemas/PingData"
 
+    ContextUsagePayload:
+      type: object
+      required: [context_usage_event, type]
+      properties:
+        type:
+          type: string
+          const: context_usage
+        context_usage_event:
+          $ref: "#/components/schemas/ContextUsageData"
+
     # ===== NAMED SCHEMAS FOR EVENT DATA =====
 
     AudioEventData:
@@ -1235,6 +1255,22 @@ components:
             - type: integer
             - type: "null"
           description: Estimated ping in milliseconds, based on previous ping/pong timing.
+
+    ContextUsageData:
+      type: object
+      required: [event_id, model, context_tokens, context_limit_tokens]
+      properties:
+        event_id:
+          type: integer
+        model:
+          type: string
+          description: Identifier of the LLM whose context window is reported
+        context_tokens:
+          type: integer
+          description: Prompt size of the turn's last LLM generation in provider tokens (uncached input plus cache reads and writes)
+        context_limit_tokens:
+          type: integer
+          description: The model's maximum context window size in tokens
 
     ASRInitiationMetadataPayload:
       type: object


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds support for the `context_usage` server event across `@elevenlabs/types`, `@elevenlabs/client` and `@elevenlabs/react`.

## Note on the schema download

The task asked to download `https://api.elevenlabs.io/convai-asyncapi.yml` into `packages/types/schemas/agent.asyncapi.yaml`. I downloaded and diffed it, but **did not** overwrite the file: the two documents are not the same contract, and replacing one with the other breaks the SDK.

- `packages/types/schemas/agent.asyncapi.yaml` is hand-authored in this repo (`packages/types/README.md` documents "Update the AsyncAPI specification" as the workflow for adding types), and it is a superset in the directions the SDK cares about — it defines `tentative_user_transcript`, `rich_content`, `agent_reasoning_response_part`, `agent_typing`, `external_agent_connected`, `asr_initiation_metadata`, `error`, and the `internal_*` events, none of which exist in the published document.
- The two files also disagree on `publish`/`subscribe` semantics. Locally `publish` is server-to-client; in the published document `publish` is client-to-server. Since `scripts/generate-all-types.ts` maps `publish` to `incoming` for `role: client`, a swap silently inverts the `Incoming`/`Outgoing` barrels — after the swap `incoming.ts` exported `Pong`, `UserAudioChunk`, `UserMessage`, `ContextualUpdate` and `ClientToolResult`.
- Message names differ throughout (`AudioResponse` vs `AudioClientEvent`, `ConversationInitiationMetadata` vs `ConversationMetadata`, and so on), so every consumer import breaks.

Overwriting, regenerating and running `tsc --build --force` in `packages/client` produces **40 errors**. Instead, this PR adds the `ContextUsage` message to the local contract, transcribing the field names, types, requiredness and descriptions from the published document.

Happy to do the full migration to the published contract instead if that is the actual goal, but it is a breaking rename across client, react, react-native and the widget rather than an additive change, and several events the SDK handles today would need to be added upstream first.

## Changes

- `packages/types`: add the `ContextUsage` message, `ContextUsagePayload` and `ContextUsageData` schemas, add `context_usage` to the `ClientEvent` enum, and regenerate `generated/types`.
- `packages/client`: add a `ContextUsageEvent` alias, include it in `IncomingSocketEvent`, add the `onContextUsage` callback to `Callbacks` and `CALLBACK_KEYS`, dispatch `context_usage` to a `handleContextUsage` handler, and export the type from the package entry point.
- `packages/react`: add `onContextUsage` to `HookCallbacks`.
- `examples/agent-testbench`: log the new event.
- Changeset: `minor` for client and react, `patch` for types.

The callback receives `{ event_id, model, context_tokens, context_limit_tokens }`. Previously `context_usage` fell through to `onDebug`.

## Testing

`pnpm run check-types` (16 tasks), `pnpm run lint` (29 tasks) and `pnpm run build` all pass. Full test suites pass headless:

| Package | Test files | Tests |
| --- | --- | --- |
| `@elevenlabs/client` | 18 passed | 218 passed |
| `@elevenlabs/react` | 13 passed | 141 passed |
| `@elevenlabs/convai-widget-core` | 10 passed | 212 passed |

New tests: three in `packages/client/src/BaseConversation.test.ts` covering payload forwarding, that nothing is sent back to the server, and that a missing callback does not throw; one in `packages/react/src/conversation/useConversation.test.tsx` proving a hook-level `onContextUsage` is composed into the session options and invoked.

The pre-existing `CALLBACK_KEYS` completeness test in `ConversationProvider.test.tsx` is a compile-time guard that `Callbacks` and `CALLBACK_KEYS` stay in sync, so it also covers this addition.

Locally the test runs use `--browser.headless` per `agents.md`, since the bare `test` script launches a headed browser that needs the Playwright container CI provides.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a1519ba-27e4-4a9f-bab2-d79e17803c25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a1519ba-27e4-4a9f-bab2-d79e17803c25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

