### PR TITLE
[Agents] Hide language selector on collapsed widget trigger

### DIFF
--- a/.changeset/language-selector-placement.md
+++ b/.changeset/language-selector-placement.md
@@ -1,6 +1,0 @@
----
-"@elevenlabs/convai-widget-core": minor
-"@elevenlabs/convai-widget-embed": minor
----
-
-Add a `language_selector_placement` widget config option (and matching `language-selector-placement` embed attribute) that controls whether the language dropdown appears on the collapsed launcher (`trigger`, default) or only in the expanded sheet header (`sheet`).

--- a/.changeset/language-selector-placement.md
+++ b/.changeset/language-selector-placement.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/convai-widget-core": minor
+"@elevenlabs/convai-widget-embed": minor
+---
+
+Add a `language_selector_placement` widget config option (and matching `language-selector-placement` embed attribute) that controls whether the language dropdown appears on the collapsed launcher (`trigger`, default) or only in the expanded sheet header (`sheet`).

--- a/.changeset/show-language-selector-on-trigger.md
+++ b/.changeset/show-language-selector-on-trigger.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/convai-widget-core": minor
+"@elevenlabs/convai-widget-embed": minor
+---
+
+Add a `show_language_selector_on_trigger` widget config option (and matching `show-language-selector-on-trigger` embed attribute). Default `true` keeps the language dropdown on the collapsed launcher. Set to `false` to hide it there; the expanded sheet header still shows it.

