### PR TITLE
feat(client): support external_agent_disconnected handback

### DIFF
--- a/.changeset/light-crews-repeat.md
+++ b/.changeset/light-crews-repeat.md
@@ -1,0 +1,8 @@
+---
+"@elevenlabs/types": minor
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/convai-widget-core": minor
+---
+
+Add support for the `external_agent_disconnected` client event. The client SDK exposes a new `onExternalAgentDisconnected` callback, and the widget leaves external-agent mode (and clears the typing indicator) when the external human agent disconnects and the AI agent resumes control.

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -16,6 +16,7 @@ import type {
   AgentTypingEvent,
   ClientToolCallEvent,
   ExternalAgentConnectedEvent,
+  ExternalAgentDisconnectedEvent,
   IncomingSocketEvent,
   InternalTentativeAgentResponseEvent,
   InterruptionEvent,
@@ -140,6 +141,7 @@ export abstract class BaseConversation {
       onAgentResponseCorrection: () => {},
       onAgentTyping: () => {},
       onExternalAgentConnected: () => {},
+      onExternalAgentDisconnected: () => {},
       onPing: () => {},
       ...partialOptions,
       textOnly,
@@ -443,6 +445,14 @@ export abstract class BaseConversation {
     }
   }
 
+  protected handleExternalAgentDisconnected(
+    _event: ExternalAgentDisconnectedEvent
+  ) {
+    if (this.options.onExternalAgentDisconnected) {
+      this.options.onExternalAgentDisconnected();
+    }
+  }
+
   protected handleErrorEvent(event: ErrorMessageEvent) {
     const errorEvent = event.error_event;
     const errorType = errorEvent?.error_type;
@@ -598,6 +608,11 @@ export abstract class BaseConversation {
 
       case "external_agent_connected": {
         this.handleExternalAgentConnected(parsedEvent);
+        return;
+      }
+
+      case "external_agent_disconnected": {
+        this.handleExternalAgentDisconnected(parsedEvent);
         return;
       }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -145,6 +145,7 @@ export type Callbacks = {
   onAudioAlignment?: (props: AudioAlignmentEvent) => void;
   onAgentTyping?: (props: AgentTypingClientEvent["agent_typing_event"]) => void;
   onExternalAgentConnected?: () => void;
+  onExternalAgentDisconnected?: () => void;
   /**
    * Called for every `ping` event received from the server. The SDK
    * automatically replies with a `pong`, so this callback is purely
@@ -197,6 +198,7 @@ export const CALLBACK_KEYS = [
   "onGuardrailTriggered",
   "onAgentTyping",
   "onExternalAgentConnected",
+  "onExternalAgentDisconnected",
   "onPing",
   "onDebug",
   "onIncomingEvent",

--- a/packages/client/src/utils/events.ts
+++ b/packages/client/src/utils/events.ts
@@ -13,6 +13,7 @@ import type {
   ConversationMetadata,
   ErrorMessage,
   ExternalAgentConnectedClientEvent,
+  ExternalAgentDisconnectedClientEvent,
   GuardrailTriggered,
   Interruption,
   McpConnectionStatusClientEvent,
@@ -54,6 +55,8 @@ export type ErrorMessageEvent = ErrorMessage;
 export type GuardrailTriggeredEvent = GuardrailTriggered;
 export type AgentTypingEvent = AgentTypingClientEvent;
 export type ExternalAgentConnectedEvent = ExternalAgentConnectedClientEvent;
+export type ExternalAgentDisconnectedEvent =
+  ExternalAgentDisconnectedClientEvent;
 export type { AudioAlignmentEvent };
 
 export type IncomingSocketEvent =
@@ -80,7 +83,8 @@ export type IncomingSocketEvent =
   | ErrorMessageEvent
   | GuardrailTriggeredEvent
   | AgentTypingEvent
-  | ExternalAgentConnectedEvent;
+  | ExternalAgentConnectedEvent
+  | ExternalAgentDisconnectedEvent;
 
 // Compatibility layer - outgoing events
 export type PongEvent = Outgoing.PongClientToOrchestratorEvent;

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -404,6 +404,10 @@ function useConversationSetup() {
             onExternalAgentConnected: () => {
               isExternalAgentMode.value = true;
             },
+            onExternalAgentDisconnected: () => {
+              setAgentTyping(false);
+              isExternalAgentMode.value = false;
+            },
             onDisconnect: details => {
               receivedFirstMessageRef.current = false;
               conversationTextOnly.value = null;

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -538,6 +538,9 @@ export const Worker = setupWorker(
         });
       }
       if (agentId === "external_agent") {
+        // Simulates a human agent takeover: the first user message triggers
+        // "external agent connected + typing", the second one triggers a
+        // handback via external_agent_disconnected with no other frames.
         let takenOver = false;
         client.addEventListener("message", async event => {
           const data =
@@ -553,7 +556,6 @@ export const Worker = setupWorker(
               })
             );
             await new Promise(resolve => setTimeout(resolve, 0));
-            // No duration_ms, so the indicator stays up until something clears it.
             client.send(
               JSON.stringify({
                 type: "agent_typing",
@@ -563,9 +565,6 @@ export const Worker = setupWorker(
             return;
           }
 
-          // Deliberately the only frame sent on handback. An `agent_response`
-          // would also clear the typing indicator, which would make this
-          // scenario pass even if `external_agent_disconnected` were ignored.
           client.send(
             JSON.stringify({
               type: "external_agent_disconnected",

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -263,6 +263,15 @@ const codeBlock = true;
     default_expanded: true,
     first_message: "",
   },
+  external_agent: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
 } as const satisfies Record<string, WidgetConfig>;
 
 function isValidAgentId(agentId: string): agentId is keyof typeof AGENTS {
@@ -332,7 +341,8 @@ export const Worker = setupWorker(
         agentId !== "tool_call" &&
         agentId !== "stream_consolidation" &&
         agentId !== "file_upload" &&
-        agentId !== "no_file_upload"
+        agentId !== "no_file_upload" &&
+        agentId !== "external_agent"
       ) {
         const agentResponse =
           agentId === "markdown_agent_response"
@@ -523,6 +533,43 @@ export const Worker = setupWorker(
             JSON.stringify({
               type: "agent_chat_response_part",
               text_response_part: { text: "", type: "stop", event_id: 2 },
+            })
+          );
+        });
+      }
+      if (agentId === "external_agent") {
+        let takenOver = false;
+        client.addEventListener("message", async event => {
+          const data =
+            typeof event.data === "string" ? JSON.parse(event.data) : null;
+          if (data?.type !== "user_message") return;
+
+          if (!takenOver) {
+            takenOver = true;
+            client.send(
+              JSON.stringify({
+                type: "external_agent_connected",
+                external_agent_connected_event: {},
+              })
+            );
+            await new Promise(resolve => setTimeout(resolve, 0));
+            // No duration_ms, so the indicator stays up until something clears it.
+            client.send(
+              JSON.stringify({
+                type: "agent_typing",
+                agent_typing_event: { is_typing: true },
+              })
+            );
+            return;
+          }
+
+          // Deliberately the only frame sent on handback. An `agent_response`
+          // would also clear the typing indicator, which would make this
+          // scenario pass even if `external_agent_disconnected` were ignored.
+          client.send(
+            JSON.stringify({
+              type: "external_agent_disconnected",
+              external_agent_disconnected_event: {},
             })
           );
         });

--- a/packages/convai-widget-core/src/widget/ExternalAgentMode.test.ts
+++ b/packages/convai-widget-core/src/widget/ExternalAgentMode.test.ts
@@ -1,0 +1,31 @@
+import { page, userEvent } from "vitest/browser";
+import { describe, it, beforeAll, expect, afterAll } from "vitest";
+import { Worker } from "../mocks/browser";
+import { setupWebComponent } from "../mocks/web-component";
+
+describe("External agent mode", () => {
+  beforeAll(() => Worker.start({ quiet: true }));
+  afterAll(() => Worker.stop());
+
+  it("clears the typing indicator when the external agent disconnects", async () => {
+    setupWebComponent({
+      "agent-id": "external_agent",
+      variant: "compact",
+    });
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    const typingIndicator = page.getByText("Agent is typing ...");
+
+    await textInput.fill("escalate");
+    await userEvent.keyboard("{Enter}");
+    await expect.element(typingIndicator).toBeInTheDocument();
+
+    // The mock replies with `external_agent_disconnected` and nothing else, so
+    // the handler under test is the only thing that can clear the indicator.
+    await textInput.fill("still there?");
+    await userEvent.keyboard("{Enter}");
+    await expect.element(typingIndicator).not.toBeInTheDocument();
+  });
+});

--- a/packages/react/src/conversation/types.ts
+++ b/packages/react/src/conversation/types.ts
@@ -47,6 +47,7 @@ export type HookCallbacks = Pick<
   | "onGuardrailTriggered"
   | "onAgentTyping"
   | "onExternalAgentConnected"
+  | "onExternalAgentDisconnected"
   | "onPing"
   | "onIncomingEvent"
   | "onOutgoingEvent"

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -191,7 +191,8 @@ export type ConversationConfigOverrideConversationClientEventsItem =
   | "internal_turn_probability"
   | "internal_tentative_agent_response"
   | "agent_typing"
-  | "external_agent_connected";
+  | "external_agent_connected"
+  | "external_agent_disconnected";
 
 export interface SourceInfo {
   source?: string;
@@ -561,6 +562,11 @@ export interface ExternalAgentConnected {
   external_agent_connected_event?: Record<string, any>;
 }
 
+export interface ExternalAgentDisconnected {
+  type: "external_agent_disconnected";
+  external_agent_disconnected_event?: Record<string, any>;
+}
+
 export interface ErrorMessage {
   type: "error";
   error_event: ErrorEvent;
@@ -717,6 +723,11 @@ export interface AgentTypingClientEvent {
 export interface ExternalAgentConnectedClientEvent {
   type: "external_agent_connected";
   external_agent_connected_event?: Record<string, any>;
+}
+
+export interface ExternalAgentDisconnectedClientEvent {
+  type: "external_agent_disconnected";
+  external_agent_disconnected_event?: Record<string, any>;
 }
 
 export interface ErrorClientEvent {

--- a/packages/types/generated/types/incoming.ts
+++ b/packages/types/generated/types/incoming.ts
@@ -17,6 +17,7 @@ export type {
   ConversationInitiationMetadataEvent,
   ErrorClientEvent,
   ExternalAgentConnectedClientEvent,
+  ExternalAgentDisconnectedClientEvent,
   FinalTranscriptMessage,
   FinalTranscriptWithTimestampsMessage,
   GuardrailTriggeredClientEvent,

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -70,6 +70,7 @@ channels:
           - $ref: "#/components/messages/InternalTentativeAgentResponse"
           - $ref: "#/components/messages/AgentTyping"
           - $ref: "#/components/messages/ExternalAgentConnected"
+          - $ref: "#/components/messages/ExternalAgentDisconnected"
           - $ref: "#/components/messages/ErrorMessage"
     subscribe:
       summary: Messages received from client to server
@@ -366,6 +367,14 @@ components:
       payload:
         $ref: "#/components/schemas/ExternalAgentConnectedPayload"
 
+    ExternalAgentDisconnected:
+      name: ExternalAgentDisconnectedClientEvent
+      title: External Agent Disconnected
+      summary: Indicates that an external agent (e.g., Genesys) has disconnected and the AI agent resumed control
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/ExternalAgentDisconnectedPayload"
+
     # ===== ERROR MESSAGES =====
 
     ErrorMessage:
@@ -404,6 +413,7 @@ components:
         - internal_tentative_agent_response
         - agent_typing
         - external_agent_connected
+        - external_agent_disconnected
       description: Types of events that can be sent from server to client
 
     Language:
@@ -1345,6 +1355,17 @@ components:
         external_agent_connected_event:
           type: object
           description: Empty event indicating external agent connection
+
+    ExternalAgentDisconnectedPayload:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          const: external_agent_disconnected
+        external_agent_disconnected_event:
+          type: object
+          description: Empty event indicating external agent disconnection
 
     SourceInfo:
       type: object


### PR DESCRIPTION
## Background

When a text conversation is escalated to a human agent, the orchestrator sends `external_agent_connected` and the chat UI enters external-agent mode, where it starts honouring `agent_typing` to show that a *human* is typing on the other end.

There was no way back. When the human closed the ticket, the backend teardown ran but nothing reached the UI: the chat stayed stuck in human mode indefinitely, with the typing indicator potentially stuck on.

[elevenlabs/xi#42700](https://github.com/elevenlabs/xi/pull/42700) adds the server half, emitting a new `external_agent_disconnected` event on handback and firing an AI turn so the agent announces it has resumed control. **This PR is the client half.**

It exists because of [this review comment](https://github.com/elevenlabs/xi/pull/42700#discussion_r3797579314): the xi PR only updated the two dashboard chat UIs, which parse WebSocket events by hand. There are three independent chat UIs, and the public embeddable widget consumes this repo instead.

| UI | Where | Covered by |
|---|---|---|
| Dashboard agent preview | xi, hand-rolled WS types | xi#42700 |
| Dashboard conversation view | xi, hand-rolled WS types | xi#42700 |
| **Public embeddable widget** | **this repo** | **this PR** |

(`services/js/convai-widget` in xi never implemented external-agent mode, so it is not a fourth gap.)

## What changed

- **`@elevenlabs/types`** - mirror the event into `agent.asyncapi.yaml` (message, payload, channel list, event enum) and regenerate. The generated files are pure generator output; I re-ran `generate-types` and the result was byte-identical to the committed diff.
- **`@elevenlabs/client`** - new `onExternalAgentDisconnected` callback, handler, switch case, and event union member, mirroring the existing `external_agent_connected` path at every site.
- **`@elevenlabs/react`** - re-export the callback through `HookCallbacks`.
- **`@elevenlabs/convai-widget-core`** - leave external-agent mode and clear the typing indicator on handback.

## Testing

Created playwright test (widget test), also did manual inspection - typing indicators stop (not a lot to showcase).