### PR TITLE
feat(client): add fileIds to sendMultimodalMessage

### DIFF
--- a/.changeset/multi-file-upload-client.md
+++ b/.changeset/multi-file-upload-client.md
@@ -1,0 +1,7 @@
+---
+"@elevenlabs/client": minor
+"@elevenlabs/react": minor
+"@elevenlabs/types": patch
+---
+
+Add `fileIds` to `sendMultimodalMessage` and dual-send `file` + `files` on the wire.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -417,6 +417,80 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("sendMultimodalMessage", () => {
+    function conversationSending() {
+      const sendMessage = vi.fn();
+      const connection = {
+        ...noopConnection,
+        sendMessage,
+      } as unknown as BaseConnection;
+      return {
+        sendMessage,
+        conversation: TestConversation.create({}, connection),
+      };
+    }
+
+    it("dual-sends file and files when fileId is set", () => {
+      const { sendMessage, conversation } = conversationSending();
+
+      conversation.sendMultimodalMessage({
+        text: "What is this?",
+        fileId: "file_a",
+      });
+
+      expect(JSON.parse(JSON.stringify(sendMessage.mock.calls[0][0]))).toEqual({
+        type: "multimodal_message",
+        text: { type: "user_message", text: "What is this?" },
+        file: { type: "file_input", file_id: "file_a" },
+        files: [{ type: "file_input", file_id: "file_a" }],
+      });
+    });
+
+    it("dual-sends file and files when fileIds is set", () => {
+      const { sendMessage, conversation } = conversationSending();
+
+      conversation.sendMultimodalMessage({ fileIds: ["file_a", "file_b"] });
+
+      expect(JSON.parse(JSON.stringify(sendMessage.mock.calls[0][0]))).toEqual({
+        type: "multimodal_message",
+        file: { type: "file_input", file_id: "file_a" },
+        files: [
+          { type: "file_input", file_id: "file_a" },
+          { type: "file_input", file_id: "file_b" },
+        ],
+      });
+    });
+
+    it("prefers fileIds when both fileId and fileIds are set", () => {
+      const { sendMessage, conversation } = conversationSending();
+
+      conversation.sendMultimodalMessage({
+        fileId: "ignored",
+        fileIds: ["file_a", "file_b"],
+      });
+
+      expect(JSON.parse(JSON.stringify(sendMessage.mock.calls[0][0]))).toEqual({
+        type: "multimodal_message",
+        file: { type: "file_input", file_id: "file_a" },
+        files: [
+          { type: "file_input", file_id: "file_a" },
+          { type: "file_input", file_id: "file_b" },
+        ],
+      });
+    });
+
+    it("omits file fields for text-only messages", () => {
+      const { sendMessage, conversation } = conversationSending();
+
+      conversation.sendMultimodalMessage({ text: "Hello" });
+
+      expect(JSON.parse(JSON.stringify(sendMessage.mock.calls[0][0]))).toEqual({
+        type: "multimodal_message",
+        text: { type: "user_message", text: "Hello" },
+      });
+    });
+  });
+
   describe("ping events", () => {
     it("replies with a pong and forwards the payload to onPing", async () => {
       const onPing = vi.fn();

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -107,7 +107,9 @@ export type PartialOptions = SessionConfig &
 
 export type MultimodalMessageInput = {
   text?: string;
+  /** @deprecated Use `fileIds`. */
   fileId?: string;
+  fileIds?: string[];
 };
 
 /**
@@ -873,14 +875,22 @@ export abstract class BaseConversation {
   }
 
   public sendMultimodalMessage(options: MultimodalMessageInput) {
+    const fileIds = options.fileIds?.length
+      ? options.fileIds
+      : options.fileId
+        ? [options.fileId]
+        : [];
+    const files = fileIds.map(file_id => ({
+      type: "file_input" as const,
+      file_id,
+    }));
     this.connection.sendMessage({
       type: "multimodal_message",
       text: options.text
         ? { type: "user_message" as const, text: options.text }
         : undefined,
-      file: options.fileId
-        ? { type: "file_input" as const, file_id: options.fileId }
-        : undefined,
+      file: files[0],
+      files: files.length ? files : undefined,
     });
   }
 

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -215,6 +215,7 @@ export interface MultimodalMessage {
   type: "multimodal_message";
   text?: ReservedText;
   file?: File;
+  files?: File[];
 }
 
 export interface ReservedText {
@@ -809,6 +810,7 @@ export interface MultimodalMessageClientToOrchestratorEvent {
   type: "multimodal_message";
   text?: ReservedText;
   file?: File;
+  files?: File[];
 }
 
 export interface InputAudioChunk {

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -806,6 +806,11 @@ components:
           $ref: "#/components/schemas/MultimodalMessageFileData"
           nullable: true
           description: The file component of the multimodal message
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/MultimodalMessageFileData"
+          description: The file components of the multimodal message
 
     # ===== SERVER MESSAGE PAYLOADS =====
 


### PR DESCRIPTION
## Summary
- Add `fileIds` to `sendMultimodalMessage` on `@elevenlabs/client` (plural wins over deprecated `fileId`).
- Dual-send `file` + `files` so older backends still receive the first attachment.
- Changeset for `@elevenlabs/client`, `@elevenlabs/react`, and `@elevenlabs/types`.

Widget follow-up: `bharath/multi-file-upload-widget`.

Written by Cursor Grok 4.6, using Cursor

## Test plan
- [x] `BaseConversation` tests for singular, plural, prefer-plural, and text-only
- [ ] CI on this PR
- [ ] Publish `@elevenlabs/react` after merge so xi can pin `fileIds`