### PR TITLE
feat(widget): render the concurrency wait-queue status

### DIFF
--- a/.changeset/convai-widget-queue-status.md
+++ b/.changeset/convai-widget-queue-status.md
@@ -3,4 +3,4 @@
 "@elevenlabs/convai-widget-embed": patch
 ---
 
-Support concurrency wait-queue (`queue_status`) server events: show a waiting status while all agents are busy, hide the typing indicator and block text/attachment sending while queued, and render a friendly non-error message when the queue wait times out. Adds `queue_waiting_status`, `queue_waiting_status_short`, and `queue_timed_out` text-content keys for customization and localization.
+Support concurrency wait-queue (`queue_status`) server events: show a waiting status while all agents are busy, hide the typing indicator and block text/attachment sending while queued, and render a friendly non-error message when the queue wait times out.

--- a/.changeset/convai-widget-queue-status.md
+++ b/.changeset/convai-widget-queue-status.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/convai-widget-core": minor
+"@elevenlabs/convai-widget-embed": patch
+---
+
+Support concurrency wait-queue (`queue_status`) server events: show a waiting status while all agents are busy, hide the typing indicator and block text/attachment sending while queued, and render a friendly non-error message when the queue wait times out. Adds `queue_waiting_status` and `queue_timed_out` text-content keys for customization and localization.

--- a/.changeset/convai-widget-queue-status.md
+++ b/.changeset/convai-widget-queue-status.md
@@ -3,4 +3,4 @@
 "@elevenlabs/convai-widget-embed": patch
 ---
 
