### PR TITLE
fix(react-native): stop hard-coding Android output to the speaker

### DIFF
--- a/.changeset/react-native-audio-output-routing.md
+++ b/.changeset/react-native-audio-output-routing.md
@@ -1,5 +1,5 @@
 ---
-"@elevenlabs/client": patch
+"@elevenlabs/client": minor
 "@elevenlabs/react-native": patch
 ---
 

--- a/.changeset/react-native-audio-output-routing.md
+++ b/.changeset/react-native-audio-output-routing.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/client": patch
+"@elevenlabs/react-native": patch
+---
+
+Fix @elevenlabs/react-native always routing conversation audio to the phone speaker on Android, even with a Bluetooth or wired headset connected. `preferredOutputList` no longer hard-codes `["speaker"]`; it now defers to the native module's own default routing order (bluetooth, then headset, then speaker, then earpiece) unless a new `webRtc.reactNative.audioSession` option overrides it.

--- a/.changeset/react-native-audio-output-routing.md
+++ b/.changeset/react-native-audio-output-routing.md
@@ -3,4 +3,4 @@
 "@elevenlabs/react-native": patch
 ---
 
-Fix @elevenlabs/react-native always routing conversation audio to the phone speaker on Android, even with a Bluetooth or wired headset connected. `preferredOutputList` no longer hard-codes `["speaker"]`; it now defers to the native module's own default routing order (bluetooth, then headset, then speaker, then earpiece) unless a new `webRtc.reactNative.audioSession` option overrides it.
+Fix @elevenlabs/react-native always routing conversation audio to the phone speaker on Android, even with a Bluetooth or wired headset connected. `preferredOutputList` no longer hard-codes `["speaker"]` and now defaults to the native module's own routing order (bluetooth, then headset, then speaker, then earpiece), which a new `webRtc.reactNative.audioSession` option can override. The resolved order is always sent to the native AudioSession rather than omitted, so an override applied to one conversation no longer persists into later conversations in the same app session, and a list containing duplicate outputs is rejected up front instead of crashing the app from the native audio switch.

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -46,6 +46,38 @@ export type BaseSessionConfig = {
      * livekit-client's own default, currently true.
      */
     singlePeerConnection?: boolean;
+    /**
+     * @elevenlabs/react-native only. Ignored on other platforms.
+     */
+    reactNative?: {
+      /**
+       * Overrides the native AudioSession routing @elevenlabs/react-native
+       * applies before the connection starts.
+       */
+      audioSession?: {
+        android?: {
+          /**
+           * The automatic output routing order. Omit to use the native
+           * module's own default (bluetooth, then headset, then speaker,
+           * then earpiece), which routes to a connected Bluetooth or wired
+           * headset instead of always using the speaker.
+           */
+          preferredOutputList?: (
+            | "speaker"
+            | "earpiece"
+            | "headset"
+            | "bluetooth"
+          )[];
+        };
+        ios?: {
+          /**
+           * The output to prefer when no headset or Bluetooth device is
+           * connected. Defaults to "speaker".
+           */
+          defaultOutput?: "speaker" | "earpiece";
+        };
+      };
+    };
   };
   overrides?: {
     agent?: {

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -57,10 +57,13 @@ export type BaseSessionConfig = {
       audioSession?: {
         android?: {
           /**
-           * The automatic output routing order. Omit to use the native
-           * module's own default (bluetooth, then headset, then speaker,
-           * then earpiece), which routes to a connected Bluetooth or wired
-           * headset instead of always using the speaker.
+           * The automatic output routing order, most preferred first. Entries
+           * are moved to the front of the default order rather than filtering
+           * it, so ["speaker"] prefers the speaker but still falls back to the
+           * remaining outputs. Must not contain duplicates. Omit it, or pass an
+           * empty list, for the default order: bluetooth, then headset, then
+           * speaker, then earpiece, which routes to a connected Bluetooth or
+           * wired headset instead of always using the speaker.
            */
           preferredOutputList?: (
             | "speaker"

--- a/packages/react-native/src/audioSession.ts
+++ b/packages/react-native/src/audioSession.ts
@@ -1,0 +1,57 @@
+import type { Options } from "@elevenlabs/client";
+
+type ReactNativeAudioSession = NonNullable<
+  NonNullable<NonNullable<Options["webRtc"]>["reactNative"]>["audioSession"]
+>;
+
+/** The `preferredOutputList` type, derived from `Options` so it cannot drift. */
+export type AndroidPreferredOutputList = NonNullable<
+  NonNullable<ReactNativeAudioSession["android"]>["preferredOutputList"]
+>;
+
+/**
+ * The native module's own constructor default, spelled out so it can be sent
+ * explicitly. `AudioSwitchManager` seeds this same order in its constructor.
+ */
+export const ANDROID_DEFAULT_PREFERRED_OUTPUT_LIST: AndroidPreferredOutputList =
+  ["bluetooth", "headset", "speaker", "earpiece"];
+
+/**
+ * Resolves the `preferredOutputList` to send to the native AudioSession.
+ *
+ * The key is always sent, never omitted. `LivekitReactNativeModule.configureAudio`
+ * writes `preferredOutputList` only when the key is present and has no `else`
+ * branch, and it stores the value on `AudioSwitchManager.preferredDeviceList`,
+ * a field of the native module that lives as long as the React context.
+ * `stopAudioSession()` clears the `AudioSwitch` but not that field, and the next
+ * `startAudioSession()` builds a fresh `AudioSwitch` from whatever it still
+ * holds. Omitting the key therefore means "keep the previous session's order",
+ * not "use the default", so a single overridden session would silently pin the
+ * routing of every session opened after it.
+ *
+ * An empty list is resolved to the default rather than forwarded, because the
+ * native audio switch maps an empty list onto its own default order, which
+ * places earpiece above speaker and so is not the default documented here.
+ */
+export function resolveAndroidPreferredOutputList(
+  preferredOutputList: AndroidPreferredOutputList | undefined
+): AndroidPreferredOutputList {
+  if (!preferredOutputList?.length) {
+    return ANDROID_DEFAULT_PREFERRED_OUTPUT_LIST;
+  }
+
+  const duplicate = preferredOutputList.find(
+    (output, index) => preferredOutputList.indexOf(output) !== index
+  );
+  if (duplicate !== undefined) {
+    throw new Error(
+      "webRtc.reactNative.audioSession.android.preferredOutputList must not " +
+        `contain duplicate entries, but "${duplicate}" appears more than once. ` +
+        "The native audio switch rejects duplicates from a task posted to the " +
+        "main looper, after startAudioSession() has already resolved, so the " +
+        "resulting exception crashes the app rather than failing this call."
+    );
+  }
+
+  return preferredOutputList;
+}

--- a/packages/react-native/src/index.react-native.ts
+++ b/packages/react-native/src/index.react-native.ts
@@ -11,6 +11,7 @@ import {
   type VoiceSessionSetupResult,
 } from "@elevenlabs/client/internal";
 import { attachNativeVolume } from "./nativeVolume.js";
+import { resolveAndroidPreferredOutputList } from "./audioSession.js";
 
 // Polyfill WebRTC globals needed by livekit-client in React Native
 registerGlobals();
@@ -41,17 +42,14 @@ async function reactNativeSessionSetup(
   const audioSessionOverrides = options.webRtc?.reactNative?.audioSession;
   await AudioSession.configureAudio({
     android: {
-      // No preferredOutputList here routes to the native module's own
-      // default (bluetooth > headset > speaker > earpiece), so a connected
+      // Defaults to bluetooth > headset > speaker > earpiece, so a connected
       // Bluetooth or wired headset is used automatically instead of always
-      // forcing the speaker. Callers who want a fixed order, e.g. always
-      // "speaker", can still ask for one explicitly.
-      ...(audioSessionOverrides?.android?.preferredOutputList !== undefined
-        ? {
-            preferredOutputList:
-              audioSessionOverrides.android.preferredOutputList,
-          }
-        : {}),
+      // forcing the speaker. Callers who want a different order can ask for
+      // one explicitly. The list is always sent, never omitted; see
+      // resolveAndroidPreferredOutputList for why.
+      preferredOutputList: resolveAndroidPreferredOutputList(
+        audioSessionOverrides?.android?.preferredOutputList
+      ),
       audioTypeOptions: AndroidAudioTypePresets.communication,
     },
     ios: {

--- a/packages/react-native/src/index.react-native.ts
+++ b/packages/react-native/src/index.react-native.ts
@@ -38,13 +38,24 @@ async function reactNativeSessionSetup(
     );
   }
 
+  const audioSessionOverrides = options.webRtc?.reactNative?.audioSession;
   await AudioSession.configureAudio({
     android: {
-      preferredOutputList: ["speaker"],
+      // No preferredOutputList here routes to the native module's own
+      // default (bluetooth > headset > speaker > earpiece), so a connected
+      // Bluetooth or wired headset is used automatically instead of always
+      // forcing the speaker. Callers who want a fixed order, e.g. always
+      // "speaker", can still ask for one explicitly.
+      ...(audioSessionOverrides?.android?.preferredOutputList !== undefined
+        ? {
+            preferredOutputList:
+              audioSessionOverrides.android.preferredOutputList,
+          }
+        : {}),
       audioTypeOptions: AndroidAudioTypePresets.communication,
     },
     ios: {
-      defaultOutput: "speaker",
+      defaultOutput: audioSessionOverrides?.ios?.defaultOutput ?? "speaker",
     },
   });
   await AudioSession.startAudioSession();


### PR DESCRIPTION
Fixes #881.

## What happens

`reactNativeSessionSetup` in `packages/react-native/src/index.react-native.ts` calls `AudioSession.configureAudio` on every `startSession()`, with `android.preferredOutputList` hard-coded to `["speaker"]`:

```ts
await AudioSession.configureAudio({
  android: {
    preferredOutputList: ["speaker"],
    audioTypeOptions: AndroidAudioTypePresets.communication,
  },
  ios: {
    defaultOutput: "speaker",
  },
});
```

On Android, `preferredOutputList` sets the automatic output routing order. It is prepended to the native default rather than replacing it (`AbstractAudioSwitch.getPreferredDeviceList`), so `["speaker"]` does not remove Bluetooth and wired headsets from routing, it demotes them: the resolved order becomes speaker, bluetooth, headset, earpiece. The symptom is the same either way, because the speaker is always available and the first available entry wins, so a user with a connected Bluetooth headset still hears the phone speaker. Because the SDK calls `configureAudio` before every session, an app can't work around this: any app-level `AudioSession.configureAudio(...)` called beforehand is overwritten by the SDK's own copy on the next `startSession()`.

iOS is materially less affected, as the issue notes: the native module keeps `.allowBluetooth`/`.allowBluetoothA2DP` in the category options regardless, and `defaultOutput: "speaker"` only adds `.defaultToSpeaker`, which yields to a connected headset. Verified the premise against `main` (dce9815): the Android hard-coding is unchanged, iOS is as described.

## What this does

`@livekit/react-native`'s native default routing order is bluetooth, then headset, then speaker, then earpiece, a phone-call-like order. `android.preferredOutputList` now resolves to that order instead of hard-coding `["speaker"]`. Speaker-only behaviour is unchanged when no headset or Bluetooth device is connected, since the speaker is still reached.

The resolved list is always sent, never omitted. `LivekitReactNativeModule.configureAudio` writes `preferredOutputList` only when the key is present and has no `else` branch, and it stores the value on `AudioSwitchManager.preferredDeviceList`, a field of the native module that outlives the session: `stopAudioSession()` clears the `AudioSwitch` but not that field, and the next `startAudioSession()` builds a fresh switch from whatever survives. Omitting the key therefore means "keep the previous session's order", not "use the default". An earlier revision of this PR omitted it, and @kulikov0 caught the resulting state leak on a Pixel 6: an override applied to one conversation silently pinned the routing of every conversation opened after it in the same React context.

Two edges follow from the same native contract. An empty list resolves to the default rather than being forwarded, because the native switch maps an empty list onto audioswitch's own default, which orders earpiece above speaker. And duplicate entries are rejected before `configureAudio` is reached, because `AbstractAudioSwitch` enforces `require(hasNoDuplicates(...))` from a task posted to the main looper, after `startAudioSession()` has already resolved, so the resulting exception crashes the app rather than failing the session start.

The issue's second proposed direction (make it overridable) is folded in rather than picked over the first, since a fixed default is still an opinion some apps will want to override (e.g. an app that always wants speaker output regardless of connected accessories). A new `webRtc.reactNative.audioSession` session option lets a caller override `android.preferredOutputList` and/or `ios.defaultOutput` explicitly; anything not overridden keeps the new default. This is scoped to exactly the two fields the issue is about, not a full passthrough of `AudioConfiguration` (which also covers Android audio focus/mode/stream-type options unrelated to this bug).

## Tests

`packages/react-native` has no test infrastructure (no vitest dependency, no config, no `.test.ts` files anywhere in the package), so this does not add a test runner to the package as part of a bug fix. The routing logic is a standalone pure module (`src/audioSession.ts`) that a harness can pick up directly if a maintainer would rather have one here.

Verified instead by transcribing the native semantics described above into a model and replaying a two-session sequence against both the old and the new call site, with a Bluetooth headset connected throughout except where noted:

| case | expected | before | after |
| --- | --- | --- | --- |
| no override, fresh app | bluetooth | bluetooth | bluetooth |
| override earpiece, then no override | bluetooth | **earpiece** | bluetooth |
| explicit override honoured | earpiece | earpiece | earpiece |
| empty list, headset connected | bluetooth | bluetooth | bluetooth |
| empty list, no headset connected | speaker | **earpiece** | speaker |
| `["speaker", "speaker"]` | rejected | **app crash** | rejected |

This is a model of the native behaviour rather than a device test, so it is only as good as the transcription. A confirmation on hardware is welcome.

Workspace-wide: `build` 13/13, `check-types` 16/16, `lint` 29/29, `packages/client` 238/238, `packages/react` 141/141. The new `webRtc.reactNative` field is additive to `BaseSessionConfig` in `packages/client`, so it doesn't affect anything not opting in.
