### PR TITLE
[Widget] First message rich content language

### DIFF
--- a/.changeset/first-message-rich-content-language.md
+++ b/.changeset/first-message-rich-content-language.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": minor
+---
+
+Greeting buttons now follow the active language, and update when the visitor switches language before a conversation starts.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -20,7 +20,12 @@ import FingerprintJS from "@fingerprintjs/fingerprintjs";
 
 import { useContextSafely } from "../utils/useContextSafely";
 import { useTerms } from "./terms";
-import { useFirstMessage, useWidgetConfig } from "./widget-config";
+import {
+  useFirstMessage,
+  useFirstMessageRichContent,
+  useWidgetConfig,
+} from "./widget-config";
+import type { FirstMessageRichContent } from "../types/config";
 import { ConversationMode } from "./conversation-mode";
 import { useShadowHost } from "./shadow-host";
 
@@ -94,6 +99,24 @@ export type TranscriptEntry =
       conversationIndex: number;
     };
 
+function firstMessageRichContentEntries(
+  richContent: FirstMessageRichContent | null
+): TranscriptEntry[] {
+  if (!richContent) {
+    return [];
+  }
+  return [
+    {
+      type: "rich_content",
+      component: richContent.component,
+      props: richContent.props,
+      eventId: 1,
+      richContentId: "first_message",
+      conversationIndex: 0,
+    },
+  ];
+}
+
 export function ConversationProvider({ children }: ConversationProviderProps) {
   const value = useConversationSetup();
 
@@ -142,6 +165,7 @@ function useConversationSetup() {
 
   const widgetConfig = useWidgetConfig();
   const firstMessage = useFirstMessage();
+  const firstMessageRichContent = useFirstMessageRichContent();
   const terms = useTerms();
   const config = useSessionConfig();
 
@@ -162,7 +186,7 @@ function useConversationSetup() {
     };
   }, []);
 
-  return useMemo(() => {
+  const conversation = useMemo(() => {
     const status = signal<Status>("disconnected");
     const isDisconnected = computed(() => status.value === "disconnected");
 
@@ -173,20 +197,8 @@ function useConversationSetup() {
     const lastId = signal<string | null>(null);
     const canSendFeedback = signal(false);
 
-    const firstMessageEntries = (): TranscriptEntry[] => {
-      const richContent = widgetConfig.peek().first_message_rich_content;
-      if (!richContent) return [];
-      return [
-        {
-          type: "rich_content",
-          component: richContent.component,
-          props: richContent.props,
-          eventId: 1,
-          richContentId: "first_message",
-          conversationIndex: 0,
-        },
-      ];
-    };
+    const firstMessageEntries = (): TranscriptEntry[] =>
+      firstMessageRichContentEntries(firstMessageRichContent.peek());
 
     const transcript = signal<TranscriptEntry[]>(firstMessageEntries());
     const conversationIndex = signal(0);
@@ -632,6 +644,26 @@ function useConversationSetup() {
       },
     };
   }, [config]);
+
+  useSignalEffect(() => {
+    const richContent = firstMessageRichContent.value;
+    if (conversation.status.value !== "disconnected") {
+      return;
+    }
+    const isGreetingOnly = conversation.transcript
+      .peek()
+      .every(
+        entry =>
+          entry.type === "rich_content" &&
+          entry.richContentId === "first_message"
+      );
+    if (!isGreetingOnly) {
+      return;
+    }
+    conversation.transcript.value = firstMessageRichContentEntries(richContent);
+  });
+
+  return conversation;
 }
 
 async function getOrCreateUserId(): Promise<string> {

--- a/packages/convai-widget-core/src/contexts/widget-config.tsx
+++ b/packages/convai-widget-core/src/contexts/widget-config.tsx
@@ -274,6 +274,18 @@ export function useFirstMessage() {
   });
 }
 
