### PR TITLE
fix(client): publish selected inputDeviceId on WebRTC session start

### DIFF
--- a/.changeset/webrtc-input-device-id.md
+++ b/.changeset/webrtc-input-device-id.md
@@ -1,0 +1,19 @@
+---
+"@elevenlabs/client": patch
+---
+
+Publish the selected `inputDeviceId` on WebRTC session start instead of the
+browser default microphone.
+
+`WebRTCConnection.create()` enabled the microphone with
+`setMicrophoneEnabled(true)`, which always captures the browser's default
+device and ignores a configured `inputDeviceId`. The selected device only
+drove the local level meter, so a user on a non-default mic sent a silent or
+wrong track to the agent with no error surfaced — and the documented
+workaround of calling `changeInputDevice` after `startSession` republished
+the live track mid-connect and could leave the mic dead when re-acquire
+threw. `create()` now publishes a `createLocalAudioTrack({ deviceId: { exact }
+})` up front when an `inputDeviceId` is set, skipping the post-connect
+republish entirely. `setAudioInputDevice` also now acquires the new track
+before stopping the old one, so a failed re-acquire can no longer tear down
+the live mic.

--- a/.changeset/webrtc-input-device-id.md
+++ b/.changeset/webrtc-input-device-id.md
@@ -2,18 +2,4 @@
 "@elevenlabs/client": patch
 ---
 
-Publish the selected `inputDeviceId` on WebRTC session start instead of the
-browser default microphone.
-
-`WebRTCConnection.create()` enabled the microphone with
-`setMicrophoneEnabled(true)`, which always captures the browser's default
-device and ignores a configured `inputDeviceId`. The selected device only
-drove the local level meter, so a user on a non-default mic sent a silent or
-wrong track to the agent with no error surfaced — and the documented
-workaround of calling `changeInputDevice` after `startSession` republished
-the live track mid-connect and could leave the mic dead when re-acquire
-threw. `create()` now publishes a `createLocalAudioTrack({ deviceId: { exact }
-})` up front when an `inputDeviceId` is set, skipping the post-connect
-republish entirely. `setAudioInputDevice` also now acquires the new track
-before stopping the old one, so a failed re-acquire can no longer tear down
-the live mic.
+Publish the configured `inputDeviceId` when a WebRTC session starts, instead of the browser's default microphone. The mic was enabled with LiveKit's `setMicrophoneEnabled(true)`, which always captures the default device, so the selected device only drove the local level meter while the agent received a wrong or silent track. `changeInputDevice` now also acquires the new track before stopping the old one, so a failed re-acquire leaves the current microphone live instead of tearing it down.

--- a/.changeset/webrtc-mute-through-device-change.md
+++ b/.changeset/webrtc-mute-through-device-change.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Keep a muted WebRTC session muted across an input device change. `changeInputDevice` published the newly captured track without reapplying the session's mute state, so a user who switched microphones while muted kept sending audio to the agent while `isMuted()` and the volume meter still reported muted. The new track is now muted before it is published.

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -538,6 +538,177 @@ describe("WebRTCConnection", () => {
     connection.close();
   });
 
