### PR TITLE
fix(client): allow forcing the dual peer connection path on WebRTC

### DIFF
--- a/.changeset/webrtc-single-peer-connection-option.md
+++ b/.changeset/webrtc-single-peer-connection-option.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Add an optional `webRtc.singlePeerConnection` session option for WebRTC connections. Set it to `false` to force LiveKit's dual peer connection path, which restores the microphone request timing used before livekit-client began defaulting to the v1 join protocol. Leaving it unset keeps livekit-client's own default.

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -38,6 +38,14 @@ export type BaseSessionConfig = {
      * Defaults to "all".
      */
     iceTransportPolicy?: "all" | "relay";
+    /**
+     * Whether to negotiate over a single peer connection (LiveKit's v1 join
+     * protocol, which bundles the publisher offer in the JoinRequest). Set to
+     * false to force the dual peer connection path, e.g. on platforms that
+     * reject the microphone request at the point v1 issues it. Defaults to
+     * livekit-client's own default, currently true.
+     */
+    singlePeerConnection?: boolean;
   };
   overrides?: {
     agent?: {

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -165,6 +165,97 @@ describe("WebRTCConnection", () => {
     connection.close();
   });
 
+  describe("webRtc.singlePeerConnection", () => {
+    // Options the Room constructor was last called with, if any.
+    function lastRoomOptions(): { singlePeerConnection?: boolean } | undefined {
+      return (Room as unknown as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1
+      )?.[0];
+    }
+
+    // Returns a room mock whose connect sequence resolves, so create() runs to
+    // completion and we can inspect how the Room itself was constructed.
+    function mockConnectingRoom() {
+      const mockRoom = new Room() as any;
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "connected") {
+            queueMicrotask(callback);
+          }
+        }
+      );
+      (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "signalConnected") {
+            queueMicrotask(callback);
+          }
+        }
+      );
+      return mockRoom;
+    }
+
+    it("forces the dual peer connection path when set to false", async () => {
+      mockConnectingRoom();
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+        webRtc: { singlePeerConnection: false },
+      });
+
+      expect(Room).toHaveBeenLastCalledWith({ singlePeerConnection: false });
+
+      connection.close();
+    });
+
+    it("passes the option through when set to true", async () => {
+      mockConnectingRoom();
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+        webRtc: { singlePeerConnection: true },
+      });
+
+      expect(Room).toHaveBeenLastCalledWith({ singlePeerConnection: true });
+
+      connection.close();
+    });
+
+    // The back-compat control: an unset option must leave livekit-client's own
+    // default in place rather than pinning it from here. Asserts that no mode
+    // was pinned rather than the exact call arity, since `new Room()` and
+    // `new Room(undefined)` are the same thing to LiveKit.
+    it("leaves the LiveKit default alone when the option is omitted", async () => {
+      mockConnectingRoom();
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+      });
+
+      expect(lastRoomOptions()?.singlePeerConnection).toBeUndefined();
+
+      connection.close();
+    });
+
+    // The two webRtc options are independent: setting the sibling must not
+    // start pinning the peer connection mode.
+    it("does not pin the peer connection mode when only iceTransportPolicy is set", async () => {
+      mockConnectingRoom();
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+        webRtc: { iceTransportPolicy: "relay" },
+      });
+
+      expect(lastRoomOptions()?.singlePeerConnection).toBeUndefined();
+
+      connection.close();
+    });
+  });
+
   it("reconnects input analyser after unmuting", async () => {
     const mockRoom = new Room() as any;
 

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -289,7 +289,15 @@ export class WebRTCConnection extends BaseConnection {
       );
     }
 
-    const room = new Room();
+    // livekit-client defaults `singlePeerConnection` to true, which bundles the
+    // publisher offer in the JoinRequest and moves the microphone request
+    // earlier in the connection sequence. Callers that need the dual peer
+    // connection path can opt back into it. Left undefined so the LiveKit
+    // default applies unless the caller says otherwise.
+    const singlePeerConnection = config.webRtc?.singlePeerConnection;
+    const room = new Room(
+      singlePeerConnection === undefined ? undefined : { singlePeerConnection }
+    );
 
     try {
       // Create connection instance first to set up event listeners


### PR DESCRIPTION
Fixes #960

## What happens

`WebRTCConnection.create()` constructs the LiveKit `Room` with no options, so `singlePeerConnection` takes livekit-client's own default, which is `true` as of 2.21.0:

```ts
// livekit-client 2.21.0, options.d.ts
/**
 * will attempt to connect via single peer connection mode.
 * falls back to dual peer connection mode if not available.
 *
 * @default true
 */
singlePeerConnection: boolean;
```

The v1 join protocol bundles the publisher offer in the JoinRequest, which moves the point in the connection sequence where the microphone is requested. `create()` enables the microphone off `RoomEvent.SignalConnected`, so the timing of that request follows the protocol version:

```ts
room.once(RoomEvent.SignalConnected, () => {
  room.localParticipant.setMicrophoneEnabled(true)...
});
```

@sailod reports that on iOS and iPadOS Safari the request is rejected at that earlier point with `NotAllowedError`, and that pinning `singlePeerConnection: false` through `patch-package` restores it.

## Why this is not a straight revert

`singlePeerConnection: false` did exist. It was added in ae50508 (#782) as defense in depth for LiveKit servers that did not process a bundled publisher offer, and removed in c037e48 (#780). The removal was deliberate, not incidental: that commit message calls it out by name as an intended edit that a rebase had dropped and that was being restored.

So this PR does not restore `false` as the client default. Whether the server side is now uniformly ready for v1 is a call I cannot make from outside the deployment, and re-pinning every caller to v0 would undo #780 for everyone in order to fix one platform.

## What it does instead

Adds `webRtc.singlePeerConnection`, following the shape #934 landed three days ago. That PR started as a general `rtcConfig` passthrough and was narrowed before merge to a single named option under `webRtc`, so this reuses the same namespace and the same one-option-at-a-time convention rather than reopening the passthrough question.

```ts
const singlePeerConnection = config.webRtc?.singlePeerConnection;
const room = new Room(
  singlePeerConnection === undefined ? undefined : { singlePeerConnection }
);
```

Left `undefined` when unset, so livekit-client's default continues to apply and nothing changes for existing callers. The reporter can drop `patch-package` and pass `webRtc: { singlePeerConnection: false }` instead.

## Considered and not taken

Defaulting to `false` on iOS and iPadOS specifically. That means user agent sniffing in a package that deliberately keeps DOM assumptions out of common code, and it would encode a guess about which platforms are affected. If you would rather ship a platform default, or flip the client default back to `false` outright, both are small follow-ups on top of this and I am happy to send either.

## Verification

Four tests in `WebRTCConnection.test.ts`, placed beside the existing `iceTransportPolicy` test rather than at the end of the file, since my open #953 appends there.

| Test | Asserts |
| --- | --- |
| `forces the dual peer connection path when set to false` | `false` reaches the `Room` constructor |
| `passes the option through when set to true` | `true` does too, so the option is not hard-coded one way |
| `leaves the LiveKit default alone when the option is omitted` | no mode is pinned when unset |
| `does not pin the peer connection mode when only iceTransportPolicy is set` | the two `webRtc` options stay independent |

**Fail-first**, stashing only `WebRTCConnection.ts`: **2 failed, 17 passed**. The two failures are the two that assert the new behaviour. The other two pass both ways by design, which is the point of them: they are the back-compat controls, and a fix that pinned a default would break them.

They assert that no `singlePeerConnection` was pinned rather than asserting the exact `Room` call arity, because `new Room()` and `new Room(undefined)` are the same thing to LiveKit and pinning the arity would fail on any harmless refactor.

- `packages/client` suite: **238 on main, 242 on the branch**, delta exactly the four added, zero failures either side.
- `pnpm -w run check-types`: 16 successful, 16 total.
- `prettier --check` clean on all four touched files.
- Changeset added, `minor`, matching #934's bump for the sibling option.
