### PR TITLE
[Widget] First message rich content

### DIFF
--- a/.changeset/button-tap-attribution.md
+++ b/.changeset/button-tap-attribution.md
@@ -1,0 +1,27 @@
+---
+"@elevenlabs/types": minor
+"@elevenlabs/client": minor
+"@elevenlabs/convai-widget-core": minor
+---
+
+Draw rich content alongside the first message, and echo button taps back to the
+server.
+
+A `first_message_rich_content` entry on the widget config is painted with the
+first message before any connection exists, so a text-only widget shows its
+buttons on a cold start. Tapping one starts the conversation with that button's
+message, the same way typing into the input does — previously a button was
+disabled until connected, which left a first-message button waiting for the
+session it would itself begin.
+
+A row the customer has already answered is retired rather than left sitting in
+the transcript. Whether a component does this is per-component, so display
+components can later stay and merely de-emphasise instead of disappearing.
+
+`sendUserMessage` accepts an optional attribution (`richContentId`) that rides
+the `user_message` event as `rich_content_id`; the widget sends it automatically
+when a button is tapped, on both the mid-conversation and conversation-starting
+paths. It names the row the button belonged to rather than the button itself —
+given the row, the message text says which button was pressed. Purely additive:
+servers that predate the field ignore it, and the message text alone remains
+what the agent acts on.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -373,6 +373,50 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("sendUserMessage", () => {
+    function conversationSending() {
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      return {
+        sendMessage,
+        conversation: TestConversation.create({}, connection),
+      };
+    }
+
+    it("attributes a tap to the row its button came from", () => {
+      const { sendMessage, conversation } = conversationSending();
+
+      conversation.sendUserMessage("Can you track my order?", {
+        richContentId: "first_message",
+      });
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "user_message",
+        text: "Can you track my order?",
+        rich_content_id: "first_message",
+      });
+    });
+
+    it("omits the attribution entirely for a typed message", () => {
+      const { sendMessage, conversation } = conversationSending();
+
+      conversation.sendUserMessage("Where is my order?");
+
+      // Assert the wire form, not the object: both transports JSON.stringify,
+      // which drops undefined but keeps null. A server predating the field must
+      // see exactly the payload it saw before, so an explicit null would be a
+      // regression while an undefined property is harmless.
+      const payload = sendMessage.mock.calls[0][0];
+      expect(JSON.parse(JSON.stringify(payload))).toEqual({
+        type: "user_message",
+        text: "Where is my order?",
+      });
+    });
+  });
+
   describe("ping events", () => {
     it("replies with a pong and forwards the payload to onPing", async () => {
       const onPing = vi.fn();

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -75,6 +75,16 @@ export type ContextualUpdateOptions = {
   contextId?: string;
 };
 
+/**
+ * Attribution for a user message that came from a rich-content button tap.
+ * Best-effort: a server that ignores it loses nothing but the reporting, and
+ * the message text alone is what the agent acts on.
+ */
+export type SendUserMessageOptions = {
+  /** The rich-content row the tapped button belonged to. */
+  richContentId?: string;
+};
+
 export type Options = SessionConfig &
   Callbacks &
   ConversationLifecycleOptions &
@@ -825,10 +835,11 @@ export abstract class BaseConversation {
     });
   }
 
-  public sendUserMessage(text: string) {
+  public sendUserMessage(text: string, options?: SendUserMessageOptions) {
     this.connection.sendMessage({
       type: "user_message",
       text,
+      rich_content_id: options?.richContentId ?? undefined,
     });
   }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -21,6 +21,7 @@ export type {
   ConversationCreatedCallback,
   ConversationLifecycleOptions,
   ContextualUpdateOptions,
+  SendUserMessageOptions,
 } from "./BaseConversation.js";
 export type {
   InputController,

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -2,6 +2,7 @@ import {
   Conversation,
   Mode,
   Role,
+  SendUserMessageOptions,
   SessionConfig,
   Status,
 } from "@elevenlabs/client";
@@ -167,7 +168,23 @@ function useConversationSetup() {
     const error = signal<string | null>(null);
     const lastId = signal<string | null>(null);
     const canSendFeedback = signal(false);
-    const transcript = signal<TranscriptEntry[]>([]);
+
+    const firstMessageEntries = (): TranscriptEntry[] => {
+      const richContent = widgetConfig.peek().first_message_rich_content;
+      if (!richContent) return [];
+      return [
+        {
+          type: "rich_content",
+          component: richContent.component,
+          props: richContent.props,
+          eventId: 1,
+          richContentId: "first_message",
+          conversationIndex: 0,
+        },
+      ];
+    };
+
+    const transcript = signal<TranscriptEntry[]>(firstMessageEntries());
     const conversationIndex = signal(0);
     const conversationTextOnly = signal<boolean | null>(null);
     const isAgentTyping = signal(false);
@@ -197,7 +214,11 @@ function useConversationSetup() {
       transcript,
       isAgentTyping,
       isExternalAgentMode,
-      startSession: async (element: HTMLElement, initialMessage?: string) => {
+      startSession: async (
+        element: HTMLElement,
+        initialMessage?: string,
+        initialMessageOptions?: SendUserMessageOptions
+      ) => {
         await terms.requestTerms();
 
         if (conversationRef.current?.isOpen()) {
@@ -238,17 +259,20 @@ function useConversationSetup() {
         }
 
         conversationTextOnly.value = processedConfig.textOnly ?? false;
-        transcript.value = initialMessage
-          ? [
-              {
-                type: "message",
-                role: "user",
-                message: initialMessage,
-                isText: true,
-                conversationIndex: conversationIndex.peek(),
-              },
-            ]
-          : [];
+        transcript.value = [
+          ...firstMessageEntries(),
+          ...(initialMessage
+            ? [
+                {
+                  type: "message",
+                  role: "user",
+                  message: initialMessage,
+                  isText: true,
+                  conversationIndex: conversationIndex.peek(),
+                } satisfies TranscriptEntry,
+              ]
+            : []),
+        ];
 
         try {
           lockRef.current = Conversation.startSession({
@@ -441,7 +465,11 @@ function useConversationSetup() {
           if (initialMessage) {
             const instance = conversationRef.current;
             // TODO: Remove the delay once BE can handle it
-            setTimeout(() => instance.sendUserMessage(initialMessage), 100);
+            setTimeout(
+              () =>
+                instance.sendUserMessage(initialMessage, initialMessageOptions),
+              100
+            );
           }
 
           const id = conversationRef.current.getId();
@@ -488,8 +516,8 @@ function useConversationSetup() {
       sendFeedback: (like: boolean) => {
         conversationRef.current?.sendFeedback(like);
       },
-      sendUserMessage: (text: string) => {
-        conversationRef.current?.sendUserMessage(text);
+      sendUserMessage: (text: string, options?: SendUserMessageOptions) => {
+        conversationRef.current?.sendUserMessage(text, options);
         transcript.value = [
           ...transcript.value,
           {

--- a/packages/convai-widget-core/src/index.dev.tsx
+++ b/packages/convai-widget-core/src/index.dev.tsx
@@ -1,12 +1,19 @@
 import "./playground.css";
 import { render } from "preact";
 import { jsx } from "preact/jsx-runtime";
+import { setSourceInfo } from "@elevenlabs/client/internal";
 import { ConvAIWidget } from "./widget";
+import { PACKAGE_VERSION } from "./version";
 import { useRef } from "preact/compat";
 import {
   usePlaygroundSettings,
   PlaygroundSettingsPanel,
 } from "./PlaygroundSettings";
+
+// The production entry (index.ts) sets this, but the playground mounts
+// ConvAIWidget directly. Without it the server sees a generic sdk source, and
+// anything gated on the widget channel — rich content, for one — never loads.
+setSourceInfo({ name: "widget", version: PACKAGE_VERSION });
 
 /**
  * A dev-only playground for testing the ConvAIWidget component without Shadow DOM.

--- a/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
+++ b/packages/convai-widget-core/src/rich-content/ButtonGroup.tsx
@@ -17,11 +17,13 @@ export type RichContentButton = MessageButton | LinkButton;
 
 export interface ButtonGroupProps {
   buttons: RichContentButton[];
+  richContentId?: string;
 }
 
-export function ButtonGroup({ buttons }: ButtonGroupProps) {
-  const { sendUserMessage, status } = useConversation();
-  const disabled = status.value !== "connected";
+export function ButtonGroup({ buttons, richContentId }: ButtonGroupProps) {
+  const { sendUserMessage, startSession, isDisconnected, status } =
+    useConversation();
+  const disabled = status.value !== "connected" && !isDisconnected.value;
 
   if (buttons.length === 0) return null;
 
@@ -37,7 +39,14 @@ export function ButtonGroup({ buttons }: ButtonGroupProps) {
             key={index}
             variant="outline"
             disabled={disabled}
-            onClick={() => sendUserMessage(button.message)}
+            onClick={e => {
+              const attribution = { richContentId };
+              if (isDisconnected.value) {
+                void startSession(e.currentTarget, button.message, attribution);
+              } else {
+                sendUserMessage(button.message, attribution);
+              }
+            }}
           >
             {button.label}
           </Button>

--- a/packages/convai-widget-core/src/rich-content/RichContentRenderer.tsx
+++ b/packages/convai-widget-core/src/rich-content/RichContentRenderer.tsx
@@ -6,30 +6,37 @@ import { parseButtonGroupProps } from "./validate";
 interface RichContentRendererProps {
   component: string;
   props: unknown;
+  richContentId?: string;
 }
 
 interface RichContentComponentEntry {
   parseProps: (raw: unknown) => unknown | null;
-  render: (props: unknown) => ComponentChildren;
+  render: (props: unknown, richContentId?: string) => ComponentChildren;
 }
 
 const RICH_CONTENT_COMPONENTS: Record<string, RichContentComponentEntry> = {
   buttons: {
     parseProps: parseButtonGroupProps,
-    render: props => <ButtonGroup {...(props as ButtonGroupProps)} />,
+    render: (props, richContentId) => (
+      <ButtonGroup
+        {...(props as ButtonGroupProps)}
+        richContentId={richContentId}
+      />
+    ),
   },
 };
 
 export function RichContentRenderer({
   component,
   props,
+  richContentId,
 }: RichContentRendererProps) {
   const entry = RICH_CONTENT_COMPONENTS[component];
   const parsed = entry?.parseProps(props);
   if (entry && parsed) {
-    return entry.render(parsed);
+    return entry.render(parsed, richContentId);
   }
-  
+
   return <RichContentUnavailable />;
 }
 

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -84,6 +84,10 @@ export interface WidgetConfig {
     max_files_per_conversation?: number;
   };
   show_resize_button?: boolean;
+  first_message_rich_content?: {
+    component: string;
+    props: unknown;
+  } | null;
 }
 
 export type AvatarConfig =

--- a/packages/convai-widget-core/src/utils/display-transcript.test.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.test.ts
@@ -68,6 +68,7 @@ function richContent(
 const defaults: DisplayTranscriptConfig = {
   showAgentStatus: false,
   transcriptEnabled: true,
+  showRichContent: true,
 };
 
 function build(
@@ -597,6 +598,70 @@ describe("buildDisplayTranscript", () => {
     });
   });
 
+  describe("rich content past a user turn", () => {
+    const richContentEntries = (result: DisplayTranscriptEntry[]) =>
+      result.filter(entry => entry.type === "rich_content");
+
+    // A user turn after a row means the customer has moved on. Agent turns do
+    // not count: the tool flow puts a short agent follow-up after every row.
+    it("drops a row once a user message follows it", () => {
+      const result = build([
+        msg("agent", "Two options", { eventId: 2 }),
+        richContent("a"),
+        msg("user", "the first one"),
+      ]);
+
+      expect(richContentEntries(result)).toHaveLength(0);
+      expect(result).toHaveLength(2);
+    });
+
+    it("keeps a row live under agent follow-ups", () => {
+      const result = build([
+        msg("user", "show me options"),
+        richContent("a"),
+        msg("agent", "Which would you like?", { eventId: 2 }),
+      ]);
+
+      expect(richContentEntries(result)).toHaveLength(1);
+      expect(result[1]).toMatchObject({ type: "rich_content" });
+    });
+
+    it("counts a filtered voice turn as the customer moving on", () => {
+      // The check reads the raw entries, so a non-text user turn hidden from
+      // the display still retires the row.
+      const result = build(
+        [richContent("a"), msg("user", "spoken reply", { isText: false })],
+        { transcriptEnabled: false }
+      );
+
+      expect(richContentEntries(result)).toHaveLength(0);
+    });
+
+    it("draws no component during a voice conversation", () => {
+      // The customer is speaking, so tap targets are noise — and a spoken first
+      // message is a transcript entry rather than a locally prepended one, so a
+      // seeded row would otherwise sit above the greeting.
+      const result = build(
+        [richContent("a"), msg("agent", "Hello!", { eventId: 1 })],
+        { showRichContent: false }
+      );
+
+      expect(richContentEntries(result)).toHaveLength(0);
+      expect(result).toHaveLength(1);
+    });
+
+    it("only user turns before the row leave it live", () => {
+      const result = build([
+        msg("user", "hi"),
+        msg("agent", "Hello!", { eventId: 2 }),
+        richContent("a"),
+      ]);
+
+      expect(richContentEntries(result)).toHaveLength(1);
+      expect(result[2]).toMatchObject({ type: "rich_content" });
+    });
+  });
+
   describe("rich content", () => {
     it("keeps components where they arrived, in arrival order", () => {
       const input = [
@@ -604,17 +669,15 @@ describe("buildDisplayTranscript", () => {
         msg("agent", "Two options", { eventId: 2 }),
         richContent("a"),
         richContent("b"),
-        msg("user", "thanks"),
-        msg("agent", "Anything else?", { eventId: 4 }),
+        msg("agent", "Anything else?", { eventId: 2 }),
       ];
       const result = build(input);
 
-      expect(result).toHaveLength(6);
+      expect(result).toHaveLength(5);
       expect(result[1]).toMatchObject({ message: "Two options" });
       expect(result[2]).toMatchObject({ richContentId: "rc_a" });
       expect(result[3]).toMatchObject({ richContentId: "rc_b" });
-      expect(result[4]).toMatchObject({ message: "thanks" });
-      expect(result[5]).toMatchObject({ message: "Anything else?" });
+      expect(result[4]).toMatchObject({ message: "Anything else?" });
     });
 
     it("keeps a component above the reply even when a placeholder precedes it", () => {

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -57,6 +57,7 @@ export type DisplayTranscriptEntry =
 export interface DisplayTranscriptConfig {
   showAgentStatus: boolean;
   transcriptEnabled: boolean;
+  showRichContent: boolean;
   /** If set, prepend as the first agent message (for text-only first message). */
   firstMessage?: string;
   /** The conversationIndex to use for the prepended first message. */
@@ -109,11 +110,25 @@ export function buildDisplayTranscript(
     }
   }
 
-  for (const entry of entries) {
+  let lastUserEntryIndex = -1;
+  entries.forEach((entry, index) => {
+    if (entry.type === "message" && entry.role === "user") {
+      lastUserEntryIndex = index;
+    }
+  });
+
+  for (const [entryIndex, entry] of entries.entries()) {
     // Skip tool entries (consumed into status)
     if (
       entry.type === "agent_tool_request" ||
       entry.type === "agent_tool_response"
+    ) {
+      continue;
+    }
+
+    if (
+      entry.type === "rich_content" &&
+      (!config.showRichContent || entryIndex < lastUserEntryIndex)
     ) {
       continue;
     }

--- a/packages/convai-widget-core/src/widget/Sheet.tsx
+++ b/packages/convai-widget-core/src/widget/Sheet.tsx
@@ -59,6 +59,7 @@ export function Sheet({ open }: SheetProps) {
       showAgentStatus: config.value.show_agent_status ?? false,
       transcriptEnabled:
         isTextOnly || (config.value.transcript_enabled ?? false),
+      showRichContent: isTextOnly,
       // Prepend first message only when the widget is text-only
       // (not when it switched to text-only due to user input)
       firstMessage:

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -283,7 +283,11 @@ function RichContentMessage({
 }) {
   return (
     <div className="pe-8">
-      <RichContentRenderer component={entry.component} props={entry.props} />
+      <RichContentRenderer
+        component={entry.component}
+        props={entry.props}
+        richContentId={entry.richContentId}
+      />
     </div>
   );
 }

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -15,6 +15,7 @@ export interface Pong {
 export interface UserMessage {
   type: "user_message";
   text?: string;
+  rich_content_id?: string;
 }
 
 export interface UserActivity {
@@ -218,6 +219,7 @@ export interface MultimodalMessage {
 export interface ReservedText {
   type: "user_message";
   text?: string;
+  rich_content_id?: string;
 }
 
 export interface File {
@@ -750,6 +752,7 @@ export interface PongClientToOrchestratorEvent {
 export interface UserMessageClientToOrchestratorEvent {
   type: "user_message";
   text?: string;
+  rich_content_id?: string;
 }
 
 export interface UserActivityClientToOrchestratorEvent {

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -653,6 +653,13 @@ components:
           type: string
           nullable: true
           description: User's text message (null for text-only mode signal)
+        rich_content_id:
+          type: string
+          description: >-
+            Set when the message came from a rich-content button tap rather
+            than typing: the row the button belonged to. Given the row, the
+            text says which button. Best-effort attribution only — older
+            clients never send it.
 
     UserActivityPayload:
       type: object


### PR DESCRIPTION
A `first_message_rich_content` entry is painted alongside the first message before any connection exists, so a text-only
widget shows its buttons on a cold start. It travels in config rather than over the socket because the widget paints that turn locally, before there is a socket to receive anything on.

Rich content belongs to its turn; once a user message follows, it is removed rather than left as a control that no longer fits.

<img width="375" height="351" alt="Screenshot 2026-08-17 at 5 39 03 PM" src="https://github.com/user-attachments/assets/ddee6e45-ad64-4fd4-83a3-bd9563fddf87" />