-Support concurrency wait-queue (`queue_status`) server events: show a waiting status while all agents are busy, hide the typing indicator and block text/attachment sending while queued, and render a friendly non-error message when the queue wait times out. Adds `queue_waiting_status` and `queue_timed_out` text-content keys for customization and localization.
+Support concurrency wait-queue (`queue_status`) server events: show a waiting status while all agents are busy, hide the typing indicator and block text/attachment sending while queued, and render a friendly non-error message when the queue wait times out. Adds `queue_waiting_status`, `queue_waiting_status_short`, and `queue_timed_out` text-content keys for customization and localization.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -575,6 +575,8 @@ function useConversationSetup() {
         conversationRef.current?.sendFeedback(like);
       },
       sendUserMessage: (text: string, options?: SendUserMessageOptions) => {
+        // The orchestrator discards messages sent while held in the queue.
+        if (isWaitingForAgent.peek()) return;
         conversationRef.current?.sendUserMessage(text, options);
         transcript.value = [
           ...transcript.value,
@@ -591,6 +593,7 @@ function useConversationSetup() {
         text?: string;
         file: TranscriptFileInput & { fileId: string };
       }) => {
+        if (isWaitingForAgent.peek()) return;
         const trimmed = input.text?.trim() ?? "";
         const { fileId, ...fileInput } = input.file;
         conversationRef.current?.sendMultimodalMessage({

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -88,6 +88,10 @@ export type TranscriptEntry =
       type: "mode_toggle";
       mode: ConversationMode;
       conversationIndex: number;
+    }
+  | {
+      type: "queue_timeout";
+      conversationIndex: number;
     };
 
 export function ConversationProvider({ children }: ConversationProviderProps) {
@@ -189,6 +193,21 @@ function useConversationSetup() {
     const conversationTextOnly = signal<boolean | null>(null);
     const isAgentTyping = signal(false);
     const isExternalAgentMode = signal(false);
+    const queueStatus = signal<string | null>(null);
+    // The caller reached the agent when it never entered the concurrency wait
+    // queue (null) or was admitted from it. A status added on the backend but
+    // unknown here counts as reached, degrading gracefully to the regular UI.
+    const reachedAgent = computed(() => {
+      const s = queueStatus.value;
+      return s === null || (s !== "waiting" && s !== "timed_out");
+    });
+    // While queued the transport is connected but the orchestrator discards
+    // client messages. "timed_out" arrives as a heads-up just before the
+    // server closes the connection, so it still counts as waiting until the
+    // disconnect actually lands.
+    const isWaitingForAgent = computed(
+      () => !reachedAgent.value && !isDisconnected.value
+    );
 
     const setAgentTyping = (typing: boolean, durationMs?: number | null) => {
       clearTypingTimer();
@@ -214,6 +233,8 @@ function useConversationSetup() {
       transcript,
       isAgentTyping,
       isExternalAgentMode,
+      queueStatus,
+      isWaitingForAgent,
       startSession: async (
         element: HTMLElement,
         initialMessage?: string,
@@ -259,6 +280,7 @@ function useConversationSetup() {
         }
 
         conversationTextOnly.value = processedConfig.textOnly ?? false;
+        queueStatus.value = null;
         transcript.value = [
           ...firstMessageEntries(),
           ...(initialMessage
@@ -432,7 +454,27 @@ function useConversationSetup() {
               setAgentTyping(false);
               isExternalAgentMode.value = false;
             },
+            // The SDK forwards server events it does not handle (such as
+            // queue_status) to onDebug, alongside other debug payloads, so
+            // the event shape has to be narrowed here.
+            onDebug: (props: unknown) => {
+              const event = props as {
+                type?: string;
+                queue_status_event?: { status?: unknown };
+              };
+              if (
+                event?.type === "queue_status" &&
+                typeof event.queue_status_event?.status === "string"
+              ) {
+                queueStatus.value = event.queue_status_event.status;
+              }
+            },
             onDisconnect: details => {
+              // The server closes with an error after a queue timeout; show
+              // friendly copy instead of the raw close reason in that case.
+              const queueTimedOut =
+                details.reason === "error" &&
+                queueStatus.peek() === "timed_out";
               receivedFirstMessageRef.current = false;
               conversationTextOnly.value = null;
               streamingMessageIndexRef.current = null;
@@ -442,20 +484,25 @@ function useConversationSetup() {
               isExternalAgentMode.value = false;
               transcript.value = [
                 ...transcript.peek(),
-                details.reason === "error"
+                queueTimedOut
                   ? {
-                      type: "error",
-                      message: details.message,
+                      type: "queue_timeout",
                       conversationIndex: conversationIndex.peek(),
                     }
-                  : {
-                      type: "disconnection",
-                      role: details.reason === "user" ? "user" : "agent",
-                      conversationIndex: conversationIndex.peek(),
-                    },
+                  : details.reason === "error"
+                    ? {
+                        type: "error",
+                        message: details.message,
+                        conversationIndex: conversationIndex.peek(),
+                      }
+                    : {
+                        type: "disconnection",
+                        role: details.reason === "user" ? "user" : "agent",
+                        conversationIndex: conversationIndex.peek(),
+                      },
               ];
               conversationIndex.value++;
-              if (details.reason === "error") {
+              if (details.reason === "error" && !queueTimedOut) {
                 error.value = details.message;
                 console.error(
                   "[ConversationalAI] Disconnected due to an error:",
@@ -481,21 +528,33 @@ function useConversationSetup() {
           error.value = null;
           return id;
         } catch (e) {
-          let message = "Could not start a conversation.";
-          if (e instanceof CloseEvent) {
-            message = e.reason || message;
-          } else if (e instanceof Error) {
-            message = e.message || message;
+          // A queue timeout can close the connection before startSession
+          // resolves; it gets the same friendly treatment as in onDisconnect.
+          if (queueStatus.peek() === "timed_out") {
+            transcript.value = [
+              ...transcript.value,
+              {
+                type: "queue_timeout",
+                conversationIndex: conversationIndex.peek(),
+              },
+            ];
+          } else {
+            let message = "Could not start a conversation.";
+            if (e instanceof CloseEvent) {
+              message = e.reason || message;
+            } else if (e instanceof Error) {
+              message = e.message || message;
+            }
+            error.value = message;
+            transcript.value = [
+              ...transcript.value,
+              {
+                type: "error",
+                message,
+                conversationIndex: conversationIndex.peek(),
+              },
+            ];
           }
-          error.value = message;
-          transcript.value = [
-            ...transcript.value,
-            {
-              type: "error",
-              message,
-              conversationIndex: conversationIndex.peek(),
-            },
-          ];
         } finally {
           lockRef.current = null;
         }

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -194,18 +194,12 @@ function useConversationSetup() {
     const isAgentTyping = signal(false);
     const isExternalAgentMode = signal(false);
     const queueStatus = signal<string | null>(null);
-    // Only the statuses that hold a caller back are listed, so no queue,
-    // admission, and any status this build does not know about all mean "not
-    // held" — a status added on the backend renders like the pre-queue flow
-    // instead of locking the UI.
+    // Unknown statuses mean "not held" so a new backend status cannot lock the UI.
     const isHeldInQueue = computed(
-      () =>
-        queueStatus.value === "waiting" || queueStatus.value === "timed_out"
+      () => queueStatus.value === "waiting" || queueStatus.value === "timed_out"
     );
-    // While queued the transport is connected but the orchestrator discards
-    // client messages. "timed_out" counts as held: the server sends it as a
-    // heads-up just before closing the connection, so it still renders as
-    // waiting until the disconnect actually lands.
+    // "timed_out" still counts as held: the server sends it just before
+    // closing, so the UI keeps showing waiting until the disconnect lands.
     const isWaitingForAgent = computed(
       () => isHeldInQueue.value && !isDisconnected.value
     );
@@ -455,9 +449,9 @@ function useConversationSetup() {
               setAgentTyping(false);
               isExternalAgentMode.value = false;
             },
-            // The SDK forwards server events it does not handle (such as
-            // queue_status) to onDebug, alongside other debug payloads, so
-            // the event shape has to be narrowed here.
+            // The SDK forwards unhandled server events to onDebug.
+            // TODO: drop this narrowing once the SDK handles queue_status
+            // explicitly (planned after the queue protocol is finalized).
             onDebug: (props: unknown) => {
               const event = props as {
                 type?: string;
@@ -471,8 +465,8 @@ function useConversationSetup() {
               }
             },
             onDisconnect: details => {
-              // The server closes with an error after a queue timeout; show
-              // friendly copy instead of the raw close reason in that case.
+              // A queue timeout closes with an error; show friendly copy
+              // instead of the raw close reason.
               const queueTimedOut =
                 details.reason === "error" &&
                 queueStatus.peek() === "timed_out";
@@ -530,7 +524,7 @@ function useConversationSetup() {
           return id;
         } catch (e) {
           // A queue timeout can close the connection before startSession
-          // resolves; it gets the same friendly treatment as in onDisconnect.
+          // resolves.
           if (queueStatus.peek() === "timed_out") {
             transcript.value = [
               ...transcript.value,

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -194,19 +194,20 @@ function useConversationSetup() {
     const isAgentTyping = signal(false);
     const isExternalAgentMode = signal(false);
     const queueStatus = signal<string | null>(null);
-    // The caller reached the agent when it never entered the concurrency wait
-    // queue (null) or was admitted from it. A status added on the backend but
-    // unknown here counts as reached, degrading gracefully to the regular UI.
-    const reachedAgent = computed(() => {
-      const s = queueStatus.value;
-      return s === null || (s !== "waiting" && s !== "timed_out");
-    });
+    // Only the statuses that hold a caller back are listed, so no queue,
+    // admission, and any status this build does not know about all mean "not
+    // held" — a status added on the backend renders like the pre-queue flow
+    // instead of locking the UI.
+    const isHeldInQueue = computed(
+      () =>
+        queueStatus.value === "waiting" || queueStatus.value === "timed_out"
+    );
     // While queued the transport is connected but the orchestrator discards
-    // client messages. "timed_out" arrives as a heads-up just before the
-    // server closes the connection, so it still counts as waiting until the
-    // disconnect actually lands.
+    // client messages. "timed_out" counts as held: the server sends it as a
+    // heads-up just before closing the connection, so it still renders as
+    // waiting until the disconnect actually lands.
     const isWaitingForAgent = computed(
-      () => !reachedAgent.value && !isDisconnected.value
+      () => isHeldInQueue.value && !isDisconnected.value
     );
 
     const setAgentTyping = (typing: boolean, durationMs?: number | null) => {

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -349,6 +349,45 @@ describe("elevenlabs-convai", () => {
         .toBeInTheDocument();
     });
 
+    it("disables rich-content buttons and drops bridged sends while queued", async () => {
+      const widget = setupWebComponent({
+        "agent-id": "queued",
+        transcript: "true",
+        "text-input": "true",
+        "allow-events": "true",
+        "default-expanded": "true",
+      });
+
+      // Start via the textarea so the conversation is text-only and rich
+      // content renders.
+      const textInput = page.getByRole("textbox", {
+        name: "Text message input",
+      });
+      await textInput.fill("Hello");
+      await userEvent.keyboard("{Enter}");
+      const acceptButton = page.getByRole("button", { name: "Accept" });
+      await acceptButton.click();
+
+      await expect
+        .element(page.getByText("Waiting for an available agent"))
+        .toBeInTheDocument();
+
+      // Rich-content buttons received while queued render disabled.
+      await expect
+        .element(page.getByRole("button", { name: "Quick reply" }))
+        .toBeDisabled();
+
+      // Programmatic sends via the event bridge are dropped while queued.
+      widget.dispatchEvent(
+        new CustomEvent("elevenlabs-agent:user-message", {
+          detail: { message: "Bridged message" },
+        })
+      );
+      await expect
+        .element(page.getByText("Bridged message"))
+        .not.toBeInTheDocument();
+    });
+
     it("shows the full waiting message on the avatar overlay", async () => {
       // The expanded sheet without a transcript shows the avatar overlay,
       // which renders the full waiting copy.

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -318,8 +318,7 @@ describe("elevenlabs-convai", () => {
         .element(page.getByText("Agent is typing ..."))
         .not.toBeInTheDocument();
 
-      // Sending is blocked: the orchestrator discards client messages while
-      // held in the queue, so they would only pollute the local transcript.
+      // Sending is blocked while held in the queue.
       const textInput = page.getByRole("textbox", {
         name: "Text message input",
       });
@@ -351,9 +350,8 @@ describe("elevenlabs-convai", () => {
     });
 
     it("shows the full waiting message on the avatar overlay", async () => {
-      // An expanded sheet without a transcript shows the avatar overlay,
-      // which has room for the full reassurance copy instead of the short
-      // pill form.
+      // The expanded sheet without a transcript shows the avatar overlay,
+      // which renders the full waiting copy.
       setupWebComponent({ "agent-id": "queued_overlay" });
 
       const startButton = page.getByRole("button", { name: "Start a call" });
@@ -367,9 +365,8 @@ describe("elevenlabs-convai", () => {
     });
 
     it("keeps the waiting status inside the full trigger", async () => {
-      // The trigger sizes itself from the labels' shared grid cell; with an
-      // absolutely positioned status label the long waiting copy would not
-      // affect layout and would get clipped at the card edge mid-word.
+      // Regression: the long waiting copy must size the trigger, not get
+      // clipped at the card edge.
       setupWebComponent({ "agent-id": "queued", variant: "full" });
 
       const startButton = page.getByRole("button", { name: "Start a call" });
@@ -444,8 +441,7 @@ describe("elevenlabs-convai", () => {
         .element(page.getByText("Waiting for an available agent"))
         .toBeInTheDocument();
 
-      // The server closes after the timeout; the caller gets friendly copy
-      // instead of the raw close reason or error styling.
+      // Friendly copy instead of the raw close reason or error styling.
       await expect
         .element(
           page.getByText("All agents are still busy. Please try again later.")

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -310,7 +310,7 @@ describe("elevenlabs-convai", () => {
       await acceptButton.click();
 
       await expect
-        .element(page.getByText("All agents are busy right now"))
+        .element(page.getByText("Waiting for an available agent"))
         .toBeInTheDocument();
 
       // The typing indicator stays hidden while queued.
@@ -339,7 +339,7 @@ describe("elevenlabs-convai", () => {
         .element(page.getByText("You ended the conversation"))
         .toBeInTheDocument();
       await expect
-        .element(page.getByText("All agents are busy right now"))
+        .element(page.getByText("Waiting for an available agent"))
         .not.toBeInTheDocument();
 
       // No residual gating: a new conversation can start from the textarea.
@@ -347,6 +347,22 @@ describe("elevenlabs-convai", () => {
       await userEvent.keyboard("{Enter}");
       await expect
         .element(page.getByText("New text message"))
+        .toBeInTheDocument();
+    });
+
+    it("shows the full waiting message on the avatar overlay", async () => {
+      // An expanded sheet without a transcript shows the avatar overlay,
+      // which has room for the full reassurance copy instead of the short
+      // pill form.
+      setupWebComponent({ "agent-id": "queued_overlay" });
+
+      const startButton = page.getByRole("button", { name: "Start a call" });
+      await startButton.click();
+      const acceptButton = page.getByRole("button", { name: "Accept" });
+      await acceptButton.click();
+
+      await expect
+        .element(page.getByText("All agents are busy right now"))
         .toBeInTheDocument();
     });
 
@@ -363,7 +379,7 @@ describe("elevenlabs-convai", () => {
       await acceptButton.click();
 
       await expect
-        .element(page.getByText("All agents are busy right now"))
+        .element(page.getByText("Waiting for an available agent"))
         .toBeInTheDocument();
 
       // Admitted: the waiting status clears and the agent responds.
@@ -371,7 +387,7 @@ describe("elevenlabs-convai", () => {
         .element(page.getByText("Queue cleared response"))
         .toBeInTheDocument();
       await expect
-        .element(page.getByText("All agents are busy right now"))
+        .element(page.getByText("Waiting for an available agent"))
         .not.toBeInTheDocument();
 
       // Sending works again.
@@ -398,7 +414,7 @@ describe("elevenlabs-convai", () => {
       await acceptButton.click();
 
       await expect
-        .element(page.getByText("All agents are busy right now"))
+        .element(page.getByText("Waiting for an available agent"))
         .toBeInTheDocument();
 
       // The server closes after the timeout; the caller gets friendly copy

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -296,6 +296,128 @@ describe("elevenlabs-convai", () => {
     }
   );
 
+  describe("concurrency wait queue", () => {
+    it("shows the waiting status and blocks sending while queued", async () => {
+      setupWebComponent({
+        "agent-id": "queued",
+        transcript: "true",
+        "text-input": "true",
+      });
+
+      const startButton = page.getByRole("button", { name: "Start a call" });
+      await startButton.click();
+      const acceptButton = page.getByRole("button", { name: "Accept" });
+      await acceptButton.click();
+
+      await expect
+        .element(page.getByText("All agents are busy right now"))
+        .toBeInTheDocument();
+
+      // The typing indicator stays hidden while queued.
+      await expect
+        .element(page.getByText("Agent is typing ..."))
+        .not.toBeInTheDocument();
+
+      // Sending is blocked: the orchestrator discards client messages while
+      // held in the queue, so they would only pollute the local transcript.
+      const textInput = page.getByRole("textbox", {
+        name: "Text message input",
+      });
+      await textInput.fill("Queued message");
+      await expect
+        .element(page.getByRole("button", { name: "Send", exact: true }))
+        .toBeDisabled();
+      await userEvent.keyboard("{Enter}");
+      await expect
+        .element(page.getByText("Queued message"))
+        .not.toBeInTheDocument();
+
+      // Hanging up while queued goes through the regular disconnect flow.
+      const endButton = page.getByRole("button", { name: "End", exact: true });
+      await endButton.click();
+      await expect
+        .element(page.getByText("You ended the conversation"))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByText("All agents are busy right now"))
+        .not.toBeInTheDocument();
+
+      // No residual gating: a new conversation can start from the textarea.
+      await textInput.fill("New text message");
+      await userEvent.keyboard("{Enter}");
+      await expect
+        .element(page.getByText("New text message"))
+        .toBeInTheDocument();
+    });
+
+    it("returns to the regular flow when admitted from the queue", async () => {
+      setupWebComponent({
+        "agent-id": "queue_admit",
+        transcript: "true",
+        "text-input": "true",
+      });
+
+      const startButton = page.getByRole("button", { name: "Start a call" });
+      await startButton.click();
+      const acceptButton = page.getByRole("button", { name: "Accept" });
+      await acceptButton.click();
+
+      await expect
+        .element(page.getByText("All agents are busy right now"))
+        .toBeInTheDocument();
+
+      // Admitted: the waiting status clears and the agent responds.
+      await expect
+        .element(page.getByText("Queue cleared response"))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByText("All agents are busy right now"))
+        .not.toBeInTheDocument();
+
+      // Sending works again.
+      const textInput = page.getByRole("textbox", {
+        name: "Text message input",
+      });
+      await textInput.fill("Hello after queue");
+      await userEvent.keyboard("{Enter}");
+      await expect
+        .element(page.getByText("Hello after queue"))
+        .toBeInTheDocument();
+    });
+
+    it("shows a friendly message when the queue wait times out", async () => {
+      setupWebComponent({
+        "agent-id": "queue_timeout",
+        transcript: "true",
+        "text-input": "true",
+      });
+
+      const startButton = page.getByRole("button", { name: "Start a call" });
+      await startButton.click();
+      const acceptButton = page.getByRole("button", { name: "Accept" });
+      await acceptButton.click();
+
+      await expect
+        .element(page.getByText("All agents are busy right now"))
+        .toBeInTheDocument();
+
+      // The server closes after the timeout; the caller gets friendly copy
+      // instead of the raw close reason or error styling.
+      await expect
+        .element(
+          page.getByText("All agents are still busy. Please try again later.")
+        )
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByText("An error occurred"))
+        .not.toBeInTheDocument();
+      await expect
+        .element(page.getByText("too many concurrent connections"))
+        .not.toBeInTheDocument();
+      await expect.element(startButton).toBeInTheDocument();
+    });
+  });
+
   describe("expansion events", () => {
     it.each(["document", "widget"])(
       "should expand and collapse widget when elevenlabs-agent:expand event is dispatched (%s)",

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -366,6 +366,33 @@ describe("elevenlabs-convai", () => {
         .toBeInTheDocument();
     });
 
+    it("keeps the waiting status inside the full trigger", async () => {
+      // The trigger sizes itself from the labels' shared grid cell; with an
+      // absolutely positioned status label the long waiting copy would not
+      // affect layout and would get clipped at the card edge mid-word.
+      setupWebComponent({ "agent-id": "queued", variant: "full" });
+
+      const startButton = page.getByRole("button", { name: "Start a call" });
+      await startButton.click();
+      const acceptButton = page.getByRole("button", { name: "Accept" });
+      await acceptButton.click();
+
+      const label = page.getByText("Waiting for an available agent");
+      await expect.element(label).toBeInTheDocument();
+
+      const labelElement = label.element() as HTMLElement;
+      // The full copy is visible, not ellipsized...
+      expect(labelElement.scrollWidth).toBeLessThanOrEqual(
+        labelElement.clientWidth + 1
+      );
+      // ...and the label stays within the trigger card.
+      const card = labelElement.closest(".rounded-sheet")!;
+      const labelRect = labelElement.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      expect(labelRect.right).toBeLessThanOrEqual(cardRect.right);
+      expect(labelRect.left).toBeGreaterThanOrEqual(cardRect.left);
+    });
+
     it("returns to the regular flow when admitted from the queue", async () => {
       setupWebComponent({
         "agent-id": "queue_admit",

--- a/packages/convai-widget-core/src/markdown.dev.tsx
+++ b/packages/convai-widget-core/src/markdown.dev.tsx
@@ -258,6 +258,8 @@ function MockConversationProvider({
       transcript: mockTranscript,
       isAgentTyping: signal(false),
       isExternalAgentMode: signal(false),
+      queueStatus: signal<string | null>(null),
+      isWaitingForAgent: signal(false),
       startSession: async () => "",
       endSession: async () => {},
       getInputVolume: () => 0,

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -42,6 +42,12 @@ export const AGENTS = {
     use_rtc: true,
   },
   fail: BASIC_CONFIG,
+  // Held in the concurrency wait queue and never admitted.
+  queued: BASIC_CONFIG,
+  // Admitted from the wait queue after a delay.
+  queue_admit: BASIC_CONFIG,
+  // The wait queue times out and the server closes with an error.
+  queue_timeout: BASIC_CONFIG,
   end_call_test: {
     ...BASIC_CONFIG,
     text_only: true,
@@ -374,6 +380,57 @@ export const Worker = setupWorker(
         client.addEventListener("message", () => {
           client.close(3000, "Test reason");
         });
+      }
+      if (
+        agentId === "queued" ||
+        agentId === "queue_admit" ||
+        agentId === "queue_timeout"
+      ) {
+        client.send(
+          JSON.stringify({
+            type: "queue_status",
+            queue_status_event: { status: "waiting" },
+          })
+        );
+      }
+      if (agentId === "queued") {
+        // A typing indicator arriving while queued must stay hidden.
+        client.send(JSON.stringify({ type: "external_agent_connected" }));
+        client.send(
+          JSON.stringify({
+            type: "agent_typing",
+            agent_typing_event: { is_typing: true },
+          })
+        );
+      }
+      if (agentId === "queue_admit") {
+        await new Promise(resolve => setTimeout(resolve, 1500));
+        client.send(
+          JSON.stringify({
+            type: "queue_status",
+            queue_status_event: { status: "admitted" },
+          })
+        );
+        client.send(
+          JSON.stringify({
+            type: "agent_response",
+            agent_response_event: {
+              agent_response: "Queue cleared response",
+              event_id: 4,
+            },
+          })
+        );
+      }
+      if (agentId === "queue_timeout") {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        client.send(
+          JSON.stringify({
+            type: "queue_status",
+            queue_status_event: { status: "timed_out" },
+          })
+        );
+        await new Promise(resolve => setTimeout(resolve, 400));
+        client.close(3008, "too many concurrent connections");
       }
       if (agentId === "end_call_test") {
         client.addEventListener("message", async () => {

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -44,8 +44,7 @@ export const AGENTS = {
   fail: BASIC_CONFIG,
   // Held in the concurrency wait queue and never admitted.
   queued: BASIC_CONFIG,
-  // Same, but with the sheet expanded and no transcript, so the avatar
-  // overlay (the spacious waiting-copy surface) is what renders.
+  // Expanded with no transcript so the avatar overlay renders the waiting copy.
   queued_overlay: {
     ...BASIC_CONFIG,
     text_input_enabled: true,

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -409,6 +409,26 @@ export const Worker = setupWorker(
             agent_typing_event: { is_typing: true },
           })
         );
+        // Rich-content buttons arriving while queued must render disabled.
+        client.send(
+          JSON.stringify({
+            type: "rich_content",
+            rich_content: {
+              rich_content_id: "rc_queued",
+              component: "buttons",
+              props: {
+                buttons: [
+                  {
+                    type: "message",
+                    label: "Quick reply",
+                    message: "Quick reply",
+                  },
+                ],
+              },
+              event_id: 2,
+            },
+          })
+        );
       }
       if (agentId === "queue_admit") {
         await new Promise(resolve => setTimeout(resolve, 1500));

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -44,6 +44,13 @@ export const AGENTS = {
   fail: BASIC_CONFIG,
   // Held in the concurrency wait queue and never admitted.
   queued: BASIC_CONFIG,
+  // Same, but with the sheet expanded and no transcript, so the avatar
+  // overlay (the spacious waiting-copy surface) is what renders.
+  queued_overlay: {
+    ...BASIC_CONFIG,
+    text_input_enabled: true,
+    default_expanded: true,
+  },
   // Admitted from the wait queue after a delay.
   queue_admit: BASIC_CONFIG,
   // The wait queue times out and the server closes with an error.
@@ -383,6 +390,7 @@ export const Worker = setupWorker(
       }
       if (
         agentId === "queued" ||
+        agentId === "queued_overlay" ||
         agentId === "queue_admit" ||
         agentId === "queue_timeout"
       ) {

--- a/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
+++ b/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
@@ -21,9 +21,16 @@ export interface ButtonGroupProps {
 }
 
 export function ButtonGroup({ buttons, richContentId }: ButtonGroupProps) {
-  const { sendUserMessage, startSession, isDisconnected, status } =
-    useConversation();
-  const disabled = status.value !== "connected" && !isDisconnected.value;
+  const {
+    sendUserMessage,
+    startSession,
+    isDisconnected,
+    status,
+    isWaitingForAgent,
+  } = useConversation();
+  const disabled =
+    (status.value !== "connected" && !isDisconnected.value) ||
+    isWaitingForAgent.value;
 
   if (buttons.length === 0) return null;
 

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -129,6 +129,8 @@ export const DefaultTextContents = {
   speaking_status: "Talk to interrupt",
   connecting_status: "Connecting",
   chatting_status: "Chatting with AI Agent",
+  queue_waiting_status:
+    "All agents are busy right now. We'll connect you automatically as soon as one is available.",
 
   input_label: "Text message input",
   input_placeholder: "Send a message...",
@@ -139,6 +141,7 @@ export const DefaultTextContents = {
   agent_ended_conversation: "The agent ended the conversation",
   conversation_id: "ID",
   error_occurred: "An error occurred",
+  queue_timed_out: "All agents are still busy. Please try again later.",
   copy_id: "Copy ID",
   initiate_feedback: "How was this conversation?",
   request_follow_up_feedback: "Tell us more",

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -131,6 +131,7 @@ export const DefaultTextContents = {
   chatting_status: "Chatting with AI Agent",
   queue_waiting_status:
     "All agents are busy right now. We'll connect you automatically as soon as one is available.",
+  queue_waiting_status_short: "Waiting for an available agent",
 
   input_label: "Text message input",
   input_placeholder: "Send a message...",

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -46,6 +46,10 @@ export type DisplayTranscriptEntry =
       conversationIndex: number;
     }
   | {
+      type: "queue_timeout";
+      conversationIndex: number;
+    }
+  | {
       type: "rich_content";
       component: string;
       props: unknown;

--- a/packages/convai-widget-core/src/widget/AvatarOverlay.tsx
+++ b/packages/convai-widget-core/src/widget/AvatarOverlay.tsx
@@ -57,7 +57,10 @@ export function AvatarOverlay({
           </div>
         </InOutTransition>
         <InOutTransition active={showStatusLabel}>
-          <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 translate-y-full transition-[opacity,transform] data-hidden:opacity-0 data-hidden:scale-75">
+          {/* w-max: an absolutely positioned box at left-1/2 otherwise
+              shrink-to-fits against half the avatar container, collapsing
+              wrapped copy (the queue waiting status) to min-content width. */}
+          <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 translate-y-full w-max transition-[opacity,transform] data-hidden:opacity-0 data-hidden:scale-75">
             <StatusLabel />
           </div>
         </InOutTransition>

--- a/packages/convai-widget-core/src/widget/AvatarOverlay.tsx
+++ b/packages/convai-widget-core/src/widget/AvatarOverlay.tsx
@@ -57,9 +57,7 @@ export function AvatarOverlay({
           </div>
         </InOutTransition>
         <InOutTransition active={showStatusLabel}>
-          {/* w-max: an absolutely positioned box at left-1/2 otherwise
-              shrink-to-fits against half the avatar container, collapsing
-              wrapped copy (the queue waiting status) to min-content width. */}
+          {/* w-max keeps the wrapped status label from collapsing to min-content width */}
           <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 translate-y-full w-max transition-[opacity,transform] data-hidden:opacity-0 data-hidden:scale-75">
             <StatusLabel />
           </div>

--- a/packages/convai-widget-core/src/widget/AvatarOverlay.tsx
+++ b/packages/convai-widget-core/src/widget/AvatarOverlay.tsx
@@ -57,7 +57,6 @@ export function AvatarOverlay({
           </div>
         </InOutTransition>
         <InOutTransition active={showStatusLabel}>
-          {/* w-max keeps the wrapped status label from collapsing to min-content width */}
           <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 translate-y-full w-max transition-[opacity,transform] data-hidden:opacity-0 data-hidden:scale-75">
             <StatusLabel />
           </div>

--- a/packages/convai-widget-core/src/widget/FullTrigger.tsx
+++ b/packages/convai-widget-core/src/widget/FullTrigger.tsx
@@ -26,8 +26,6 @@ export function FullTrigger({
     >
       <div className="flex items-center p-1 gap-2 min-w-60">
         <Avatar />
-        {/* Both labels share one grid cell so the wider one sizes the trigger
-            and long status copy is not clipped */}
         <div className="grid items-center text-sm max-w-64">
           <span
             className={clsx(

--- a/packages/convai-widget-core/src/widget/FullTrigger.tsx
+++ b/packages/convai-widget-core/src/widget/FullTrigger.tsx
@@ -36,7 +36,10 @@ export function FullTrigger({
             {text.main_label}
           </span>
           <InOutTransition active={!isDisconnected.value}>
-            <StatusLabel className="absolute top-1/2 -translate-y-1/2 transition-[transform,opacity] duration-200 data-hidden:opacity-0 data-hidden:scale-90" />
+            <StatusLabel
+              compact
+              className="absolute top-1/2 -translate-y-1/2 transition-[transform,opacity] duration-200 data-hidden:opacity-0 data-hidden:scale-90"
+            />
           </InOutTransition>
         </div>
       </div>

--- a/packages/convai-widget-core/src/widget/FullTrigger.tsx
+++ b/packages/convai-widget-core/src/widget/FullTrigger.tsx
@@ -26,10 +26,8 @@ export function FullTrigger({
     >
       <div className="flex items-center p-1 gap-2 min-w-60">
         <Avatar />
-        {/* Both labels share one grid cell so the wider of the two sizes the
-            trigger — an absolutely positioned status label would not affect
-            layout and long copy (the queue waiting status) would get clipped
-            at the card edge. */}
+        {/* Both labels share one grid cell so the wider one sizes the trigger
+            and long status copy is not clipped */}
         <div className="grid items-center text-sm max-w-64">
           <span
             className={clsx(

--- a/packages/convai-widget-core/src/widget/FullTrigger.tsx
+++ b/packages/convai-widget-core/src/widget/FullTrigger.tsx
@@ -26,10 +26,14 @@ export function FullTrigger({
     >
       <div className="flex items-center p-1 gap-2 min-w-60">
         <Avatar />
-        <div className="relative text-sm max-w-64">
+        {/* Both labels share one grid cell so the wider of the two sizes the
+            trigger — an absolutely positioned status label would not affect
+            layout and long copy (the queue waiting status) would get clipped
+            at the card edge. */}
+        <div className="grid items-center text-sm max-w-64">
           <span
             className={clsx(
-              "block transition-[transform,opacity] duration-200",
+              "col-start-1 row-start-1 transition-[transform,opacity] duration-200",
               !isDisconnected.value && "opacity-0 scale-90"
             )}
           >
@@ -38,7 +42,7 @@ export function FullTrigger({
           <InOutTransition active={!isDisconnected.value}>
             <StatusLabel
               compact
-              className="absolute top-1/2 -translate-y-1/2 transition-[transform,opacity] duration-200 data-hidden:opacity-0 data-hidden:scale-90"
+              className="col-start-1 row-start-1 justify-self-start max-w-full transition-[transform,opacity] duration-200 data-hidden:opacity-0 data-hidden:scale-90"
             />
           </InOutTransition>
         </div>

--- a/packages/convai-widget-core/src/widget/Sheet.tsx
+++ b/packages/convai-widget-core/src/widget/Sheet.tsx
@@ -48,6 +48,7 @@ export function Sheet({ open }: SheetProps) {
     conversationIndex,
     isAgentTyping,
     isExternalAgentMode,
+    isWaitingForAgent,
   } = useConversation();
   const firstMessage = useFirstMessage();
   const { currentContent, currentConfig } = useSheetContent();
@@ -67,7 +68,10 @@ export function Sheet({ open }: SheetProps) {
           ? firstMessage.value
           : undefined,
       firstMessageConversationIndex: conversationIndex.peek(),
-      showTypingIndicator: isExternalAgentMode.value && isAgentTyping.value,
+      showTypingIndicator:
+        isExternalAgentMode.value &&
+        isAgentTyping.value &&
+        !isWaitingForAgent.value,
     });
   });
   const showTranscript = useComputed(

--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -114,7 +114,6 @@ export function SheetActions({
   const canSend = useComputed(() => {
     const hasText = !!userMessage.value.trim();
     const hasReadyFile = pendingFile.value?.status === "ready";
-    // The orchestrator discards client messages while the caller is queued.
     return (
       (hasText || hasReadyFile) &&
       !isUploading.value &&

--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -53,6 +53,7 @@ export function SheetActions({
     startSession,
     sendUserMessage,
     sendMultimodalMessage,
+    isWaitingForAgent,
   } = useConversation();
 
   const fileError = useSignal<string | null>(null);
@@ -89,7 +90,8 @@ export function SheetActions({
     () =>
       !pendingFile.value &&
       !hasReachedLimit.value &&
-      status.value === "connected"
+      status.value === "connected" &&
+      !isWaitingForAgent.value
   );
 
   const handleFileSelect = useCallback(
@@ -112,7 +114,13 @@ export function SheetActions({
   const canSend = useComputed(() => {
     const hasText = !!userMessage.value.trim();
     const hasReadyFile = pendingFile.value?.status === "ready";
-    return (hasText || hasReadyFile) && !isUploading.value;
+    // While held in the concurrency wait queue the orchestrator discards
+    // client messages, so sending would only pollute the local transcript.
+    return (
+      (hasText || hasReadyFile) &&
+      !isUploading.value &&
+      !isWaitingForAgent.value
+    );
   });
 
   const handleSendMessage = useCallback(

--- a/packages/convai-widget-core/src/widget/SheetActions.tsx
+++ b/packages/convai-widget-core/src/widget/SheetActions.tsx
@@ -114,8 +114,7 @@ export function SheetActions({
   const canSend = useComputed(() => {
     const hasText = !!userMessage.value.trim();
     const hasReadyFile = pendingFile.value?.status === "ready";
-    // While held in the concurrency wait queue the orchestrator discards
-    // client messages, so sending would only pollute the local transcript.
+    // The orchestrator discards client messages while the caller is queued.
     return (
       (hasText || hasReadyFile) &&
       !isUploading.value &&

--- a/packages/convai-widget-core/src/widget/SheetHeader.tsx
+++ b/packages/convai-widget-core/src/widget/SheetHeader.tsx
@@ -51,7 +51,10 @@ export function SheetHeader({
             <div className="relative w-8 h-8" />
           )}
           <InOutTransition active={showStatusLabel}>
-            <StatusLabel className="transition-opacity data-hidden:opacity-0" />
+            <StatusLabel
+              compact
+              className="transition-opacity data-hidden:opacity-0"
+            />
           </InOutTransition>
         </div>
         <div className="absolute flex flex-row items-center gap-2 ms-auto end-3">

--- a/packages/convai-widget-core/src/widget/StatusLabel.tsx
+++ b/packages/convai-widget-core/src/widget/StatusLabel.tsx
@@ -7,7 +7,6 @@ import { useTextContents } from "../contexts/text-contents";
 import { useIsConversationTextOnly } from "../contexts/widget-config";
 import { useConversationMode } from "../contexts/conversation-mode";
 
-
 function userCurrentLabel(compact: boolean) {
   const { status, isSpeaking, isWaitingForAgent } = useConversation();
   const textOnly = useIsConversationTextOnly();
@@ -21,18 +20,45 @@ function userCurrentLabel(compact: boolean) {
     // short form; spacious ones the full reassurance, wrapped.
     if (isWaitingForAgent.value)
       return compact
-        ? {label: text.queue_waiting_status_short.value, updateImmediately: true, wrap: false}
-        : {label: text.queue_waiting_status.value, updateImmediately: true, wrap: true};
+        ? {
+            label: text.queue_waiting_status_short.value,
+            updateImmediately: true,
+            wrap: false,
+          }
+        : {
+            label: text.queue_waiting_status.value,
+            updateImmediately: true,
+            wrap: true,
+          };
 
-    if (status.value !== "connected") return {label: text.connecting_status.value, updateImmediately: true, wrap: false};
+    if (status.value !== "connected")
+      return {
+        label: text.connecting_status.value,
+        updateImmediately: true,
+        wrap: false,
+      };
 
-    if (textOnly.value || isTextMode.value) return {label: text.chatting_status.value, updateImmediately: isSpeaking.value, wrap: false};
+    if (textOnly.value || isTextMode.value)
+      return {
+        label: text.chatting_status.value,
+        updateImmediately: isSpeaking.value,
+        wrap: false,
+      };
 
-    if (isSpeaking.value) return {label: text.speaking_status.value, updateImmediately: isSpeaking.value, wrap: false};
+    if (isSpeaking.value)
+      return {
+        label: text.speaking_status.value,
+        updateImmediately: isSpeaking.value,
+        wrap: false,
+      };
 
-    return {label: text.listening_status.value, updateImmediately: isSpeaking.value, wrap: false};
-  }
-  return useComputed(compute)
+    return {
+      label: text.listening_status.value,
+      updateImmediately: isSpeaking.value,
+      wrap: false,
+    };
+  };
+  return useComputed(compute);
 }
 
 interface StatusLabelProps extends HTMLAttributes<HTMLDivElement> {
@@ -74,7 +100,10 @@ export function StatusLabel({
         <div
           className={clsx(
             "animate-text transition-[opacity,transform] ease-out duration-200 data-hidden:opacity-0 transform data-hidden:translate-y-2",
-            wrap ? "whitespace-normal max-w-60 text-center" : "whitespace-nowrap"
+            // truncate degrades gracefully when a surface caps the label's
+            // width (e.g. long custom copy in the trigger): ellipsis instead
+            // of spilling past the card edge.
+            wrap ? "whitespace-normal max-w-60 text-center" : "truncate"
           )}
         >
           {label}

--- a/packages/convai-widget-core/src/widget/StatusLabel.tsx
+++ b/packages/convai-widget-core/src/widget/StatusLabel.tsx
@@ -8,7 +8,7 @@ import { useIsConversationTextOnly } from "../contexts/widget-config";
 import { useConversationMode } from "../contexts/conversation-mode";
 
 
-function userCurrentLabel() {
+function userCurrentLabel(compact: boolean) {
   const { status, isSpeaking, isWaitingForAgent } = useConversation();
   const textOnly = useIsConversationTextOnly();
   const { isTextMode } = useConversationMode();
@@ -17,8 +17,12 @@ function userCurrentLabel() {
   const compute = () => {
     // The waiting copy wins over the connected states: while held in the
     // concurrency wait queue the transport is connected but no agent is
-    // listening or speaking yet.
-    if (isWaitingForAgent.value) return {label: text.queue_waiting_status.value, updateImmediately: true, wrap: true};
+    // listening or speaking yet. Compact surfaces (single-line pills) get the
+    // short form; spacious ones the full reassurance, wrapped.
+    if (isWaitingForAgent.value)
+      return compact
+        ? {label: text.queue_waiting_status_short.value, updateImmediately: true, wrap: false}
+        : {label: text.queue_waiting_status.value, updateImmediately: true, wrap: true};
 
     if (status.value !== "connected") return {label: text.connecting_status.value, updateImmediately: true, wrap: false};
 
@@ -31,11 +35,17 @@ function userCurrentLabel() {
   return useComputed(compute)
 }
 
+interface StatusLabelProps extends HTMLAttributes<HTMLDivElement> {
+  /** Render single-line copy for cramped surfaces (header pill, trigger). */
+  compact?: boolean;
+}
+
 export function StatusLabel({
   className,
+  compact = false,
   ...props
-}: HTMLAttributes<HTMLDivElement>) {
-  const currentLabel = userCurrentLabel();
+}: StatusLabelProps) {
+  const currentLabel = userCurrentLabel(compact);
   const [{ label, wrap }, setLabel] = useState(() => {
     const { label, wrap } = currentLabel.peek();
     return { label, wrap };

--- a/packages/convai-widget-core/src/widget/StatusLabel.tsx
+++ b/packages/convai-widget-core/src/widget/StatusLabel.tsx
@@ -14,48 +14,37 @@ function userCurrentLabel(compact: boolean) {
   const text = useTextContents();
 
   const compute = () => {
-    // The waiting copy wins over the connected states: while held in the
-    // concurrency wait queue the transport is connected but no agent is
-    // listening or speaking yet. Compact surfaces (single-line pills) get the
-    // short form; spacious ones the full reassurance, wrapped.
+    // While queued the transport is connected but no agent is present yet,
+    // so the waiting copy wins over the connected statuses.
     if (isWaitingForAgent.value)
-      return compact
-        ? {
-            label: text.queue_waiting_status_short.value,
-            updateImmediately: true,
-            wrap: false,
-          }
-        : {
-            label: text.queue_waiting_status.value,
-            updateImmediately: true,
-            wrap: true,
-          };
+      return {
+        label: compact
+          ? text.queue_waiting_status_short.value
+          : text.queue_waiting_status.value,
+        updateImmediately: true,
+      };
 
     if (status.value !== "connected")
       return {
         label: text.connecting_status.value,
         updateImmediately: true,
-        wrap: false,
       };
 
     if (textOnly.value || isTextMode.value)
       return {
         label: text.chatting_status.value,
         updateImmediately: isSpeaking.value,
-        wrap: false,
       };
 
     if (isSpeaking.value)
       return {
         label: text.speaking_status.value,
         updateImmediately: isSpeaking.value,
-        wrap: false,
       };
 
     return {
       label: text.listening_status.value,
       updateImmediately: isSpeaking.value,
-      wrap: false,
     };
   };
   return useComputed(compute);
@@ -72,17 +61,14 @@ export function StatusLabel({
   ...props
 }: StatusLabelProps) {
   const currentLabel = userCurrentLabel(compact);
-  const [{ label, wrap }, setLabel] = useState(() => {
-    const { label, wrap } = currentLabel.peek();
-    return { label, wrap };
-  });
+  const [{ label }, setLabel] = useState(() => currentLabel.peek());
   useSignalEffect(() => {
     const next = currentLabel.value;
     if (next.updateImmediately) {
-      setLabel({ label: next.label, wrap: next.wrap });
+      setLabel(next);
     } else {
       const timeout = setTimeout(() => {
-        setLabel({ label: next.label, wrap: next.wrap });
+        setLabel(next);
       }, 500);
       return () => clearTimeout(timeout);
     }
@@ -100,10 +86,7 @@ export function StatusLabel({
         <div
           className={clsx(
             "animate-text transition-[opacity,transform] ease-out duration-200 data-hidden:opacity-0 transform data-hidden:translate-y-2",
-            // truncate degrades gracefully when a surface caps the label's
-            // width (e.g. long custom copy in the trigger): ellipsis instead
-            // of spilling past the card edge.
-            wrap ? "whitespace-normal max-w-60 text-center" : "truncate"
+            compact ? "truncate" : "whitespace-normal max-w-60 text-center"
           )}
         >
           {label}

--- a/packages/convai-widget-core/src/widget/StatusLabel.tsx
+++ b/packages/convai-widget-core/src/widget/StatusLabel.tsx
@@ -9,19 +9,24 @@ import { useConversationMode } from "../contexts/conversation-mode";
 
 
 function userCurrentLabel() {
-  const { status, isSpeaking } = useConversation();
+  const { status, isSpeaking, isWaitingForAgent } = useConversation();
   const textOnly = useIsConversationTextOnly();
   const { isTextMode } = useConversationMode();
   const text = useTextContents();
 
   const compute = () => {
-    if (status.value !== "connected") return {label: text.connecting_status.value, updateImmediately: true};
+    // The waiting copy wins over the connected states: while held in the
+    // concurrency wait queue the transport is connected but no agent is
+    // listening or speaking yet.
+    if (isWaitingForAgent.value) return {label: text.queue_waiting_status.value, updateImmediately: true, wrap: true};
 
-    if (textOnly.value || isTextMode.value) return {label: text.chatting_status.value, updateImmediately: isSpeaking.value};
+    if (status.value !== "connected") return {label: text.connecting_status.value, updateImmediately: true, wrap: false};
 
-    if (isSpeaking.value) return {label: text.speaking_status.value, updateImmediately: isSpeaking.value};
+    if (textOnly.value || isTextMode.value) return {label: text.chatting_status.value, updateImmediately: isSpeaking.value, wrap: false};
 
-    return {label: text.listening_status.value, updateImmediately: isSpeaking.value};
+    if (isSpeaking.value) return {label: text.speaking_status.value, updateImmediately: isSpeaking.value, wrap: false};
+
+    return {label: text.listening_status.value, updateImmediately: isSpeaking.value, wrap: false};
   }
   return useComputed(compute)
 }
@@ -31,14 +36,17 @@ export function StatusLabel({
   ...props
 }: HTMLAttributes<HTMLDivElement>) {
   const currentLabel = userCurrentLabel();
-  const [label, setLabel] = useState(currentLabel.peek().label);
+  const [{ label, wrap }, setLabel] = useState(() => {
+    const { label, wrap } = currentLabel.peek();
+    return { label, wrap };
+  });
   useSignalEffect(() => {
-    const label = currentLabel.value;
-    if (label.updateImmediately) {
-      setLabel(label.label);
+    const next = currentLabel.value;
+    if (next.updateImmediately) {
+      setLabel({ label: next.label, wrap: next.wrap });
     } else {
       const timeout = setTimeout(() => {
-        setLabel(label.label);
+        setLabel({ label: next.label, wrap: next.wrap });
       }, 500);
       return () => clearTimeout(timeout);
     }
@@ -53,7 +61,12 @@ export function StatusLabel({
       {...props}
     >
       <InOutTransition key={label} initial={false} active={true}>
-        <div className="animate-text whitespace-nowrap transition-[opacity,transform] ease-out duration-200 data-hidden:opacity-0 transform data-hidden:translate-y-2">
+        <div
+          className={clsx(
+            "animate-text transition-[opacity,transform] ease-out duration-200 data-hidden:opacity-0 transform data-hidden:translate-y-2",
+            wrap ? "whitespace-normal max-w-60 text-center" : "whitespace-nowrap"
+          )}
+        >
           {label}
         </div>
       </InOutTransition>

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -215,9 +215,7 @@ function ErrorMessage({
   );
 }
 
-// Rendered when the session ended because the concurrency wait-queue hold
-// timed out. Deliberately not styled as an error: the caller did nothing
-// wrong, all agents were simply busy.
+// Not styled as an error: the caller did nothing wrong, all agents were busy.
 function QueueTimeoutMessage() {
   const text = useTextContents();
   const { lastId } = useConversation();

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -215,7 +215,6 @@ function ErrorMessage({
   );
 }
 
-// Not styled as an error: the caller did nothing wrong, all agents were busy.
 function QueueTimeoutMessage() {
   const text = useTextContents();
   const { lastId } = useConversation();

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -215,6 +215,27 @@ function ErrorMessage({
   );
 }
 
+// Rendered when the session ended because the concurrency wait-queue hold
+// timed out. Deliberately not styled as an error: the caller did nothing
+// wrong, all agents were simply busy.
+function QueueTimeoutMessage() {
+  const text = useTextContents();
+  const { lastId } = useConversation();
+  const config = useWidgetConfig();
+
+  return (
+    <div className="px-8 text-xs text-base-subtle text-center transition-opacity duration-200 data-hidden:opacity-0">
+      {text.queue_timed_out}
+      <br />
+      {lastId.value && config.value.show_conversation_id && (
+        <span className="break-all">
+          {text.conversation_id}: {lastId.value}
+        </span>
+      )}
+    </div>
+  );
+}
+
 interface ModeToggleMessageProps {
   entry: Extract<DisplayTranscriptEntry, { type: "mode_toggle" }>;
 }
@@ -301,6 +322,9 @@ function getMessageComponent(entry: DisplayTranscriptEntry) {
   }
   if (entry.type === "error") {
     return <ErrorMessage entry={entry} />;
+  }
+  if (entry.type === "queue_timeout") {
+    return <QueueTimeoutMessage />;
   }
   if (entry.type === "typing_indicator") {
     return <TypingIndicatorMessage />;


### PR DESCRIPTION
## What

Widget follow-up to elevenlabs/xi#46137: the embeddable ConvAI widget now renders the concurrency wait-queue lifecycle from the `queue_status` server events (`waiting` / `admitted` / `timed_out`).


- No `@elevenlabs/client` changes: the SDK forwards unhandled server events to `onDebug` on both the WebSocket and WebRTC transports. Once the queue is finalized then we will make the SDK changes.


## Testing

Tested by embedding widget in a local server connecting it to local backend 

https://github.com/user-attachments/assets/7c1cd93a-9215-44d3-95d8-b2d75ed3325e