--- a/packages/convai-widget-core/src/PlaygroundSettings.tsx
+++ b/packages/convai-widget-core/src/PlaygroundSettings.tsx
@@ -22,6 +22,8 @@ export function usePlaygroundSettings() {
   const [dismissible, setDismissible] = useState(false);
   const [showAgentStatus, setShowAgentStatus] = useState(false);
   const [showResizeButton, setShowResizeButton] = useState(true);
+  const [showLanguageSelectorOnTrigger, setShowLanguageSelectorOnTrigger] =
+    useState(true);
   const [dynamicVariablesStr, setDynamicVariablesStr] = useState("");
   const [expanded, setExpanded] = useState(false);
   const [allowEvents, setAllowEvents] = useState(false);
@@ -70,6 +72,8 @@ export function usePlaygroundSettings() {
     setShowAgentStatus,
     showResizeButton,
     setShowResizeButton,
+    showLanguageSelectorOnTrigger,
+    setShowLanguageSelectorOnTrigger,
     dynamicVariablesStr,
     setDynamicVariablesStr,
     dynamicVariables,
@@ -192,6 +196,16 @@ export function PlaygroundSettingsPanel({
           onChange={e => state.setShowResizeButton(e.currentTarget.checked)}
         />{" "}
         Show resize button
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={state.showLanguageSelectorOnTrigger}
+          onChange={e =>
+            state.setShowLanguageSelectorOnTrigger(e.currentTarget.checked)
+          }
+        />{" "}
+        Show language selector on trigger
       </label>
       <label>
         Dynamic variables (i.e., new-line separated name=value)

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -11,7 +11,6 @@ import {
   DefaultStyles,
   parsePlacement,
   parseVariant,
-  parseLanguageSelectorPlacement,
   type SyntaxHighlightTheme,
   type WidgetConfig,
 } from "../types/config";
@@ -140,7 +139,9 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
   const showAgentStatus = useAttribute("show-agent-status");
   const showConversationId = useAttribute("show-conversation-id");
   const showResizeButton = useAttribute("show-resize-button");
-  const languageSelectorPlacement = useAttribute("language-selector-placement");
+  const showLanguageSelectorOnTrigger = useAttribute(
+    "show-language-selector-on-trigger"
+  );
 
   const value = useComputed<WidgetConfig | null>(() => {
     if (!fetchedConfig.value) {
@@ -195,10 +196,10 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       parseBoolAttribute(showResizeButton.value) ??
       fetchedConfig.value.show_resize_button ??
       true;
-    const patchedLanguageSelectorPlacement = parseLanguageSelectorPlacement(
-      languageSelectorPlacement.value ??
-        fetchedConfig.value.language_selector_placement
-    );
+    const patchedShowLanguageSelectorOnTrigger =
+      parseBoolAttribute(showLanguageSelectorOnTrigger.value) ??
+      fetchedConfig.value.show_language_selector_on_trigger ??
+      true;
 
     return {
       ...fetchedConfig.value,
@@ -216,7 +217,7 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       show_agent_status: patchedShowAgentStatus,
       show_conversation_id: patchedShowConversationId,
       show_resize_button: patchedShowResizeButton,
-      language_selector_placement: patchedLanguageSelectorPlacement,
+      show_language_selector_on_trigger: patchedShowLanguageSelectorOnTrigger,
     };
   });
 

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -11,6 +11,7 @@ import {
   DefaultStyles,
   parsePlacement,
   parseVariant,
+  parseLanguageSelectorPlacement,
   type SyntaxHighlightTheme,
   type WidgetConfig,
 } from "../types/config";
@@ -139,6 +140,7 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
   const showAgentStatus = useAttribute("show-agent-status");
   const showConversationId = useAttribute("show-conversation-id");
   const showResizeButton = useAttribute("show-resize-button");
+  const languageSelectorPlacement = useAttribute("language-selector-placement");
 
   const value = useComputed<WidgetConfig | null>(() => {
     if (!fetchedConfig.value) {
@@ -193,6 +195,10 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       parseBoolAttribute(showResizeButton.value) ??
       fetchedConfig.value.show_resize_button ??
       true;
+    const patchedLanguageSelectorPlacement = parseLanguageSelectorPlacement(
+      languageSelectorPlacement.value ??
+        fetchedConfig.value.language_selector_placement
+    );
 
     return {
       ...fetchedConfig.value,
@@ -210,6 +216,7 @@ export function WidgetConfigProvider({ children }: WidgetConfigProviderProps) {
       show_agent_status: patchedShowAgentStatus,
       show_conversation_id: patchedShowConversationId,
       show_resize_button: patchedShowResizeButton,
+      language_selector_placement: patchedLanguageSelectorPlacement,
     };
   });
 

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -44,6 +44,9 @@ function Playground() {
           dismissible={JSON.stringify(state.dismissible)}
           show-agent-status={JSON.stringify(state.showAgentStatus)}
           show-resize-button={JSON.stringify(state.showResizeButton)}
+          show-language-selector-on-trigger={JSON.stringify(
+            state.showLanguageSelectorOnTrigger
+          )}
           dynamic-variables={JSON.stringify(state.dynamicVariables)}
           server-location={state.location}
           override-first-message={

--- a/packages/convai-widget-core/src/shadowdom.dev.tsx
+++ b/packages/convai-widget-core/src/shadowdom.dev.tsx
@@ -38,6 +38,9 @@ function Playground() {
       dismissible: JSON.stringify(state.dismissible),
       "show-agent-status": JSON.stringify(state.showAgentStatus),
       "show-resize-button": JSON.stringify(state.showResizeButton),
+      "show-language-selector-on-trigger": JSON.stringify(
+        state.showLanguageSelectorOnTrigger
+      ),
       "dynamic-variables": JSON.stringify(state.dynamicVariables),
       "server-location": state.location,
       "override-first-message": state.overrideFirstMessage
@@ -66,6 +69,7 @@ function Playground() {
     state.dismissible,
     state.showAgentStatus,
     state.showResizeButton,
+    state.showLanguageSelectorOnTrigger,
     state.dynamicVariables,
     state.location,
     state.overrideFirstMessage,

--- a/packages/convai-widget-core/src/types/attributes.ts
+++ b/packages/convai-widget-core/src/types/attributes.ts
@@ -59,6 +59,7 @@ export const CustomAttributeList = [
   "show-agent-status",
   "show-conversation-id",
   "show-resize-button",
+  "language-selector-placement",
   "environment",
 ] as const;
 

--- a/packages/convai-widget-core/src/types/attributes.ts
+++ b/packages/convai-widget-core/src/types/attributes.ts
@@ -59,7 +59,7 @@ export const CustomAttributeList = [
   "show-agent-status",
   "show-conversation-id",
   "show-resize-button",
-  "language-selector-placement",
+  "show-language-selector-on-trigger",
   "environment",
 ] as const;
 

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -24,6 +24,20 @@ export function parsePlacement(placement: string | undefined): Placement {
     : "bottom-right";
 }
 
+export const LanguageSelectorPlacements = ["trigger", "sheet"] as const;
+export type LanguageSelectorPlacement =
+  (typeof LanguageSelectorPlacements)[number];
+
+export function parseLanguageSelectorPlacement(
+  placement: string | undefined
+): LanguageSelectorPlacement {
+  return LanguageSelectorPlacements.includes(
+    placement as LanguageSelectorPlacement
+  )
+    ? (placement as LanguageSelectorPlacement)
+    : "trigger";
+}
+
 export type FeedbackMode = "none" | "during" | "end";
 export type FeedbackType = "rating";
 export type SyntaxHighlightTheme = "light" | "dark";
@@ -84,6 +98,7 @@ export interface WidgetConfig {
     max_files_per_conversation?: number;
   };
   show_resize_button?: boolean;
+  language_selector_placement?: LanguageSelectorPlacement;
 }
 
 export type AvatarConfig =

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -24,20 +24,6 @@ export function parsePlacement(placement: string | undefined): Placement {
     : "bottom-right";
 }
 
-export const LanguageSelectorPlacements = ["trigger", "sheet"] as const;
-export type LanguageSelectorPlacement =
-  (typeof LanguageSelectorPlacements)[number];
-
-export function parseLanguageSelectorPlacement(
-  placement: string | undefined
-): LanguageSelectorPlacement {
-  return LanguageSelectorPlacements.includes(
-    placement as LanguageSelectorPlacement
-  )
-    ? (placement as LanguageSelectorPlacement)
-    : "trigger";
-}
-
 export type FeedbackMode = "none" | "during" | "end";
 export type FeedbackType = "rating";
 export type SyntaxHighlightTheme = "light" | "dark";
@@ -98,7 +84,7 @@ export interface WidgetConfig {
     max_files_per_conversation?: number;
   };
   show_resize_button?: boolean;
-  language_selector_placement?: LanguageSelectorPlacement;
+  show_language_selector_on_trigger?: boolean;
 }
 
 export type AvatarConfig =

--- a/packages/convai-widget-core/src/widget/ExpandableTriggerActions.test.ts
+++ b/packages/convai-widget-core/src/widget/ExpandableTriggerActions.test.ts
@@ -119,6 +119,38 @@ describe("Trigger entry points", () => {
       }
     );
 
+    it.each(Variants)(
+      "$0 hides the language picker on the launcher when placement is sheet",
+      async variant => {
+        setupWebComponent({
+          "agent-id": "localized",
+          variant,
+          "text-input": "true",
+          "language-selector-placement": "sheet",
+        });
+
+        await expect
+          .element(page.getByRole("combobox", { name: "Change language" }))
+          .not.toBeInTheDocument();
+      }
+    );
+
+    it("shows the language picker in the sheet when placement is sheet", async () => {
+      setupWebComponent({
+        "agent-id": "localized",
+        variant: "compact",
+        "text-input": "true",
+        "language-selector-placement": "sheet",
+      });
+
+      await page.getByRole("button", { name: "Message" }).click();
+      await page.getByRole("button", { name: "Accept" }).click();
+
+      await expect
+        .element(page.getByRole("combobox", { name: "Change language" }))
+        .toBeVisible();
+    });
+
     it("opens the dropdown without expanding the widget", async () => {
       setupWebComponent({
         "agent-id": "localized",

--- a/packages/convai-widget-core/src/widget/ExpandableTriggerActions.test.ts
+++ b/packages/convai-widget-core/src/widget/ExpandableTriggerActions.test.ts
@@ -120,13 +120,13 @@ describe("Trigger entry points", () => {
     );
 
     it.each(Variants)(
-      "$0 hides the language picker on the launcher when placement is sheet",
+      "$0 hides the language picker on the launcher when disabled",
       async variant => {
         setupWebComponent({
           "agent-id": "localized",
           variant,
           "text-input": "true",
-          "language-selector-placement": "sheet",
+          "show-language-selector-on-trigger": "false",
         });
 
         await expect
@@ -135,12 +135,12 @@ describe("Trigger entry points", () => {
       }
     );
 
-    it("shows the language picker in the sheet when placement is sheet", async () => {
+    it("shows the language picker in the sheet when hidden on the launcher", async () => {
       setupWebComponent({
         "agent-id": "localized",
         variant: "compact",
         "text-input": "true",
-        "language-selector-placement": "sheet",
+        "show-language-selector-on-trigger": "false",
       });
 
       await page.getByRole("button", { name: "Message" }).click();

--- a/packages/convai-widget-core/src/widget/ExpandableTriggerActions.tsx
+++ b/packages/convai-widget-core/src/widget/ExpandableTriggerActions.tsx
@@ -78,7 +78,7 @@ export function ExpandableTriggerActions({
   const collapsedConnected = !expanded.value && !isDisconnected.value;
   const showTriggerLanguageSelector =
     collapsedDisconnected &&
-    config.value.language_selector_placement === "trigger";
+    (config.value.show_language_selector_on_trigger ?? true);
 
   return (
     <>

--- a/packages/convai-widget-core/src/widget/ExpandableTriggerActions.tsx
+++ b/packages/convai-widget-core/src/widget/ExpandableTriggerActions.tsx
@@ -31,7 +31,8 @@ export function ExpandableTriggerActions({
 }: ExpandableTriggerActionsProps) {
   const conversationTextOnly = useIsConversationTextOnly();
   const { showCall, showMessage } = useTriggerEntryPoints();
-  const variant = useWidgetConfig().value.variant;
+  const config = useWidgetConfig();
+  const variant = config.value.variant;
   const isTiny = variant === "tiny";
   const { isDisconnected, startSession } = useConversation();
   const callDisabled = useCallButtonDisabled();
@@ -75,6 +76,9 @@ export function ExpandableTriggerActions({
 
   const collapsedDisconnected = !expanded.value && isDisconnected.value;
   const collapsedConnected = !expanded.value && !isDisconnected.value;
+  const showTriggerLanguageSelector =
+    collapsedDisconnected &&
+    config.value.language_selector_placement === "trigger";
 
   return (
     <>
@@ -130,7 +134,7 @@ export function ExpandableTriggerActions({
           {!isTiny && !showCall.value ? text.start_chat : undefined}
         </Button>
       </SizeTransition>
-      <TriggerLanguageSelect visible={collapsedDisconnected} />
+      <TriggerLanguageSelect visible={showTriggerLanguageSelector} />
 
       {/* Collapse/expand affordance for the connected or expanded states. */}
       <SizeTransition

--- a/packages/convai-widget-core/src/widget/TriggerActions.tsx
+++ b/packages/convai-widget-core/src/widget/TriggerActions.tsx
@@ -14,9 +14,13 @@ interface TriggerActionsProps {
 }
 
 export function TriggerActions({ onDismiss }: TriggerActionsProps) {
-  const variant = useWidgetConfig().value.variant;
+  const config = useWidgetConfig();
+  const variant = config.value.variant;
   const { isDisconnected } = useConversation();
   const callDisabled = useCallButtonDisabled();
+  const showTriggerLanguageSelector =
+    isDisconnected.value &&
+    (config.value.show_language_selector_on_trigger ?? true);
 
   return (
     <>
@@ -26,7 +30,7 @@ export function TriggerActions({ onDismiss }: TriggerActionsProps) {
         className="w-full m-1 z-1"
         disabled={callDisabled.value}
       />
-      <TriggerLanguageSelect visible={isDisconnected.value} />
+      <TriggerLanguageSelect visible={showTriggerLanguageSelector} />
       <SizeTransition visible={!isDisconnected.value} className="p-1">
         <TriggerMuteButton />
       </SizeTransition>


### PR DESCRIPTION
[AWF-89](https://linear.app/elevenlabs/issue/AWF-89/language-dropdown-visibility-feedback)
[Slack](https://eleven-labs-workspace.slack.com/archives/C08A0QJ8YQH/p1780661426842489)

**Why:** Since v0.13.0 the language dropdown sits on the collapsed launcher. Customers who sized an iframe to that launcher (HCLTech) get overflow that blocks clicks on the page behind it. They want the picker back in the expanded sheet only.

**What:**
- Add `show_language_selector_on_trigger` (embed: `show-language-selector-on-trigger`). Default `true` keeps current launcher behavior.
- `false` hides the picker on collapsed expandable and non-expandable triggers. The expanded sheet header still shows it under existing sheet rules.
<img width="800" height="617" alt="CleanShot 2026-08-20 at 16 06 17" src="https://github.com/user-attachments/assets/49f33478-437a-4eb2-9820-6387ec7f1193" />



**Test:** `ExpandableTriggerActions.test.ts` — launcher hides when `false`; sheet still shows the picker after expand.