+  it("recovers onto the default mic when publishing the new device fails", async () => {
+    const mockRoom = new Room() as any;
+
+    const oldMockTrack = {
+      mediaStreamTrack: { id: "old-track", kind: "audio" },
+      stop: vi.fn(),
+    };
+    // Model LiveKit: unpublishTrack removes the publication before resolving.
+    let micPublication: { track: unknown } | undefined = {
+      track: oldMockTrack,
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => micPublication);
+    (
+      mockRoom.localParticipant.unpublishTrack as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      micPublication = undefined;
+      return Promise.resolve();
+    });
+
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    const newMockTrack = {
+      mediaStreamTrack: { id: "new-track", kind: "audio" },
+      stop: vi.fn(),
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      newMockTrack
+    );
+    (
+      mockRoom.localParticipant.publishTrack as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("publish failed"));
+    // Ignore the default mic enabled at connect time.
+    (
+      (globalThis as Record<string, unknown>).__mockCalls__ as typeof mockCalls
+    ).setMicrophoneEnabled.length = 0;
+
+    await expect(
+      connection.setAudioInputDevice("selected-mic-id")
+    ).rejects.toThrow("publish failed");
+
+    // The old track is gone, so the unpublished new track is released and the
+    // session falls back to the default device instead of going silent.
+    expect(newMockTrack.stop).toHaveBeenCalled();
+    const micCalls = (
+      (globalThis as Record<string, unknown>).__mockCalls__ as typeof mockCalls
+    ).setMicrophoneEnabled;
+    expect(micCalls).toContain(true);
+
+    connection.close();
+  });
+
+  it("keeps the new track published when the swap succeeds", async () => {
+    const mockRoom = new Room() as any;
+
+    const oldMockTrack = {
+      mediaStreamTrack: { id: "old-track", kind: "audio" },
+      stop: vi.fn(),
+    };
+    let micPublication: { track: unknown } | undefined = {
+      track: oldMockTrack,
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => micPublication);
+    (
+      mockRoom.localParticipant.unpublishTrack as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      micPublication = undefined;
+      return Promise.resolve();
+    });
+
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    const newMockTrack = {
+      mediaStreamTrack: { id: "new-track", kind: "audio" },
+      stop: vi.fn(),
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      newMockTrack
+    );
+
+    await connection.setAudioInputDevice("selected-mic-id");
+
+    expect(newMockTrack.stop).not.toHaveBeenCalled();
+    expect(mockRoom.localParticipant.unpublishTrack).toHaveBeenCalledWith(
+      oldMockTrack
+    );
+    // unpublishTrack stops the track it removes.
+    expect(oldMockTrack.stop).not.toHaveBeenCalled();
+
+    connection.close();
+  });
+
+  it("releases the mic when publishing at session start fails", async () => {
+    const mockRoom = new Room() as any;
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const newMockTrack = {
+      mediaStreamTrack: { id: "selected-device-track", kind: "audio" },
+      stop: vi.fn(),
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValue(
+      newMockTrack
+    );
+    // The track never reaches the room, so disconnecting cannot release it.
+    (
+      mockRoom.localParticipant.publishTrack as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("publish failed"));
+
+    await expect(
+      WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+        inputDeviceId: "selected-mic-id",
+      })
+    ).rejects.toThrow("publish failed");
+
+    expect(newMockTrack.stop).toHaveBeenCalled();
+  });
+
   it("properly reports sent messages", async () => {
     const connection = await WebRTCConnection.create({
       conversationToken: "test-token",

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -709,6 +709,252 @@ describe("WebRTCConnection", () => {
     expect(newMockTrack.stop).toHaveBeenCalled();
   });
 
+  it("publishes the new device muted when the session is muted", async () => {
+    const mockRoom = new Room() as any;
+
+    const oldMockTrack = {
+      mediaStreamTrack: { id: "old-track", kind: "audio" },
+      mute: vi.fn(() => Promise.resolve()),
+      unmute: vi.fn(() => Promise.resolve()),
+      stop: vi.fn(),
+    };
+    let micPublication: { track: unknown } | undefined = {
+      track: oldMockTrack,
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => micPublication);
+    (
+      mockRoom.localParticipant.unpublishTrack as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      micPublication = undefined;
+      return Promise.resolve();
+    });
+
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    await connection.input.setMuted(true);
+
+    const newMockTrack = {
+      mediaStreamTrack: { id: "new-track", kind: "audio" },
+      mute: vi.fn(() => Promise.resolve()),
+      stop: vi.fn(),
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      newMockTrack
+    );
+
+    await connection.setAudioInputDevice("selected-mic-id");
+
+    // Muted before publishing, so the agent never receives audio from the
+    // device the user swapped to while muted.
+    expect(newMockTrack.mute).toHaveBeenCalled();
+    const muteCallOrder = newMockTrack.mute.mock.invocationCallOrder[0];
+    const publishCallOrder = (
+      mockRoom.localParticipant.publishTrack as ReturnType<typeof vi.fn>
+    ).mock.invocationCallOrder[0];
+    expect(muteCallOrder).toBeLessThan(publishCallOrder);
+    expect(connection.input.isMuted()).toBe(true);
+
+    connection.close();
+  });
+
+  it("recovers a muted session without republishing live audio", async () => {
+    const mockRoom = new Room() as any;
+
+    const oldMockTrack = {
+      mediaStreamTrack: { id: "old-track", kind: "audio" },
+      mute: vi.fn(() => Promise.resolve()),
+      unmute: vi.fn(() => Promise.resolve()),
+      stop: vi.fn(),
+    };
+    let micPublication: { track: unknown } | undefined = {
+      track: oldMockTrack,
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => micPublication);
+    (
+      mockRoom.localParticipant.unpublishTrack as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      micPublication = undefined;
+      return Promise.resolve();
+    });
+
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    await connection.input.setMuted(true);
+
+    const newMockTrack = {
+      mediaStreamTrack: { id: "new-track", kind: "audio" },
+      mute: vi.fn(() => Promise.resolve()),
+      stop: vi.fn(),
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      newMockTrack
+    );
+    (
+      mockRoom.localParticipant.publishTrack as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("publish failed"));
+    (
+      (globalThis as Record<string, unknown>).__mockCalls__ as typeof mockCalls
+    ).setMicrophoneEnabled.length = 0;
+
+    await expect(
+      connection.setAudioInputDevice("selected-mic-id")
+    ).rejects.toThrow("publish failed");
+
+    // Recovery must honour the mute state instead of going live.
+    const micCalls = (
+      (globalThis as Record<string, unknown>).__mockCalls__ as typeof mockCalls
+    ).setMicrophoneEnabled;
+    expect(micCalls).toEqual([false]);
+    expect(connection.input.isMuted()).toBe(true);
+
+    connection.close();
+  });
+
+  it("reconnects the input analyser to the recovered mic", async () => {
+    const mockRoom = new Room() as any;
+
+    const oldMockTrack = {
+      mediaStreamTrack: { id: "old-track", kind: "audio" },
+      stop: vi.fn(),
+    };
+    const recoveredTrack = {
+      mediaStreamTrack: { id: "recovered-track", kind: "audio" },
+      stop: vi.fn(),
+    };
+    let micPublication: { track: unknown } | undefined = {
+      track: oldMockTrack,
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => micPublication);
+    (
+      mockRoom.localParticipant.unpublishTrack as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      micPublication = undefined;
+      return Promise.resolve();
+    });
+    // The default mic comes back published once recovery enables it, leaving
+    // the connect-time publication alone.
+    (
+      mockRoom.localParticipant.setMicrophoneEnabled as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      micPublication ??= { track: recoveredTrack };
+      return Promise.resolve();
+    });
+
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const analysedTracks: unknown[] = [];
+    setWebRTCAudioAdapterFactory(() => {
+      const adapter = new WebAudioAdapter() as any;
+      const setupInputAnalysis = adapter.setupInputAnalysis.bind(adapter);
+      adapter.setupInputAnalysis = (track: unknown) => {
+        analysedTracks.push(track);
+        return setupInputAnalysis(track);
+      };
+      return adapter;
+    });
+
+    const mockAnalyser = {
+      frequencyBinCount: 128,
+      getByteFrequencyData: vi.fn(),
+      getFloatTimeDomainData: vi.fn(),
+    };
+    const mockSource = { connect: vi.fn() };
+    vi.stubGlobal(
+      "AudioContext",
+      vi.fn(() => ({
+        createAnalyser: vi.fn(() => mockAnalyser),
+        createMediaStreamSource: vi.fn(() => mockSource),
+        close: vi.fn(() => Promise.resolve()),
+        sampleRate: 44100,
+      }))
+    );
+    vi.stubGlobal(
+      "MediaStream",
+      vi.fn((tracks: unknown[]) => ({ getTracks: () => tracks }))
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    const newMockTrack = {
+      mediaStreamTrack: { id: "new-track", kind: "audio" },
+      mute: vi.fn(() => Promise.resolve()),
+      stop: vi.fn(),
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      newMockTrack
+    );
+    (
+      mockRoom.localParticipant.publishTrack as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("publish failed"));
+
+    await expect(
+      connection.setAudioInputDevice("selected-mic-id")
+    ).rejects.toThrow("publish failed");
+
+    // Metering must follow the live mic, not the track recovery replaced.
+    expect(analysedTracks.at(-1)).toBe(recoveredTrack.mediaStreamTrack);
+
+    connection.close();
+  });
+
   it("properly reports sent messages", async () => {
     const connection = await WebRTCConnection.create({
       conversationToken: "test-token",

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -410,6 +410,134 @@ describe("WebRTCConnection", () => {
     }
   );
 
+  it("publishes a track from the configured inputDeviceId instead of the default mic", async () => {
+    const mockRoom = new Room() as any;
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const newMockTrack = {
+      mediaStreamTrack: { id: "selected-device-track", kind: "audio" },
+    };
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockResolvedValue(
+      newMockTrack
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+      inputDeviceId: "selected-mic-id",
+    });
+
+    // The selected device must drive the published track, not the default mic.
+    expect(createLocalAudioTrack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceId: { exact: "selected-mic-id" },
+      })
+    );
+    expect(mockRoom.localParticipant.publishTrack).toHaveBeenCalledWith(
+      newMockTrack,
+      expect.objectContaining({ source: "microphone" })
+    );
+    // And the default-mic path must not have run.
+    const micCalls = (
+      (globalThis as Record<string, unknown>).__mockCalls__ as typeof mockCalls
+    ).setMicrophoneEnabled;
+    expect(micCalls).not.toContain(true);
+
+    connection.close();
+  });
+
+  it("falls back to setMicrophoneEnabled when no inputDeviceId is configured", async () => {
+    const mockRoom = new Room() as any;
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    expect(createLocalAudioTrack).not.toHaveBeenCalled();
+    const micCalls = (
+      (globalThis as Record<string, unknown>).__mockCalls__ as typeof mockCalls
+    ).setMicrophoneEnabled;
+    expect(micCalls).toContain(true);
+
+    connection.close();
+  });
+
+  it("keeps the previous mic published when setAudioInputDevice re-acquire fails", async () => {
+    const mockRoom = new Room() as any;
+
+    // Existing published mic track stays alive when the new capture fails.
+    const oldMockTrack = {
+      mediaStreamTrack: { id: "old-track", kind: "audio" },
+      stop: vi.fn(() => Promise.resolve()),
+    };
+    (
+      mockRoom.localParticipant.getTrackPublication as ReturnType<typeof vi.fn>
+    ).mockReturnValue({ track: oldMockTrack });
+
+    (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "connected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+    (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "signalConnected") {
+          queueMicrotask(callback);
+        }
+      }
+    );
+
+    const connection = await WebRTCConnection.create({
+      conversationToken: "test-token",
+      connectionType: "webrtc",
+    });
+
+    // Re-acquire the new device fails. The old track must NOT be stopped or
+    // unpublished, so the call keeps working audio.
+    (createLocalAudioTrack as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("device unavailable")
+    );
+
+    await expect(
+      connection.setAudioInputDevice("missing-device-id")
+    ).rejects.toThrow("device unavailable");
+
+    expect(oldMockTrack.stop).not.toHaveBeenCalled();
+    expect(mockRoom.localParticipant.unpublishTrack).not.toHaveBeenCalled();
+
+    connection.close();
+  });
+
   it("properly reports sent messages", async () => {
     const connection = await WebRTCConnection.create({
       conversationToken: "test-token",

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -48,7 +48,8 @@ function convertWssToHttps(origin: string): string {
 }
 
 export type WebRTCConnectionConfig = SessionConfig &
-  Pick<AudioWorkletConfig, "workletPaths"> & {
+  Pick<AudioWorkletConfig, "workletPaths"> &
+  InputDeviceConfig & {
     onDebug?: (info: unknown) => void;
   };
 
@@ -311,12 +312,18 @@ export class WebRTCConnection extends BaseConnection {
       // The server may wait for the client to publish audio before fully
       // establishing the subscriber peer connection, matching the behaviour
       // of @livekit/components-react's useLiveKitRoom hook.
+      //
+      // When an `inputDeviceId` is configured, publish a track captured from
+      // that device directly. Falling back to `setMicrophoneEnabled(true)`
+      // would publish the browser's default microphone and ignore the
+      // selected device, leaving the agent on the wrong (or silent) track
+      // until a post-connect `changeInputDevice` republish.
       const micEnabled = config.textOnly
         ? Promise.resolve()
         : new Promise<void>((resolve, reject) => {
             room.once(RoomEvent.SignalConnected, () => {
-              room.localParticipant
-                .setMicrophoneEnabled(true)
+              connection
+                .enableMicrophone(config.inputDeviceId)
                 .then(() => resolve())
                 .catch(reject);
             });
@@ -666,12 +673,25 @@ export class WebRTCConnection extends BaseConnection {
       );
     }
 
+    // Acquire the new track before tearing down the old one. The previous
+    // implementation stopped and unpublished the live mic track before
+    // calling createLocalAudioTrack, so a failed re-acquire (device unplugged
+    // mid-call, permission revoked, etc.) left the participant with no
+    // microphone at all. Creating first means a capture failure surfaces
+    // while the existing track is still published and the call can continue.
+    const audioTrack = await createLocalAudioTrack({
+      deviceId: { exact: deviceId },
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+      channelCount: { ideal: 1 },
+    });
+
     try {
-      // Get the current microphone track publication
+      // Stop and unpublish the previous microphone track only after the new
+      // one is ready.
       const currentMicTrackPublication =
         this.room.localParticipant.getTrackPublication(Track.Source.Microphone);
-
-      // Stop the current microphone track if it exists
       if (currentMicTrackPublication?.track) {
         await currentMicTrackPublication.track.stop();
         await this.room.localParticipant.unpublishTrack(
@@ -679,37 +699,51 @@ export class WebRTCConnection extends BaseConnection {
         );
       }
 
-      // Create new audio track with the specified device
-      const audioTrack = await createLocalAudioTrack({
-        deviceId: { exact: deviceId },
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true,
-        channelCount: { ideal: 1 },
-      });
-
-      // Publish the new microphone track
       await this.room.localParticipant.publishTrack(audioTrack, {
         name: "microphone",
         source: Track.Source.Microphone,
       });
 
-      // Reconnect the input analyser to the new track
       this.setupInputAnalyser(audioTrack.mediaStreamTrack);
     } catch (error) {
+      // We already hold a fresh local track; release it so the device is not
+      // left captured, then rethrow. The previously published track (if any)
+      // is still live because the swap failed before unpublish completed.
       console.error("Failed to change input device:", error);
-
-      // Try to re-enable default microphone on failure
       try {
-        await this.room.localParticipant.setMicrophoneEnabled(true);
-      } catch (recoveryError) {
+        audioTrack.stop();
+      } catch (stopError) {
         console.error(
-          "Failed to recover microphone after device switch error:",
-          recoveryError
+          "Failed to stop new track after switch error:",
+          stopError
         );
       }
-
       throw error;
     }
+  }
+
+  /**
+   * Publishes the local microphone track, using `inputDeviceId` when provided
+   * so the agent receives audio from the selected device instead of the
+   * browser default. Used during `create()` to avoid a post-connect
+   * republish.
+   */
+  private async enableMicrophone(inputDeviceId?: string): Promise<void> {
+    if (!inputDeviceId) {
+      await this.room.localParticipant.setMicrophoneEnabled(true);
+      return;
+    }
+
+    const audioTrack = await createLocalAudioTrack({
+      deviceId: { exact: inputDeviceId },
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+      channelCount: { ideal: 1 },
+    });
+    await this.room.localParticipant.publishTrack(audioTrack, {
+      name: "microphone",
+      source: Track.Source.Microphone,
+    });
   }
 }

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -683,6 +683,12 @@ export class WebRTCConnection extends BaseConnection {
         );
       }
 
+      // Publish muted rather than muting afterwards, so a muted session never
+      // sends audio from the new device.
+      if (this._isMuted) {
+        await audioTrack.mute();
+      }
+
       await this.room.localParticipant.publishTrack(audioTrack, {
         name: "microphone",
         source: Track.Source.Microphone,
@@ -700,7 +706,13 @@ export class WebRTCConnection extends BaseConnection {
         // The old track is already gone, so recover onto the default device
         // rather than leaving the session without a microphone.
         try {
-          await this.room.localParticipant.setMicrophoneEnabled(true);
+          await this.room.localParticipant.setMicrophoneEnabled(!this._isMuted);
+          const recoveredTrack = this.room.localParticipant.getTrackPublication(
+            Track.Source.Microphone
+          )?.track;
+          if (recoveredTrack) {
+            this.setupInputAnalyser(recoveredTrack.mediaStreamTrack);
+          }
         } catch (recoveryError) {
           console.error(
             "Failed to recover microphone after device switch error:",

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -16,6 +16,7 @@ import {
   createLocalAudioTrack,
 } from "livekit-client";
 import type {
+  LocalAudioTrack,
   RemoteAudioTrack,
   Participant,
   TrackPublication,
@@ -312,12 +313,8 @@ export class WebRTCConnection extends BaseConnection {
       // The server may wait for the client to publish audio before fully
       // establishing the subscriber peer connection, matching the behaviour
       // of @livekit/components-react's useLiveKitRoom hook.
-      //
-      // When an `inputDeviceId` is configured, publish a track captured from
-      // that device directly. Falling back to `setMicrophoneEnabled(true)`
-      // would publish the browser's default microphone and ignore the
-      // selected device, leaving the agent on the wrong (or silent) track
-      // until a post-connect `changeInputDevice` republish.
+      // `setMicrophoneEnabled` cannot take a device, so a configured
+      // `inputDeviceId` publishes its own track instead.
       const micEnabled = config.textOnly
         ? Promise.resolve()
         : new Promise<void>((resolve, reject) => {
@@ -673,27 +670,14 @@ export class WebRTCConnection extends BaseConnection {
       );
     }
 
-    // Acquire the new track before tearing down the old one. The previous
-    // implementation stopped and unpublished the live mic track before
-    // calling createLocalAudioTrack, so a failed re-acquire (device unplugged
-    // mid-call, permission revoked, etc.) left the participant with no
-    // microphone at all. Creating first means a capture failure surfaces
-    // while the existing track is still published and the call can continue.
-    const audioTrack = await createLocalAudioTrack({
-      deviceId: { exact: deviceId },
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true,
-      channelCount: { ideal: 1 },
-    });
+    // Acquire the new track before releasing the old one, so a failed capture
+    // leaves the live microphone published.
+    const audioTrack = await this.createMicrophoneTrack(deviceId);
 
     try {
-      // Stop and unpublish the previous microphone track only after the new
-      // one is ready.
       const currentMicTrackPublication =
         this.room.localParticipant.getTrackPublication(Track.Source.Microphone);
       if (currentMicTrackPublication?.track) {
-        await currentMicTrackPublication.track.stop();
         await this.room.localParticipant.unpublishTrack(
           currentMicTrackPublication.track
         );
@@ -703,47 +687,61 @@ export class WebRTCConnection extends BaseConnection {
         name: "microphone",
         source: Track.Source.Microphone,
       });
-
-      this.setupInputAnalyser(audioTrack.mediaStreamTrack);
     } catch (error) {
-      // We already hold a fresh local track; release it so the device is not
-      // left captured, then rethrow. The previously published track (if any)
-      // is still live because the swap failed before unpublish completed.
       console.error("Failed to change input device:", error);
-      try {
+
+      const publication = this.room.localParticipant.getTrackPublication(
+        Track.Source.Microphone
+      );
+      if (publication?.track !== audioTrack) {
         audioTrack.stop();
-      } catch (stopError) {
-        console.error(
-          "Failed to stop new track after switch error:",
-          stopError
-        );
       }
+      if (!publication?.track) {
+        // The old track is already gone, so recover onto the default device
+        // rather than leaving the session without a microphone.
+        try {
+          await this.room.localParticipant.setMicrophoneEnabled(true);
+        } catch (recoveryError) {
+          console.error(
+            "Failed to recover microphone after device switch error:",
+            recoveryError
+          );
+        }
+      }
+
       throw error;
     }
+
+    this.setupInputAnalyser(audioTrack.mediaStreamTrack);
   }
 
-  /**
-   * Publishes the local microphone track, using `inputDeviceId` when provided
-   * so the agent receives audio from the selected device instead of the
-   * browser default. Used during `create()` to avoid a post-connect
-   * republish.
-   */
   private async enableMicrophone(inputDeviceId?: string): Promise<void> {
     if (!inputDeviceId) {
       await this.room.localParticipant.setMicrophoneEnabled(true);
       return;
     }
 
-    const audioTrack = await createLocalAudioTrack({
-      deviceId: { exact: inputDeviceId },
+    const audioTrack = await this.createMicrophoneTrack(inputDeviceId);
+    try {
+      await this.room.localParticipant.publishTrack(audioTrack, {
+        name: "microphone",
+        source: Track.Source.Microphone,
+      });
+    } catch (error) {
+      // An unpublished track is unknown to the room, so disconnecting would
+      // leave the device captured.
+      audioTrack.stop();
+      throw error;
+    }
+  }
+
+  private createMicrophoneTrack(deviceId: string): Promise<LocalAudioTrack> {
+    return createLocalAudioTrack({
+      deviceId: { exact: deviceId },
       echoCancellation: true,
       noiseSuppression: true,
       autoGainControl: true,
       channelCount: { ideal: 1 },
-    });
-    await this.room.localParticipant.publishTrack(audioTrack, {
-      name: "microphone",
-      source: Track.Source.Microphone,
     });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A customer reported that `inputDeviceId` is ignored on WebRTC sessions: `startSession` always publishes the browser's default microphone, so a user on a non-default mic sends a silent or wrong track to the agent with no error surfaced. The documented workaround — calling `changeInputDevice` once connected — republishes the live track mid-connect and can leave the mic dead when the re-acquire throws.

Merging this PR will:
- Publish a track captured from the configured `inputDeviceId` when starting a WebRTC session, instead of enabling the default microphone (unchanged when no device is configured).
- Make `changeInputDevice` acquire the new track before stopping and unpublishing the old one, so a failed re-acquire leaves the existing microphone live.
- Type `inputDeviceId` on `WebRTCConnectionConfig`, which already carried it at runtime via `Options`.
- Keep a muted session muted across a device change — a pre-existing bug where the newly published track went live while `isMuted()` still reported muted (shipped as its own changeset).

[Slack Thread](https://eleven-labs-workspace.slack.com/archives/D0AEF74SWQ4/p1787640702105299?thread_ts=1787640702.105299&cid=D0AEF74SWQ4)

---

<details>

<summary>Additional context intended for coding agents and bots</summary>

## Root cause

`WebRTCConnection.create()` enabled the microphone with `room.localParticipant.setMicrophoneEnabled(true)`, a LiveKit convenience that always captures the browser default device — it has no way to take a `deviceId`. The configured `inputDeviceId` was only wired into the local level meter, so the selection appeared to work in the UI while the agent received the default device's audio. Per `git log` this has been the WebRTC behaviour since it was introduced; the WebSocket path was unaffected.

## Design

`create()` now routes through a private `enableMicrophone(inputDeviceId)`: with no device configured it keeps the existing `setMicrophoneEnabled(true)` path, and with one configured it publishes `createLocalAudioTrack({ deviceId: { exact }, echoCancellation, noiseSuppression, autoGainControl, channelCount: { ideal: 1 } })` under `Track.Source.Microphone` — the same constraints `setAudioInputDevice` already used, so a track published at connect time and one published by a later swap are identical. Publishing still happens inside the `SignalConnected` handler, preserving the ordering the subscriber peer connection depends on.

`setAudioInputDevice` is reordered to create-then-swap, so a failed capture rethrows with the old track still published. Its `catch` derives recovery from LiveKit's own state rather than tracking swap progress locally: it reads back `getTrackPublication(Track.Source.Microphone)`, stops the new track only when that publication is not the new track, and re-enables the default device when nothing is published at all. That query is authoritative at this point in livekit-client 2.21.0 — `unpublishTrack` deletes from `trackPublications` before resolving, and `publishTrack` calls `addTrackPublication` only after every throwing await, so a failed publish cannot read back as live. `setupInputAnalyser` moved out of the `try` so a level-meter failure cannot stop a published track, and the explicit `track.stop()` before `unpublishTrack` is gone because `unpublishTrack` stops what it removes (`stopLocalTrackOnUnpublish` defaults to `true`).

The swap also carries session state across it. The new track is muted before `publishTrack` when `_isMuted` is set, so there is no window of live audio — LiveKit sends `muted: track.isMuted` in the AddTrackRequest and `stopOnMute` defaults to `false`, so pre-publish muting reaches the server intact. Recovery calls `setMicrophoneEnabled(!this._isMuted)` instead of hardcoding `true`, mirroring `setMuted`'s own fallback, and reattaches `setupInputAnalyser` to the recovered publication so metering does not stay bound to the track `unpublishTrack` stopped.

`enableMicrophone` stops its track if `publishTrack` rejects: the room only learns about a track on publish, so `create()`'s `room.disconnect()` would otherwise leave the selected device captured after a failed session start. Both capture sites share a private `createMicrophoneTrack(deviceId)` so connect-time and swap-time constraints cannot drift.

## Alternatives considered

1. Keeping `setMicrophoneEnabled(true)` at connect and calling `setAudioInputDevice` immediately after — this is the current workaround, and it is what fails in production: it tears down and republishes a track while the connection is still stabilising.
2. Setting the device via LiveKit's `room.switchActiveDevice('audioinput', id, true)` before `setMicrophoneEnabled(true)` — it works, but adds a second device-negotiation round trip inside the connect critical path and leaves capture constraints (echo cancellation, noise suppression, gain, channel count) to LiveKit's defaults, so a connect-time track would not match one published by a later `changeInputDevice` swap.

## Compatibility

Behaviour change for callers that rely on `startSession` ignoring `inputDeviceId` and then call `changeInputDevice` themselves. The first published track is now already from the selected device, so the follow-up call is redundant; if still made, it performs a create-before-stop swap to the same device, which is harmless. No such pattern exists inside this repo.

## Test plan and verification

- [x] `pnpm exec vitest run src/utils/WebRTCConnection.test.ts` in `packages/client` — 24/24 pass
- [x] `pnpm exec vitest run --browser.headless` in `packages/client` — 18 files, 249 tests pass
- [x] `pnpm turbo lint` (via pre-commit) — 29/29 tasks green
- [x] Every failure-path test was re-run against the pre-fix `WebRTCConnection.ts` and fails there, so they pin the behaviour rather than passing incidentally.

Nine cases added to `WebRTCConnection.test.ts`:
- `publishes a track from the configured inputDeviceId instead of the default mic` — asserts `createLocalAudioTrack` receives `deviceId: { exact }`, the track is published with `source: microphone`, and `setMicrophoneEnabled(true)` is never called.
- `falls back to setMicrophoneEnabled when no inputDeviceId is configured` — pins the default-mic path.
- `keeps the previous mic published when setAudioInputDevice re-acquire fails` — asserts the old track is neither stopped nor unpublished when `createLocalAudioTrack` rejects.
- `recovers onto the default mic when publishing the new device fails` — the mock clears its publication on `unpublishTrack`, mirroring LiveKit, so the swap fails with nothing published; asserts the new track is stopped and `setMicrophoneEnabled(true)` runs.
- `keeps the new track published when the swap succeeds` — asserts the old track is unpublished (and not separately stopped) while the new track stays live.
- `releases the mic when publishing at session start fails` — asserts `enableMicrophone` stops its track when `publishTrack` rejects during `create()`.
- `publishes the new device muted when the session is muted` — asserts `mute()` runs before `publishTrack` via `invocationCallOrder`, so no audio can escape between the two.
- `recovers a muted session without republishing live audio` — asserts recovery calls `setMicrophoneEnabled(false)` and the session stays muted.
- `reconnects the input analyser to the recovered mic` — wraps the audio adapter to record analysed tracks and asserts the last one is the recovered publication's track.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a5ab89-58b1-5a8a-bff3-72e7af381aaa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a5ab89-58b1-5a8a-bff3-72e7af381aaa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