+export function useFirstMessageRichContent() {
+  const config = useWidgetConfig();
+  const { language } = useLanguageConfig();
+  return useComputed(
+    () =>
+      config.value.language_presets?.[language.value.languageCode]
+        ?.first_message_rich_content ??
+      config.value.first_message_rich_content ??
+      null
+  );
+}
+
 export function useTextInputEnabled() {
   const config = useWidgetConfig();
   return useComputed(() => config.value.text_input_enabled ?? false);

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -214,6 +214,10 @@ describe("elevenlabs-convai", () => {
   );
 
   describe("first message for voice-capable agents", () => {
+    afterEach(() => {
+      localStorage.removeItem("xi:convai-widget-last-used-language");
+    });
+
     it("shows the first message before a text conversation starts", async () => {
       setupWebComponent({ "agent-id": "text_and_voice", variant: "compact" });
 
@@ -236,6 +240,29 @@ describe("elevenlabs-convai", () => {
       await expect
         .element(page.getByRole("button", { name: "Track my order" }))
         .toBeInTheDocument();
+    });
+
+    it("updates first message buttons when the language changes", async () => {
+      setupWebComponent({
+        "agent-id": "localized",
+        variant: "compact",
+        "text-input": "true",
+        "default-expanded": "true",
+      });
+
+      await expect
+        .element(page.getByRole("button", { name: "Track my order" }))
+        .toBeInTheDocument();
+
+      await page.getByRole("combobox", { name: "Change language" }).click();
+      await page.getByRole("option", { name: "Español" }).click();
+
+      await expect
+        .element(page.getByRole("button", { name: "Rastrear mi pedido" }))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByRole("button", { name: "Track my order" }))
+        .not.toBeInTheDocument();
     });
 
     it("keeps a single first message when the user starts a text chat", async () => {
@@ -1108,6 +1135,9 @@ describe("elevenlabs-convai", () => {
         name: "Change language",
       });
       await expect.element(langButton).toHaveTextContent("Español");
+      await expect
+        .element(page.getByRole("button", { name: "Rastrear mi pedido" }))
+        .toBeInTheDocument();
     });
   });
 

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -66,12 +66,32 @@ export const AGENTS = {
     terms_html: "<p>Default Terms in English</p>",
     terms_key: "terms_default",
     supported_language_overrides: ["es", "fr"],
+    first_message_rich_content: {
+      component: "buttons",
+      props: {
+        buttons: [
+          { type: "message", label: "Track my order", message: "Track" },
+        ],
+      },
+    },
     language_presets: {
       es: {
         text_contents: {
           start_chat: "Iniciar una llamada",
         },
         first_message: "¡Hola! ¿Cómo puedo ayudarte?",
+        first_message_rich_content: {
+          component: "buttons",
+          props: {
+            buttons: [
+              {
+                type: "message",
+                label: "Rastrear mi pedido",
+                message: "Rastrear",
+              },
+            ],
+          },
+        },
         terms_html: "<p>Términos en Español</p>",
         terms_key: "terms_es",
       },
@@ -80,6 +100,18 @@ export const AGENTS = {
           start_chat: "Commencer un appel",
         },
         first_message: "Bonjour! Comment puis-je vous aider?",
+        first_message_rich_content: {
+          component: "buttons",
+          props: {
+            buttons: [
+              {
+                type: "message",
+                label: "Suivre ma commande",
+                message: "Suivre",
+              },
+            ],
+          },
+        },
         terms_html: "<p>Termes en Français</p>",
         terms_key: "terms_fr",
       },

--- a/packages/convai-widget-core/src/types/config.ts
+++ b/packages/convai-widget-core/src/types/config.ts
@@ -28,6 +28,11 @@ export type FeedbackMode = "none" | "during" | "end";
 export type FeedbackType = "rating";
 export type SyntaxHighlightTheme = "light" | "dark";
 
+export type FirstMessageRichContent = {
+  component: string;
+  props: unknown;
+};
+
 export interface AllowlistItem {
   hostname: string;
 }
@@ -63,6 +68,7 @@ export interface WidgetConfig {
       {
         text_contents?: Partial<TextContents>;
         first_message?: string;
+        first_message_rich_content?: FirstMessageRichContent | null;
         terms_html?: string | null;
         terms_text?: string | null;
         terms_key?: string;
@@ -85,10 +91,7 @@ export interface WidgetConfig {
   };
   show_resize_button?: boolean;
   show_language_selector_on_trigger?: boolean;
-  first_message_rich_content?: {
-    component: string;
-    props: unknown;
-  } | null;
+  first_message_rich_content?: FirstMessageRichContent | null;
 }
 
 export type AvatarConfig =


### PR DESCRIPTION
### Read first message rich content from the active language preset

Adds language support for first message rich content. `first_message_rich_content` is now read from the active language preset with a fallback to the top level value. Switching the language in the widget before a conversation starts updates the quick reply buttons text to the translated value.
