### PR TITLE
feat(client): forward agent_response attachments to onMessage

### DIFF
--- a/.changeset/spicy-melons-attach.md
+++ b/.changeset/spicy-melons-attach.md
@@ -1,0 +1,6 @@
+---
+"@elevenlabs/types": minor
+"@elevenlabs/client": minor
+---
+
+Forward the optional `attachments` field (url, name, mime_type) from the `agent_response` client event into the `onMessage` payload, so consumers can render files attached to agent messages, e.g. relayed from a human agent reply.

--- a/packages/client/src/BaseConversation.test.ts
+++ b/packages/client/src/BaseConversation.test.ts
@@ -198,6 +198,62 @@ describe("BaseConversation", () => {
     });
   });
 
+  describe("agent_response events", () => {
+    it("forwards attachments to onMessage when present", async () => {
+      const onMessage = vi.fn();
+      const conversation = TestConversation.create({ onMessage });
+
+      await conversation.receiveMessage({
+        type: "agent_response",
+        agent_response_event: {
+          agent_response: "Here is the file you asked for.",
+          event_id: 3,
+          attachments: [
+            {
+              url: "https://example.com/invoice.pdf",
+              name: "invoice.pdf",
+              mime_type: "application/pdf",
+            },
+          ],
+        },
+      });
+
+      expect(onMessage).toHaveBeenCalledWith({
+        source: "ai",
+        role: "agent",
+        message: "Here is the file you asked for.",
+        event_id: 3,
+        attachments: [
+          {
+            url: "https://example.com/invoice.pdf",
+            name: "invoice.pdf",
+            mime_type: "application/pdf",
+          },
+        ],
+      });
+    });
+
+    it("leaves attachments undefined when the event has none", async () => {
+      const onMessage = vi.fn();
+      const conversation = TestConversation.create({ onMessage });
+
+      await conversation.receiveMessage({
+        type: "agent_response",
+        agent_response_event: {
+          agent_response: "Hello there",
+          event_id: 4,
+        },
+      });
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Hello there",
+          attachments: undefined,
+        })
+      );
+    });
+  });
+
   describe("agent_response_correction events", () => {
     it("calls onAgentResponseCorrection with the correction payload", async () => {
       const onAgentResponseCorrection = vi.fn();

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -293,6 +293,7 @@ export abstract class BaseConversation {
         role: "agent",
         message: event.agent_response_event.agent_response,
         event_id: event.agent_response_event.event_id,
+        attachments: event.agent_response_event.attachments,
       });
     }
   }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -12,6 +12,7 @@ import type {
   AsrInitiationMetadataEvent,
   Interruption,
   AgentResponseCorrection,
+  AgentResponseAttachment,
   AgentChatResponsePartClientEvent,
   AgentReasoningResponsePartClientEvent,
   ContextUsageClientEvent,
@@ -72,6 +73,8 @@ export type DisconnectionDetails =
       reason: "user";
     };
 
+export type MessageAttachment = AgentResponseAttachment;
+
 export interface MessagePayload {
   message: string;
   event_id?: number;
@@ -80,6 +83,11 @@ export interface MessagePayload {
    */
   source: "user" | "ai";
   role: Role;
+  /**
+   * Files attached to an agent message, e.g. relayed from a human agent
+   * reply. Only present on agent messages.
+   */
+  attachments?: MessageAttachment[];
 }
 
 /**

--- a/packages/types/generated/types/asyncapi-types.ts
+++ b/packages/types/generated/types/asyncapi-types.ts
@@ -274,6 +274,13 @@ export interface AgentResponse {
 export interface AgentResponseEvent {
   agent_response: string;
   event_id: number;
+  attachments?: AgentResponseAttachment[];
+}
+
+export interface AgentResponseAttachment {
+  url: string;
+  name: string;
+  mime_type?: string | null;
 }
 
 export interface AgentResponseCorrection {

--- a/packages/types/schemas/agent.asyncapi.yaml
+++ b/packages/types/schemas/agent.asyncapi.yaml
@@ -781,6 +781,7 @@ components:
           description: "Behavior when a mocked tool is called but no mock response matches. Defaults to 'raise_error' for safety. Options: 'raise_error' fails the tool call, 'call_real_tool' executes the actual tool"
 
     MultimodalMessageFileData:
+      title: File
       type: object
       required: [type, file_id]
       properties:
@@ -1039,6 +1040,20 @@ components:
         event_id:
           type: integer
 
+    AgentResponseAttachment:
+      title: AgentResponseAttachment
+      type: object
+      required: [url, name]
+      properties:
+        url:
+          type: string
+        name:
+          type: string
+        mime_type:
+          anyOf:
+            - type: string
+            - type: "null"
+
     AgentResponseData:
       type: object
       required: [agent_response, event_id]
@@ -1047,6 +1062,11 @@ components:
           type: string
         event_id:
           type: integer
+        attachments:
+          type: array
+          description: Files attached to the agent response, e.g. relayed from a human agent reply
+          items:
+            $ref: "#/components/schemas/AgentResponseAttachment"
 
     AgentResponseCorrectionData:
       type: object


### PR DESCRIPTION
The xi backend can now attach files to the `agent_response` client event (server side merged in [elevenlabs/xi#48105](https://github.com/elevenlabs/xi/pull/48105); [elevenlabs/xi#46108](https://github.com/elevenlabs/xi/pull/46108) is the end-to-end working reference, including visual proof). This PR forwards that field through `@elevenlabs/client` so consumers receive it in the `onMessage` payload.

Wire payload:

```json
{
  "type": "agent_response",
  "agent_response_event": {
    "agent_response": "Here is the file you asked for.",
    "event_id": 3,
    "attachments": [
      { "url": "https://...", "name": "invoice.pdf", "mime_type": "application/pdf" }
    ]
  }
}
```

## Testing

- unit testing
- visual proof from https://github.com/elevenlabs/xi/pull/48105
