### PR TITLE
feat(client): add setOnHold to pause and resume a voice conversation

### DIFF
--- a/.changeset/conversation-on-hold.md
+++ b/.changeset/conversation-on-hold.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": minor
+---
+
+Add `setOnHold` / `isOnHold` to voice conversations, for apps that hand control back and forth between the agent and something else on the page. Putting a conversation on hold stops the agent mid-utterance instead of letting it play to completion, silences audio that keeps arriving, mutes the microphone so nothing nearby starts a turn, and sends `user_activity` periodically so the agent does not speak up on its own while it is held. The connection, conversation id and context all stay, so releasing the hold costs no reconnect: the microphone and the volume the caller asked for come back, and audio buffered during the hold is dropped rather than resumed mid-sentence. `setVolume` and `setMicMuted` calls made during a hold are applied when it is released.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -40,6 +40,10 @@ class TestConversation extends BaseConversation {
 
   public setVolume(): void {}
   public setMicMuted(): void {}
+  public setOnHold(): void {}
+  public isOnHold(): boolean {
+    return false;
+  }
   public getInputByteFrequencyData(): Uint8Array {
     return new Uint8Array(0);
   }

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -817,6 +817,14 @@ export abstract class BaseConversation {
   public abstract setVolume(options: { volume: number }): void;
   public abstract setMicMuted(isMuted: boolean): void;
   /**
+   * Puts the conversation on hold, or takes it off hold again. A held
+   * conversation keeps its connection, its id and its context, but the agent
+   * is neither heard nor spoken to until the hold is released.
+   */
+  public abstract setOnHold(isOnHold: boolean): void;
+  /** Whether the conversation is currently on hold. */
+  public abstract isOnHold(): boolean;
+  /**
    * Returns byte frequency data (0-255) for the input audio, focused on the
    * human voice range (100-8000 Hz).
    */

--- a/packages/client/src/TextConversation.ts
+++ b/packages/client/src/TextConversation.ts
@@ -16,6 +16,14 @@ export class TextConversation extends BaseConversation {
     throw new Error("setMicMuted is not supported in text conversations");
   }
 
+  public setOnHold(): void {
+    throw new Error("setOnHold is not supported in text conversations");
+  }
+
+  public isOnHold(): boolean {
+    return false;
+  }
+
   public getInputByteFrequencyData(): Uint8Array {
     return EMPTY_FREQUENCY_DATA;
   }

--- a/packages/client/src/VoiceConversation.test.ts
+++ b/packages/client/src/VoiceConversation.test.ts
@@ -3,9 +3,14 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { VoiceConversation } from "./VoiceConversation.js";
 import type { Options, PartialOptions } from "./BaseConversation.js";
 import type { InputController } from "./InputController.js";
-import type { OutputController } from "./OutputController.js";
+import type {
+  OutputController,
+  PlaybackEventTarget,
+  PlaybackStateEvent,
+} from "./OutputController.js";
 import type { BaseConnection } from "./utils/BaseConnection.js";
 import type { IncomingSocketEvent } from "./utils/events.js";
+import type { Mode } from "./types.js";
 
 const HOLD_ACTIVITY_INTERVAL_MS = 1000;
 
@@ -36,6 +41,25 @@ function createOutput() {
   };
 }
 
+function createPlaybackEventTarget() {
+  const listeners = new Set<(event: PlaybackStateEvent) => void>();
+  return {
+    addListener: vi.fn((listener: (event: PlaybackStateEvent) => void) => {
+      listeners.add(listener);
+    }),
+    removeListener: vi.fn((listener: (event: PlaybackStateEvent) => void) => {
+      listeners.delete(listener);
+    }),
+    /** What the output worklet posts as it starts and finishes a buffer. */
+    emitProgress(finished: boolean) {
+      const event = {
+        data: { type: "process", finished },
+      } as PlaybackStateEvent;
+      for (const listener of listeners) listener(event);
+    },
+  };
+}
+
 function createConnection() {
   return {
     conversationId: "test-conversation-id",
@@ -53,7 +77,10 @@ class TestVoiceConversation extends VoiceConversation {
     partialOptions: Partial<PartialOptions> = {},
     connection: ReturnType<typeof createConnection> = createConnection(),
     input: ReturnType<typeof createInput> = createInput(),
-    output: ReturnType<typeof createOutput> = createOutput()
+    output: ReturnType<typeof createOutput> = createOutput(),
+    playbackEventTarget: ReturnType<
+      typeof createPlaybackEventTarget
+    > | null = null
   ) {
     const options = super.getFullOptions({
       agentId: "test-agent-id",
@@ -64,19 +91,35 @@ class TestVoiceConversation extends VoiceConversation {
       options,
       connection as unknown as BaseConnection,
       input,
-      output
+      output,
+      playbackEventTarget
     );
     conversation.markConnected();
-    return { conversation, connection, input, output, options };
+    return {
+      conversation,
+      connection,
+      input,
+      output,
+      playbackEventTarget,
+      options,
+    };
   }
 
   private constructor(
     options: Options,
     connection: BaseConnection,
     input: InputController,
-    output: OutputController
+    output: OutputController,
+    playbackEventTarget: PlaybackEventTarget | null
   ) {
-    super(options, connection, input, output, null, async () => {});
+    super(
+      options,
+      connection,
+      input,
+      output,
+      playbackEventTarget,
+      async () => {}
+    );
   }
 
   public receiveMessage(event: IncomingSocketEvent) {
@@ -92,6 +135,13 @@ function audioEvent(eventId: number): IncomingSocketEvent {
       event_id: eventId,
     },
   } as IncomingSocketEvent;
+}
+
+/** The mode callback BaseConversation registers on the connection. */
+function connectionModeListener(
+  connection: ReturnType<typeof createConnection>
+) {
+  return connection.onModeChange.mock.calls[0]?.[0] as (mode: Mode) => void;
 }
 
 function userActivityCount(connection: ReturnType<typeof createConnection>) {
@@ -252,5 +302,122 @@ describe("VoiceConversation hold", () => {
     conversation.setOnHold(false);
     await conversation.receiveMessage(audioEvent(3));
     expect(onModeChange).toHaveBeenLastCalledWith({ mode: "speaking" });
+  });
+
+  it("does not report the agent as speaking for playback progress during a hold", () => {
+    const onModeChange = vi.fn();
+    const playback = createPlaybackEventTarget();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      createConnection(),
+      createInput(),
+      createOutput(),
+      playback
+    );
+
+    playback.emitProgress(false);
+    expect(onModeChange).toHaveBeenLastCalledWith({ mode: "speaking" });
+
+    conversation.setOnHold(true);
+    expect(onModeChange).toHaveBeenLastCalledWith({ mode: "listening" });
+
+    onModeChange.mockClear();
+    // Audio that keeps arriving is played at volume zero, so the worklet
+    // still reports progress while the hold is on.
+    playback.emitProgress(true);
+    playback.emitProgress(false);
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it("does not report the agent as speaking when the transport says so during a hold", () => {
+    const onModeChange = vi.fn();
+    const connection = createConnection();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      connection
+    );
+    const reportMode = connectionModeListener(connection);
+
+    conversation.setOnHold(true);
+    onModeChange.mockClear();
+
+    reportMode("speaking");
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it("reports the agent as speaking again when a hold over a live track is released", () => {
+    const onModeChange = vi.fn();
+    const connection = createConnection();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      connection
+    );
+    const reportMode = connectionModeListener(connection);
+
+    conversation.setOnHold(true);
+    reportMode("speaking");
+    onModeChange.mockClear();
+
+    // A transport that plays the agent's track itself was never interrupted,
+    // and it will not report the same utterance a second time.
+    conversation.setOnHold(false);
+    expect(onModeChange).toHaveBeenCalledWith({ mode: "speaking" });
+  });
+
+  it("does not report a stale speaking when the agent stopped during the hold", () => {
+    const onModeChange = vi.fn();
+    const connection = createConnection();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      connection
+    );
+    const reportMode = connectionModeListener(connection);
+
+    conversation.setOnHold(true);
+    reportMode("speaking");
+    reportMode("listening");
+    onModeChange.mockClear();
+
+    conversation.setOnHold(false);
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it("does not report speaking when a hold is released after the session ended", async () => {
+    const onModeChange = vi.fn();
+    const connection = createConnection();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      connection
+    );
+    const reportMode = connectionModeListener(connection);
+
+    conversation.setOnHold(true);
+    reportMode("speaking");
+    await conversation.endSession();
+    onModeChange.mockClear();
+
+    conversation.setOnHold(false);
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it("does not report a stale speaking when local playback was flushed on release", () => {
+    const onModeChange = vi.fn();
+    const playback = createPlaybackEventTarget();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      createConnection(),
+      createInput(),
+      createOutput(),
+      playback
+    );
+
+    conversation.setOnHold(true);
+    playback.emitProgress(false);
+    onModeChange.mockClear();
+
+    // The release flushes what was queued, and the worklet reports the drain
+    // itself, so nothing here should announce speech that was just dropped.
+    conversation.setOnHold(false);
+    expect(onModeChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/client/src/VoiceConversation.test.ts
+++ b/packages/client/src/VoiceConversation.test.ts
@@ -400,6 +400,68 @@ describe("VoiceConversation hold", () => {
     expect(onModeChange).not.toHaveBeenCalled();
   });
 
+  it("reports the agent as speaking again when it was already speaking before the hold", () => {
+    const onModeChange = vi.fn();
+    const connection = createConnection();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      connection
+    );
+    const reportMode = connectionModeListener(connection);
+
+    // The agent is mid-utterance when the hold starts. Over a live track that
+    // utterance is silenced rather than stopped, and the transport only speaks
+    // up when the active speaker *changes*, so it will not announce the same
+    // one again when the hold ends.
+    reportMode("speaking");
+    conversation.setOnHold(true);
+    expect(onModeChange).toHaveBeenLastCalledWith({ mode: "listening" });
+    onModeChange.mockClear();
+
+    conversation.setOnHold(false);
+    expect(onModeChange).toHaveBeenCalledWith({ mode: "speaking" });
+  });
+
+  it("does not report a stale speaking when an utterance from before the hold ended during it", () => {
+    const onModeChange = vi.fn();
+    const connection = createConnection();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      connection
+    );
+    const reportMode = connectionModeListener(connection);
+
+    reportMode("speaking");
+    conversation.setOnHold(true);
+    reportMode("listening");
+    onModeChange.mockClear();
+
+    conversation.setOnHold(false);
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it("does not replay speaking from before the hold when local playback was flushed", () => {
+    const onModeChange = vi.fn();
+    const playback = createPlaybackEventTarget();
+    const { conversation } = TestVoiceConversation.createTest(
+      { onModeChange },
+      createConnection(),
+      createInput(),
+      createOutput(),
+      playback
+    );
+
+    // Local playback really is interrupted, and the release flushes what was
+    // queued behind it, so an utterance from before the hold is gone rather
+    // than silenced and there is nothing to come back to.
+    playback.emitProgress(false);
+    conversation.setOnHold(true);
+    onModeChange.mockClear();
+
+    conversation.setOnHold(false);
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
   it("does not report a stale speaking when local playback was flushed on release", () => {
     const onModeChange = vi.fn();
     const playback = createPlaybackEventTarget();

--- a/packages/client/src/VoiceConversation.test.ts
+++ b/packages/client/src/VoiceConversation.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { VoiceConversation } from "./VoiceConversation.js";
+import type { Options, PartialOptions } from "./BaseConversation.js";
+import type { InputController } from "./InputController.js";
+import type { OutputController } from "./OutputController.js";
+import type { BaseConnection } from "./utils/BaseConnection.js";
+import type { IncomingSocketEvent } from "./utils/events.js";
+
+const HOLD_ACTIVITY_INTERVAL_MS = 1000;
+
+function createInput() {
+  let muted = false;
+  return {
+    close: vi.fn(async () => {}),
+    setDevice: vi.fn(async () => {}),
+    setMuted: vi.fn(async (isMuted: boolean) => {
+      muted = isMuted;
+    }),
+    isMuted: vi.fn(() => muted),
+    getAnalyser: vi.fn(() => undefined),
+    getVolume: vi.fn(() => 0),
+    getByteFrequencyData: vi.fn(() => {}),
+  };
+}
+
+function createOutput() {
+  return {
+    close: vi.fn(async () => {}),
+    setDevice: vi.fn(async () => {}),
+    setVolume: vi.fn(() => {}),
+    interrupt: vi.fn(() => {}),
+    getAnalyser: vi.fn(() => undefined),
+    getVolume: vi.fn(() => 0),
+    getByteFrequencyData: vi.fn(() => {}),
+  };
+}
+
+function createConnection() {
+  return {
+    conversationId: "test-conversation-id",
+    onMessage: vi.fn(),
+    onOutgoingMessage: vi.fn(),
+    onDisconnect: vi.fn(),
+    onModeChange: vi.fn(),
+    close: vi.fn(),
+    sendMessage: vi.fn(),
+  };
+}
+
+class TestVoiceConversation extends VoiceConversation {
+  public static createTest(
+    partialOptions: Partial<PartialOptions> = {},
+    connection: ReturnType<typeof createConnection> = createConnection(),
+    input: ReturnType<typeof createInput> = createInput(),
+    output: ReturnType<typeof createOutput> = createOutput()
+  ) {
+    const options = super.getFullOptions({
+      agentId: "test-agent-id",
+      connectionType: "webrtc",
+      ...partialOptions,
+    } as PartialOptions);
+    const conversation = new TestVoiceConversation(
+      options,
+      connection as unknown as BaseConnection,
+      input,
+      output
+    );
+    conversation.markConnected();
+    return { conversation, connection, input, output, options };
+  }
+
+  private constructor(
+    options: Options,
+    connection: BaseConnection,
+    input: InputController,
+    output: OutputController
+  ) {
+    super(options, connection, input, output, null, async () => {});
+  }
+
+  public receiveMessage(event: IncomingSocketEvent) {
+    return this["onMessage"](event);
+  }
+}
+
+function audioEvent(eventId: number): IncomingSocketEvent {
+  return {
+    type: "audio",
+    audio_event: {
+      audio_base_64: "AAAA",
+      event_id: eventId,
+    },
+  } as IncomingSocketEvent;
+}
+
+function userActivityCount(connection: ReturnType<typeof createConnection>) {
+  return connection.sendMessage.mock.calls.filter(
+    ([message]) => message?.type === "user_activity"
+  ).length;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("VoiceConversation hold", () => {
+  it("stops the agent, mutes the microphone and silences the output", () => {
+    const { conversation, input, output } = TestVoiceConversation.createTest();
+
+    expect(conversation.isOnHold()).toBe(false);
+    conversation.setOnHold(true);
+
+    expect(conversation.isOnHold()).toBe(true);
+    expect(input.setMuted).toHaveBeenCalledWith(true);
+    expect(output.interrupt).toHaveBeenCalledTimes(1);
+    expect(output.setVolume).toHaveBeenCalledWith(0);
+    // The output restores its own volume once the interrupt fade completes,
+    // so the zero has to be set after the interrupt, not before it.
+    expect(output.interrupt.mock.invocationCallOrder[0]).toBeLessThan(
+      output.setVolume.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("restores the microphone and the caller's volume when released", () => {
+    const { conversation, input, output } = TestVoiceConversation.createTest();
+    conversation.setVolume({ volume: 0.5 });
+
+    conversation.setOnHold(true);
+    output.setVolume.mockClear();
+    output.interrupt.mockClear();
+    input.setMuted.mockClear();
+
+    conversation.setOnHold(false);
+
+    expect(conversation.isOnHold()).toBe(false);
+    expect(output.setVolume).toHaveBeenCalledWith(0.5);
+    expect(input.setMuted).toHaveBeenCalledWith(false);
+    // Anything the agent sent while nobody was listening is dropped, and the
+    // volume it comes back to is set before the flush that restores it.
+    expect(output.interrupt).toHaveBeenCalledTimes(1);
+    expect(output.setVolume.mock.invocationCallOrder[0]).toBeLessThan(
+      output.interrupt.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("leaves the microphone muted if it was already muted before the hold", () => {
+    const { conversation, input } = TestVoiceConversation.createTest();
+    conversation.setMicMuted(true);
+
+    conversation.setOnHold(true);
+    conversation.setOnHold(false);
+
+    expect(input.setMuted).toHaveBeenLastCalledWith(true);
+    expect(input.isMuted()).toBe(true);
+  });
+
+  it("defers a setMicMuted call made during a hold", () => {
+    const { conversation, input } = TestVoiceConversation.createTest();
+
+    conversation.setOnHold(true);
+    input.setMuted.mockClear();
+    conversation.setMicMuted(false);
+
+    // The hold owns the microphone: the request is remembered, not applied.
+    expect(input.setMuted).not.toHaveBeenCalled();
+    expect(input.isMuted()).toBe(true);
+
+    conversation.setOnHold(false);
+    expect(input.setMuted).toHaveBeenCalledWith(false);
+  });
+
+  it("defers a setVolume call made during a hold", () => {
+    const { conversation, output } = TestVoiceConversation.createTest();
+
+    conversation.setOnHold(true);
+    output.setVolume.mockClear();
+    conversation.setVolume({ volume: 0.25 });
+
+    // A volume change must not bring a held agent back.
+    expect(output.setVolume).not.toHaveBeenCalled();
+
+    conversation.setOnHold(false);
+    expect(output.setVolume).toHaveBeenCalledWith(0.25);
+  });
+
+  it("ignores a setOnHold call for the state it is already in", () => {
+    const { conversation, output } = TestVoiceConversation.createTest();
+
+    conversation.setOnHold(true);
+    output.interrupt.mockClear();
+    conversation.setOnHold(true);
+    expect(output.interrupt).not.toHaveBeenCalled();
+
+    conversation.setOnHold(false);
+    output.interrupt.mockClear();
+    conversation.setOnHold(false);
+    expect(output.interrupt).not.toHaveBeenCalled();
+  });
+
+  it("keeps the agent quiet with user activity for as long as the hold lasts", () => {
+    vi.useFakeTimers();
+    const { conversation, connection } = TestVoiceConversation.createTest();
+
+    conversation.setOnHold(true);
+    vi.advanceTimersByTime(HOLD_ACTIVITY_INTERVAL_MS * 3);
+    expect(userActivityCount(connection)).toBe(3);
+
+    conversation.setOnHold(false);
+    vi.advanceTimersByTime(HOLD_ACTIVITY_INTERVAL_MS * 3);
+    expect(userActivityCount(connection)).toBe(3);
+  });
+
+  it("stops sending user activity when the session ends while on hold", async () => {
+    vi.useFakeTimers();
+    const { conversation, connection } = TestVoiceConversation.createTest();
+
+    conversation.setOnHold(true);
+    vi.advanceTimersByTime(HOLD_ACTIVITY_INTERVAL_MS);
+    await conversation.endSession();
+
+    const sentBeforeTeardown = userActivityCount(connection);
+    vi.advanceTimersByTime(HOLD_ACTIVITY_INTERVAL_MS * 3);
+    expect(userActivityCount(connection)).toBe(sentBeforeTeardown);
+  });
+
+  it("does not start a user activity interval for a session that has ended", async () => {
+    vi.useFakeTimers();
+    const { conversation, connection } = TestVoiceConversation.createTest();
+    await conversation.endSession();
+
+    conversation.setOnHold(true);
+    vi.advanceTimersByTime(HOLD_ACTIVITY_INTERVAL_MS * 3);
+
+    expect(userActivityCount(connection)).toBe(0);
+  });
+
+  it("does not report the agent as speaking for audio arriving during a hold", async () => {
+    const onModeChange = vi.fn();
+    const { conversation } = TestVoiceConversation.createTest({ onModeChange });
+
+    await conversation.receiveMessage(audioEvent(1));
+    expect(onModeChange).toHaveBeenLastCalledWith({ mode: "speaking" });
+
+    conversation.setOnHold(true);
+    expect(onModeChange).toHaveBeenLastCalledWith({ mode: "listening" });
+
+    onModeChange.mockClear();
+    await conversation.receiveMessage(audioEvent(2));
+    expect(onModeChange).not.toHaveBeenCalled();
+
+    conversation.setOnHold(false);
+    await conversation.receiveMessage(audioEvent(3));
+    expect(onModeChange).toHaveBeenLastCalledWith({ mode: "speaking" });
+  });
+});

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -16,6 +16,22 @@ import type { OutputController } from "./OutputController.js";
 import { ensureSetupStrategy } from "./platform/VoiceSessionSetup.js";
 import type { VoiceSessionSetupResult } from "./platform/VoiceSessionSetup.js";
 
+/**
+ * How often a `user_activity` message is sent while the conversation is on
+ * hold. The agent treats user activity as "the user is busy elsewhere", which
+ * is what keeps it from starting a turn nobody is listening to, and it is
+ * also what stops the session idling out while it is held.
+ */
+const HOLD_ACTIVITY_INTERVAL_MS = 1000;
+
+/**
+ * Fade applied to the output when a hold starts and when it is released.
+ * Long enough not to click, short enough that a hold is immediate to the ear.
+ * The two second default `interrupt()` uses for a server-side interruption is
+ * far too slow for a caller that asked for the agent to stop right now.
+ */
+const HOLD_FADE_MS = 50;
+
 export class VoiceConversation extends BaseConversation {
   readonly type = "voice";
 
@@ -69,6 +85,14 @@ export class VoiceConversation extends BaseConversation {
 
   private inputFrequencyData?: Uint8Array<ArrayBuffer>;
   private outputFrequencyData?: Uint8Array<ArrayBuffer>;
+  private onHold = false;
+  /**
+   * The microphone state to return to when the hold is released: whatever it
+   * was when the hold started, or whatever `setMicMuted` was asked for while
+   * the hold was in place.
+   */
+  private micMutedOutsideHold = false;
+  private holdActivityTimer: ReturnType<typeof setInterval> | null = null;
 
   private handlePlaybackEvent: PlaybackListener = event => {
     if (event.data.type === "process") {
@@ -90,6 +114,7 @@ export class VoiceConversation extends BaseConversation {
   }
 
   protected override async handleEndSession() {
+    this.clearHoldActivityTimer();
     this.playbackEventTarget?.removeListener(this.handlePlaybackEvent);
     this.playbackEventTarget = null;
     await this.cleanUp();
@@ -120,16 +145,96 @@ export class VoiceConversation extends BaseConversation {
 
       this.currentEventId = event.audio_event.event_id;
       this.updateCanSendFeedback();
-      this.updateMode("speaking");
+      // Audio that arrives during a hold is silenced rather than played, so
+      // reporting "speaking" would describe something the user cannot hear.
+      if (!this.onHold) {
+        this.updateMode("speaking");
+      }
     }
   }
 
   private static readonly FREQUENCY_BIN_COUNT = 1024;
 
   public setMicMuted(isMuted: boolean) {
+    if (this.onHold) {
+      // A hold owns the microphone for as long as it lasts; remember what was
+      // asked for and apply it when the hold is released.
+      this.micMutedOutsideHold = isMuted;
+      return;
+    }
+    this.applyMicMuted(isMuted);
+  }
+
+  private applyMicMuted(isMuted: boolean) {
     this.input.setMuted(isMuted).catch(error => {
       this.options.onError?.("Failed to set input muted state", error);
     });
+  }
+
+  /** Whether the conversation is currently on hold. */
+  public isOnHold(): boolean {
+    return this.onHold;
+  }
+
+  /**
+   * Puts the conversation on hold, or takes it off hold again.
+   *
+   * A hold keeps the connection, the conversation id and the agent's context
+   * intact, so the user can come back to the same conversation without paying
+   * for a reconnect. For as long as it lasts, though, the agent is neither
+   * heard nor spoken to:
+   *
+   * - whatever the agent is saying stops instead of playing to completion,
+   *   and audio that keeps arriving is silenced rather than queued up;
+   * - the microphone is muted, so nothing said nearby reaches the agent or
+   *   starts a turn;
+   * - a periodic `user_activity` message tells the agent the user is busy, so
+   *   it does not speak up on its own or let the session idle out.
+   *
+   * Releasing the hold restores the microphone and the volume the caller had
+   * asked for, and drops the audio that arrived meanwhile so the agent does
+   * not resume mid-sentence.
+   */
+  public setOnHold(isOnHold: boolean): void {
+    if (isOnHold === this.onHold) return;
+    this.onHold = isOnHold;
+
+    if (isOnHold) {
+      this.micMutedOutsideHold = this.input.isMuted();
+      // Stop the current utterance, then silence the output. Order matters:
+      // interrupt() restores the output's own volume once its fade completes,
+      // so the zero has to be the value it restores to.
+      this.output.interrupt(HOLD_FADE_MS);
+      this.output.setVolume(0);
+      this.applyMicMuted(true);
+      this.updateMode("listening");
+
+      // There is nothing to keep quiet once the session is gone, and an
+      // interval started then would outlive the conversation itself.
+      if (this.isOpen()) {
+        this.holdActivityTimer = setInterval(() => {
+          this.sendUserActivity();
+        }, HOLD_ACTIVITY_INTERVAL_MS);
+      }
+    } else {
+      this.clearHoldActivityTimer();
+      // Audio the agent sent while nobody was listening is still queued in
+      // the output; drop it so playback resumes from what the agent says next
+      // rather than from the middle of what it said during the hold. Same
+      // ordering rule as above, opposite value: interrupt() restores the
+      // output's own volume when it flushes, so the volume to come back to
+      // has to be set first.
+      this.output.setVolume(this.volume);
+      this.output.interrupt(HOLD_FADE_MS);
+      this.applyMicMuted(this.micMutedOutsideHold);
+    }
+  }
+
+  private clearHoldActivityTimer() {
+    if (this.holdActivityTimer !== null) {
+      clearInterval(this.holdActivityTimer);
+      this.holdActivityTimer = null;
+    }
   }
 
   public getInputByteFrequencyData(): Uint8Array<ArrayBuffer> {
@@ -198,6 +303,11 @@ export class VoiceConversation extends BaseConversation {
       ? Math.min(1, Math.max(0, volume))
       : 1;
     this.volume = clampedVolume;
+
+    // A hold silences the output; the requested volume is remembered above
+    // and applied when the hold is released, rather than letting a volume
+    // change bring the held agent back.
+    if (this.onHold) return;
 
     // Delegate to output controller
     this.output.setVolume(clampedVolume);

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -218,6 +218,7 @@ export class VoiceConversation extends BaseConversation {
 
     if (isOnHold) {
       this.micMutedOutsideHold = this.input.isMuted();
+      const speakingWhenHeld = this.mode === "speaking";
       // Stop the current utterance, then silence the output. Order matters:
       // interrupt() restores the output's own volume once its fade completes,
       // so the zero has to be the value it restores to.
@@ -225,6 +226,12 @@ export class VoiceConversation extends BaseConversation {
       this.output.setVolume(0);
       this.applyMicMuted(true);
       this.updateMode("listening");
+      // That "listening" is the hold announcing itself, not the agent falling
+      // quiet, so it must not count as the agent having stopped. An utterance
+      // already in progress is only silenced where the transport owns
+      // playback, and it is never announced a second time, so the hold has to
+      // remember it the same way it remembers one that arrives later.
+      this.modeSuppressedByHold = speakingWhenHeld ? "speaking" : null;
 
       // There is nothing to keep quiet once the session is gone, and an
       // interval started then would outlive the conversation itself.

--- a/packages/client/src/VoiceConversation.ts
+++ b/packages/client/src/VoiceConversation.ts
@@ -5,6 +5,7 @@ import type {
   PlaybackListener,
 } from "./OutputController.js";
 import type { BaseConnection, FormatConfig } from "./utils/BaseConnection.js";
+import type { Mode } from "./types.js";
 import type { AgentAudioEvent, InterruptionEvent } from "./utils/events.js";
 import {
   BaseConversation,
@@ -93,6 +94,11 @@ export class VoiceConversation extends BaseConversation {
    */
   private micMutedOutsideHold = false;
   private holdActivityTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * The mode a hold kept quiet about, so it can be reported once the hold is
+   * released and the agent is audible again.
+   */
+  private modeSuppressedByHold: Mode | null = null;
 
   private handlePlaybackEvent: PlaybackListener = event => {
     if (event.data.type === "process") {
@@ -145,12 +151,23 @@ export class VoiceConversation extends BaseConversation {
 
       this.currentEventId = event.audio_event.event_id;
       this.updateCanSendFeedback();
-      // Audio that arrives during a hold is silenced rather than played, so
-      // reporting "speaking" would describe something the user cannot hear.
-      if (!this.onHold) {
-        this.updateMode("speaking");
-      }
+      this.updateMode("speaking");
     }
+  }
+
+  /**
+   * A held conversation plays nothing the user can hear, so "speaking" would
+   * describe silence. The mode has three sources - the agent audio events
+   * above, the playback worklet's own progress events, and a transport that
+   * tracks the active speaker itself - so the hold is applied here, where all
+   * three arrive, rather than at each of them.
+   */
+  protected override updateMode(mode: Mode) {
+    if (this.onHold) {
+      this.modeSuppressedByHold = mode === "speaking" ? mode : null;
+      if (mode === "speaking") return;
+    }
+    super.updateMode(mode);
   }
 
   private static readonly FREQUENCY_BIN_COUNT = 1024;
@@ -218,6 +235,8 @@ export class VoiceConversation extends BaseConversation {
       }
     } else {
       this.clearHoldActivityTimer();
+      const modeSuppressed = this.modeSuppressedByHold;
+      this.modeSuppressedByHold = null;
       // Audio the agent sent while nobody was listening is still queued in
       // the output; drop it so playback resumes from what the agent says next
       // rather than from the middle of what it said during the hold. Same
@@ -227,6 +246,16 @@ export class VoiceConversation extends BaseConversation {
       this.output.setVolume(this.volume);
       this.output.interrupt(HOLD_FADE_MS);
       this.applyMicMuted(this.micMutedOutsideHold);
+
+      // Local playback was just flushed, and the worklet reports the drain
+      // itself, so there is nothing to restore where one is running. A
+      // transport that plays the agent's track itself was never interrupted,
+      // though: if the agent was still speaking when the hold was released it
+      // is audible again, and the transport will not say so a second time.
+      // A session that has already ended has nothing left to be audible.
+      if (modeSuppressed && !this.playbackEventTarget && this.isOpen()) {
+        this.updateMode(modeSuppressed);
+      }
     }
   }
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -925,6 +925,14 @@ describe("Volume Control", () => {
       conversation.setVolume({ volume: 0.5 });
     }).toThrow("setVolume is not supported in text conversations");
 
+    // As should holding one: there is no audio to stop and no microphone to
+    // mute, so a text conversation is never on hold.
+    expect(() => {
+      // @ts-expect-error setOnHold doesn't take arguments for text conversations
+      conversation.setOnHold(true);
+    }).toThrow("setOnHold is not supported in text conversations");
+    expect(conversation.isOnHold()).toBe(false);
+
     await conversation.endSession();
     server.close();
   });


### PR DESCRIPTION
Fixes #334.

`setMicMuted` stops the user being heard and `setVolume({ volume: 0 })` stops the agent being heard, but neither of them stops the agent. The utterance already in flight plays to completion, the audio behind it keeps queueing up, and the agent keeps taking turns into a page nobody is looking at. That is what the presentation app in the issue ran into, and the workaround posted there needs a forked SDK because the one piece that actually stops local playback, `output.interrupt()`, is not reachable from a `Conversation`.

This adds `setOnHold(isOnHold)` and `isOnHold()` to voice conversations. The naming follows the "on hold" framing @kraenhansen suggested on the issue and @hardiksondagar agreed with, and the boolean setter matches the shape of `setMicMuted` rather than introducing a `pause()`/`resume()` pair.

### What a hold does

- **Stops the agent, rather than muting it.** `output.interrupt()` drops the current utterance, and the output is then silenced so audio that keeps arriving is not played.
- **Mutes the microphone**, so nothing said near the device reaches the agent or starts a turn.
- **Sends `user_activity` every second**, which is how the agent is told the user is busy elsewhere. It is what keeps the agent from speaking up on its own during a long hold, and what stops the session idling out while it is held.
- **Keeps the connection, the conversation id and the agent's context.** The whole point of the issue is that reconnecting every 30 seconds is slower and more expensive than holding.

Releasing the hold restores the microphone and the volume the caller had asked for, and flushes audio that arrived during the hold so the agent does not resume from the middle of a sentence nobody heard.

### Two ordering details worth reading in the diff

`interrupt()` restores the output's *own* stored volume once its fade completes, so the value playback should come back to has to be set before that flush fires. Hold therefore sets the zero **after** `interrupt()`, and release sets the caller's volume **before** it. Both directions are pinned in the tests by invocation order, because getting this backwards silently un-mutes a held conversation 50ms later.

`playAudio` already cancels a pending interrupt timeout and posts `clearInterrupted` itself, so a chunk that arrives during either fade flushes the queue at that moment instead of undoing the hold. That is why a 50ms fade is enough here, instead of the two second default `interrupt()` uses for a server-side interruption, which is far too slow for a caller that asked for the agent to stop now.

### Calls made during a hold

`setVolume` and `setMicMuted` are remembered and applied when the hold is released, rather than taking effect immediately. A volume change bringing a held agent back, or an unrelated unmute reopening the microphone mid-hold, would both defeat the feature. The mic state to return to is read from the input controller at the moment the hold starts, so a hold released without any intervening call leaves the microphone exactly as it found it.

`onModeChange` no longer reports `speaking` for audio that arrives during a hold, since the user cannot hear it. `onAudio` is deliberately left alone: it is the wire-level callback, so consumers doing their own playback or transcript work still see everything that arrives.

### Transports

On WebSocket the local queue is what plays, so `interrupt()` is what stops the agent. On WebRTC playback belongs to LiveKit and `interrupt()` is a documented no-op there, so the local silence comes from the output volume path instead. The microphone mute and the `user_activity` suppression are identical on both, and on both the agent is inaudible for the whole hold and stops taking new turns.

### Scope

`@elevenlabs/client` only, matching the issue's label. Nothing in `@elevenlabs/react` is touched. A text conversation has no audio to stop and no microphone to mute, so `setOnHold` throws there like `setVolume` and `setMicMuted` already do, and `isOnHold()` is always `false`.

### Verification

`packages/client/src/VoiceConversation.test.ts` is new and covers the hold behaviour in 10 tests: muting and silencing on hold, restoring the volume and the microphone on release, a microphone that was already muted staying muted, deferred `setVolume`/`setMicMuted`, a repeated `setOnHold` being a no-op, the `user_activity` interval starting and stopping, the interval being cleared by `endSession`, no interval for a session that has already ended, and the mode reporting above. All 10 fail against `main` without this change. The text-conversation assertion sits next to the existing `setVolume` one in `index.test.ts`.

- `turbo check-types lint test --filter=@elevenlabs/client`: clean, 250 tests passing.
- Monorepo `turbo check-types lint test`: green except `convai-widget-core`'s `DismissButton.test.ts`, which fails identically on a clean `main` checkout (browser matcher timeout, unrelated to this change).

Changeset included as a minor bump for `@elevenlabs/client`.
