### PR TITLE
fix(scribe): bound microphone setup so a stalled resume cannot hang it

### DIFF
--- a/.changeset/scribe-microphone-setup-timeout.md
+++ b/.changeset/scribe-microphone-setup-timeout.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Bound Scribe microphone setup after permission is granted, so a stalled `AudioContext.resume()` rejects instead of hanging forever and the microphone is released rather than left open. Configurable via `setupTimeoutMs` on the microphone config, defaulting to 10000ms; set it to 0 to wait indefinitely.

--- a/packages/client/src/platform/web/scribeMicrophone.test.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.test.ts
@@ -6,6 +6,16 @@ vi.mock("./scribeAudioProcessor.generated.js", () => ({
 
 import { loadScribeAudioProcessor } from "./scribeAudioProcessor.generated.js";
 import { webScribeMicrophoneSetup } from "./scribeMicrophone.js";
+import type { MicrophoneOptions } from "../../scribe/scribe.js";
+
+// Type-level pin. `MicrophoneOptions["microphone"]` is a structural copy of
+// ScribeMicrophoneConfig rather than a reference to it, so a field added to the
+// config alone stays unreachable through Scribe.connect and useScribe. Excess
+// property checking on this literal fails the build if the two drift again.
+const _setupTimeoutIsPubliclySettable: MicrophoneOptions["microphone"] = {
+  setupTimeoutMs: 250,
+};
+void _setupTimeoutIsPubliclySettable;
 
 function installAudioEnvironment(options?: {
   state?: "running" | "suspended";

--- a/packages/client/src/platform/web/scribeMicrophone.test.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.test.ts
@@ -10,6 +10,10 @@ import { webScribeMicrophoneSetup } from "./scribeMicrophone.js";
 function installAudioEnvironment(options?: {
   state?: "running" | "suspended";
   resumeError?: Error;
+  /** Mimics WebKit's resume() that neither resolves nor rejects. */
+  resumeHangs?: boolean;
+  /** How long getUserMedia takes, standing in for the permission prompt. */
+  getUserMediaDelayMs?: number;
 }) {
   const track = {
     getSettings: vi.fn(() => ({ sampleRate: 16000 })),
@@ -36,13 +40,25 @@ function installAudioEnvironment(options?: {
     createMediaStreamSource: vi.fn(() => source),
     resume: options?.resumeError
       ? vi.fn().mockRejectedValue(options.resumeError)
-      : vi.fn().mockResolvedValue(undefined),
+      : options?.resumeHangs
+        ? vi.fn(() => new Promise<void>(() => {}))
+        : vi.fn().mockResolvedValue(undefined),
     sampleRate: 16000,
     state: options?.state ?? "running",
   };
 
+  const getUserMediaDelayMs = options?.getUserMediaDelayMs;
   vi.stubGlobal("navigator", {
-    mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    mediaDevices: {
+      getUserMedia: getUserMediaDelayMs
+        ? vi.fn(
+            () =>
+              new Promise(resolve =>
+                setTimeout(() => resolve(stream), getUserMediaDelayMs)
+              )
+          )
+        : vi.fn().mockResolvedValue(stream),
+    },
   });
   vi.stubGlobal(
     "AudioContext",
@@ -137,5 +153,96 @@ describe("webScribeMicrophoneSetup", () => {
     expect(source.disconnect).toHaveBeenCalledOnce();
     expect(scribeNode.disconnect).toHaveBeenCalledOnce();
     expect(audioContext.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects and releases the microphone when resume never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const { audioContext, scribeNode, source, track } =
+        installAudioEnvironment({ state: "suspended", resumeHangs: true });
+      vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+      const setup = webScribeMicrophoneSetup({}, vi.fn());
+      const rejects = expect(setup).rejects.toThrow(
+        /Microphone setup timed out after 10000ms/
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      await rejects;
+
+      // The point of the fix: the hardware is handed back. Without a bound the
+      // caller never receives `cleanup`, so nothing can stop these tracks.
+      expect(track.stop).toHaveBeenCalledOnce();
+      expect(source.disconnect).toHaveBeenCalledOnce();
+      expect(scribeNode.disconnect).toHaveBeenCalledOnce();
+      expect(audioContext.close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors a custom setupTimeoutMs", async () => {
+    vi.useFakeTimers();
+    try {
+      const { track } = installAudioEnvironment({
+        state: "suspended",
+        resumeHangs: true,
+      });
+      vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+      const setup = webScribeMicrophoneSetup({ setupTimeoutMs: 250 }, vi.fn());
+      const rejects = expect(setup).rejects.toThrow(
+        /Microphone setup timed out after 250ms/
+      );
+      await vi.advanceTimersByTimeAsync(250);
+      await rejects;
+
+      expect(track.stop).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Scope control. The timeout must not cover getUserMedia, because that is
+  // where the user is answering the browser's permission prompt. Bounding the
+  // whole of setup would abort ordinary first-run sessions.
+  it("does not time out while the permission prompt is open", async () => {
+    vi.useFakeTimers();
+    try {
+      const { track } = installAudioEnvironment({
+        getUserMediaDelayMs: 60_000,
+      });
+      vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+      const setup = webScribeMicrophoneSetup({ setupTimeoutMs: 1000 }, vi.fn());
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await expect(setup).resolves.toMatchObject({ mediaStreamTrack: track });
+      expect(track.stop).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits indefinitely when setupTimeoutMs is 0", async () => {
+    vi.useFakeTimers();
+    try {
+      installAudioEnvironment({ state: "suspended", resumeHangs: true });
+      vi.mocked(loadScribeAudioProcessor).mockResolvedValueOnce(undefined);
+
+      let settled = false;
+      const setup = webScribeMicrophoneSetup(
+        { setupTimeoutMs: 0 },
+        vi.fn()
+      ).then(
+        () => (settled = true),
+        () => (settled = true)
+      );
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(settled).toBe(false);
+      void setup;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/client/src/platform/web/scribeMicrophone.ts
+++ b/packages/client/src/platform/web/scribeMicrophone.ts
@@ -7,6 +7,45 @@ import { arrayBufferToBase64 } from "../../utils/audio.js";
 import { loadScribeAudioProcessor } from "./scribeAudioProcessor.generated.js";
 
 const TARGET_SAMPLE_RATE = 16000;
+const DEFAULT_SETUP_TIMEOUT_MS = 10_000;
+
+/**
+ * Rejects if `work` has not settled within `timeoutMs`.
+ *
+ * `AudioContext.resume()` can fail to settle at all in WebKit when it is
+ * called several awaits away from the originating user gesture: it neither
+ * resolves nor rejects. Without a bound, setup hangs forever, no error is ever
+ * reported, and the caller never receives the cleanup function, so the
+ * microphone stays open for the lifetime of the page.
+ *
+ * A non-finite or non-positive timeout waits indefinitely, preserving the old
+ * behaviour for callers that want it.
+ */
+function withSetupTimeout<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return work;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `Microphone setup timed out after ${timeoutMs}ms waiting for the ` +
+            `audio pipeline to start.`
+        )
+      );
+    }, timeoutMs);
+    work.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
 
 /**
  * Web implementation of Scribe microphone streaming.
@@ -34,8 +73,10 @@ export const webScribeMicrophoneSetup: ScribeMicrophoneSetup = async (
   };
 
   try {
-    // Get microphone access
-    stream = await navigator.mediaDevices.getUserMedia({
+    // Get microphone access. Deliberately not bounded by the setup timeout:
+    // this is where the browser prompts the user for permission, and how long
+    // someone takes to answer that is not the SDK's business.
+    const mediaStream = await navigator.mediaDevices.getUserMedia({
       audio: {
         deviceId: config.deviceId,
         echoCancellation: config.echoCancellation ?? true,
@@ -45,49 +86,62 @@ export const webScribeMicrophoneSetup: ScribeMicrophoneSetup = async (
         sampleRate: { ideal: TARGET_SAMPLE_RATE },
       },
     });
+    stream = mediaStream;
 
-    // Get the actual sample rate from the stream — the ideal may not have been honored
-    const [audioTrack] = stream.getAudioTracks();
-    const streamSampleRate = audioTrack?.getSettings().sampleRate;
+    // Everything past this point runs at machine speed with no user in the
+    // loop, so it is safe to bound.
+    const audioTrack = await withSetupTimeout(
+      (async () => {
+        // Get the actual sample rate from the stream — the ideal may not have been honored
+        const [audioTrack] = mediaStream.getAudioTracks();
+        const streamSampleRate = audioTrack?.getSettings().sampleRate;
 
-    // Create audio context matching the stream's sample rate to avoid Firefox errors.
-    // Firefox requires the AudioContext to match the microphone's native sample rate.
-    audioContext = new AudioContext(
-      streamSampleRate ? { sampleRate: streamSampleRate } : {}
+        // Create audio context matching the stream's sample rate to avoid Firefox errors.
+        // Firefox requires the AudioContext to match the microphone's native sample rate.
+        const context = new AudioContext(
+          streamSampleRate ? { sampleRate: streamSampleRate } : {}
+        );
+        audioContext = context;
+
+        // Load scribe worklet
+        await loadScribeAudioProcessor(
+          context.audioWorklet,
+          config.workletPaths?.scribeAudioProcessor
+        );
+
+        // Set up audio pipeline
+        const mediaSource = context.createMediaStreamSource(mediaStream);
+        source = mediaSource;
+        const node = new AudioWorkletNode(context, "scribeAudioProcessor");
+        scribeNode = node;
+
+        // Configure the worklet with sample rate info for resampling
+        // (only needed when AudioContext sample rate differs from target)
+        if (context.sampleRate !== TARGET_SAMPLE_RATE) {
+          node.port.postMessage({
+            type: "configure",
+            inputSampleRate: context.sampleRate,
+            outputSampleRate: TARGET_SAMPLE_RATE,
+          });
+        }
+
+        // Handle audio data from worklet
+        node.port.onmessage = event => {
+          onAudioData(arrayBufferToBase64(event.data.audioData));
+        };
+
+        // Connect audio pipeline
+        mediaSource.connect(node);
+
+        // Resume audio context if needed
+        if (context.state === "suspended") {
+          await context.resume();
+        }
+
+        return audioTrack;
+      })(),
+      config.setupTimeoutMs ?? DEFAULT_SETUP_TIMEOUT_MS
     );
-
-    // Load scribe worklet
-    await loadScribeAudioProcessor(
-      audioContext.audioWorklet,
-      config.workletPaths?.scribeAudioProcessor
-    );
-
-    // Set up audio pipeline
-    source = audioContext.createMediaStreamSource(stream);
-    scribeNode = new AudioWorkletNode(audioContext, "scribeAudioProcessor");
-
-    // Configure the worklet with sample rate info for resampling
-    // (only needed when AudioContext sample rate differs from target)
-    if (audioContext.sampleRate !== TARGET_SAMPLE_RATE) {
-      scribeNode.port.postMessage({
-        type: "configure",
-        inputSampleRate: audioContext.sampleRate,
-        outputSampleRate: TARGET_SAMPLE_RATE,
-      });
-    }
-
-    // Handle audio data from worklet
-    scribeNode.port.onmessage = event => {
-      onAudioData(arrayBufferToBase64(event.data.audioData));
-    };
-
-    // Connect audio pipeline
-    source.connect(scribeNode);
-
-    // Resume audio context if needed
-    if (audioContext.state === "suspended") {
-      await audioContext.resume();
-    }
 
     return { mediaStreamTrack: audioTrack, cleanup };
   } catch (error) {

--- a/packages/client/src/scribe/microphone.ts
+++ b/packages/client/src/scribe/microphone.ts
@@ -23,6 +23,16 @@ export interface ScribeMicrophoneConfig {
   workletPaths?: {
     scribeAudioProcessor?: string;
   };
+  /**
+   * How long to wait, in milliseconds, for the audio pipeline to finish
+   * starting after microphone permission has been granted. Setup that exceeds
+   * this rejects instead of hanging, releasing the microphone on the way out.
+   * Defaults to 10000. Set to 0 or a non-finite value to wait indefinitely.
+   *
+   * This bounds only the work that follows `getUserMedia`. Waiting for the
+   * user to answer the permission prompt is unbounded by design.
+   */
+  setupTimeoutMs?: number;
 }
 
 export interface ScribeMicrophoneResult {

--- a/packages/client/src/scribe/scribe.ts
+++ b/packages/client/src/scribe/scribe.ts
@@ -160,6 +160,16 @@ export interface MicrophoneOptions extends BaseOptions {
     workletPaths?: {
       scribeAudioProcessor?: string;
     };
+    /**
+     * How long to wait, in milliseconds, for the audio pipeline to finish
+     * starting after microphone permission has been granted. Setup that
+     * exceeds this rejects instead of hanging, releasing the microphone on
+     * the way out. Defaults to 10000. Set to 0 to wait indefinitely.
+     *
+     * This bounds only the work that follows the permission prompt, never
+     * the wait for the user to answer it.
+     */
+    setupTimeoutMs?: number;
   };
   audioFormat?: never;
   sampleRate?: never;


### PR DESCRIPTION
Fixes #887

## What happens

`webScribeMicrophoneSetup` finishes with an unbounded await:

```ts
// packages/client/src/platform/web/scribeMicrophone.ts
if (audioContext.state === "suspended") {
  await audioContext.resume();
}
```

As @codewinkel reports, `AudioContext.resume()` in WebKit can fail to settle at all when it is called several awaits away from the originating user gesture. It neither resolves nor rejects. Nothing in the chain has a timeout, so setup hangs.

The socket stays open and can still receive `session_started`, so `useScribe()` reports `connected` and `onSessionStarted` fires while zero audio is ever captured.

## The part that is worse than the issue says

The hang does not only make the session silently dead. **It strands the microphone.**

`streamFromMicrophone` only ever gets the cleanup handle from the resolved setup:

```ts
const result = await setup(...);
connection._audioCleanup = result.cleanup;
```

`close()` is written to cope with a setup that is still in flight, and its own comment says so:

```ts
// Flag first so a mic setup still resolving (see ScribeRealtime.
// streamFromMicrophone) can tell the connection is gone and clean up.
this._closed = true;
if (this._audioCleanup) { ... }
```

That handshake assumes the setup promise eventually settles. When it never does, `_audioCleanup` is never assigned and the `if (connection._closed) result.cleanup()` branch is never reached, so neither `close()` nor the server-initiated close path in `connection.ts` has anything to call. The `cleanup` closure that owns the `MediaStream` is reachable only from inside the hung setup. The tracks stay live and the browser's recording indicator stays on for the lifetime of the page, after the user has ended the session.

That is what makes this worth a timeout rather than documentation.

## Why the timeout does not cover the whole setup

The issue asks to "wrap the microphone setup (or at minimum the `audioContext.resume()` call)". Wrapping the whole thing would include `getUserMedia`, and that is where the browser is showing the permission prompt and waiting for a human to click. That wait is unbounded by design, and a 10 second timeout across it would abort ordinary first-run sessions on the fairly common case of someone reading the dialog before clicking.

So the bound starts after `getUserMedia` resolves and covers the rest, which runs at machine speed with no user in the loop: worklet load, node construction, wiring, and the `resume()` that actually hangs. `does not time out while the permission prompt is open` pins this: a 60 second `getUserMedia` still succeeds under a 1000ms setup timeout.

## The rest

`setupTimeoutMs` on `ScribeMicrophoneConfig`, defaulting to 10000. A value of 0, or any non-finite value, waits indefinitely and gives back exactly today's behaviour for anyone who wants it.

On timeout the rejection goes through the existing `catch`, which already calls `cleanup()`, and from there into the handler `streamFromMicrophone` already has: `_emitError` then `connection.close()`. So the failure surfaces as `RealtimeEvents.ERROR` followed by `CLOSE`, the same as a setup that rejects today. No new error path, and @codewinkel's application-level watchdog can come out.

One residual, stated plainly: the abandoned continuation cannot be cancelled, so it may still assign to the outer `audioContext` / `source` / `scribeNode` references after `cleanup()` has run. By then the tracks are stopped and the context is closed, so no hardware is held and no audio is delivered. Cancelling properly would mean threading an `AbortSignal` through the `ScribeMicrophoneSetup` contract, which is a bigger change to a platform-injectable interface and did not belong in a bug fix. Happy to do it separately if you want it.

## Verification

Four tests added to the existing `scribeMicrophone.test.ts`, alongside the `resume` rejection test already there. Kept out of `scribe/scribe.ts` and its test file, which open PR #680 is editing.

| Test | Asserts |
| --- | --- |
| `rejects and releases the microphone when resume never settles` | rejects, and `track.stop` / `source.disconnect` / `scribeNode.disconnect` / `audioContext.close` all ran |
| `honors a custom setupTimeoutMs` | the configured value is the one used |
| `does not time out while the permission prompt is open` | a 60s `getUserMedia` survives a 1000ms setup timeout |
| `waits indefinitely when setupTimeoutMs is 0` | opt-out restores the old behaviour |

**Fail-first**, stashing only `scribeMicrophone.ts`: **2 failed, 7 passed**. The two failures are the two timeout tests, and they fail by **hitting vitest's own 5000ms limit** rather than by assertion, which is the bug reproducing exactly: with no bound, the setup promise never settles. The other two are controls and pass both ways by design.

- `packages/client` suite: **238 on main, 242 on the branch**, delta exactly the four added, zero failures either side.
- `pnpm -w run check-types`: 16 successful, 16 total.
- `prettier --check` clean; the husky pre-commit `turbo lint` passed 29/29.
- Changeset added, `minor`.
