### PR TITLE
fix(react-native): re-arm iOS mic capture unit between sequential WebRTC sessions

### DIFF
--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @elevenlabs/react-native
 
+## Unreleased
+
+### Patch Changes
+
+- Fix iOS silent microphone on second (and subsequent) sequential WebRTC
+  sessions. After `stopAudioSession()` ends a call, iOS's RTCAudioSession
+  input capture unit can stall when `startAudioSession()` fires for the next
+  session — the track is live and unmuted but its audio energy is zero.
+  The setup strategy now applies an automatic mute → unmute microcycle after
+  `createConnection()` on iOS voice sessions, which forces the RTCAudioSession
+  to restart the capture unit before the conversation goes live. ([#991](https://github.com/elevenlabs/packages/issues/991))
+
 ## 1.2.25
 
 ### Patch Changes

--- a/packages/react-native/src/index.react-native.ts
+++ b/packages/react-native/src/index.react-native.ts
@@ -3,7 +3,9 @@ import {
   AudioSession,
   AndroidAudioTypePresets,
 } from "@livekit/react-native";
+import { Platform } from "react-native";
 import type { Options } from "@elevenlabs/client";
+import { WebRTCConnection } from "@elevenlabs/client";
 import {
   setSetupStrategy,
   createConnection,
@@ -16,12 +18,33 @@ import { attachNativeVolume } from "./nativeVolume.js";
 registerGlobals();
 
 /**
+ * iOS: re-arm the RTCAudioSession input capture unit after AVAudioSession
+ * reactivation.
+ *
+ * On a second (or subsequent) sequential WebRTC call, the
+ * `startAudioSession()` → LiveKit mic-publish sequence can leave the
+ * hardware input tap stalled — the track is live and unmuted at the WebRTC
+ * level but its total audio energy is zero (see issue #991).
+ *
+ * A mute → unmute cycle forces LiveKit's native RTCAudioSession to call
+ * `setRecordingEnabled:YES` again, which reliably restarts the capture unit.
+ * This is the same recovery step that a manual mute/unmute triggers.
+ */
+async function iosRearmMicrophone(connection: WebRTCConnection): Promise<void> {
+  const room = connection.getRoom();
+  await room.localParticipant.setMicrophoneEnabled(false);
+  await room.localParticipant.setMicrophoneEnabled(true);
+}
+
+/**
  * React Native voice session setup strategy.
  *
  * 1. Configures and starts the native AudioSession
  * 2. Creates a WebRTC connection and extracts its I/O controllers
- * 3. Wraps input/output controllers with native volume processors
- * 4. Wraps detach to stop the native AudioSession on cleanup
+ * 3. On iOS, re-arms the RTCAudioSession input tap to fix silent-mic on
+ *    repeated sessions (issue #991)
+ * 4. Wraps input/output controllers with native volume processors
+ * 5. Wraps detach to stop the native AudioSession on cleanup
  *
  * Only WebRTC connections are supported on React Native.
  * WebSocket connections require Web Audio APIs (AudioContext,
@@ -50,6 +73,21 @@ async function reactNativeSessionSetup(
   await AudioSession.startAudioSession();
 
   const connection = await createConnection(options);
+
+  // iOS only: re-arm the audio capture unit before the session goes live.
+  // This is a no-op for text-only sessions (no mic track is published).
+  if (Platform.OS === "ios" && !options.textOnly) {
+    if (connection instanceof WebRTCConnection) {
+      try {
+        await iosRearmMicrophone(connection);
+      } catch (e) {
+        // Non-fatal: if re-arming fails the session continues. The user may
+        // experience the silent-capture issue on this particular call.
+        console.warn("[ElevenLabs] iOS mic re-arm failed:", e);
+      }
+    }
+  }
+
   const result = attachNativeVolume(setupWebRTCSession(connection));
 
   const originalDetach = result.detach;


### PR DESCRIPTION


Closes #991

## Problem

On a physical iPhone, the **second (and subsequent) sequential WebRTC conversation** captures only silence. The microphone track is live, enabled, and unmuted at the WebRTC level ;  `bytesSent` increments and LiveKit reports the engine running but total audio energy is zero and the agent receives only `...`.

**Root cause:** The React Native setup strategy calls `AudioSession.stopAudioSession()` at the end of each session and `AudioSession.startAudioSession()` at the start of the next. On iOS, this deactivates and reactivates the AVAudioSession, but the RTCAudioSession's **input capture unit is not automatically re-armed** when the new LiveKit peer connection publishes its mic track. The hardware tap is stalled.

The reporter confirmed this by manually muting then unmuting: audio resumed immediately within the same track, without any route change. This is the critical signal — a LiveKit-level mute/unmute causes the native RTCAudioSession to call `setRecordingEnabled:YES` again, which restarts the capture unit.

## Fix

After `createConnection()` resolves (room connected, mic track published), apply an automatic **mute → unmute microcycle** on `localParticipant` when running on iOS in a voice session:

```ts
async function iosRearmMicrophone(connection: WebRTCConnection): Promise<void> {
  const room = connection.getRoom();
  await room.localParticipant.setMicrophoneEnabled(false);
  await room.localParticipant.setMicrophoneEnabled(true);
}
```

This runs before `attachNativeVolume` and before the conversation is considered ready, so it is invisible to the user (~1–2 async ticks at session start, before the agent begins listening).

**Guards:**
- `Platform.OS === "ios"` — Android is unaffected and unchanged
- `!options.textOnly` — no mic track is published in text-only sessions; no-op there
- `try/catch` — failure is non-fatal and logged via `console.warn`; the session continues

## Changes

| File | Change |
|------|--------|
| `packages/react-native/src/index.react-native.ts` | Add `iosRearmMicrophone()` helper; call it in `reactNativeSessionSetup` after `createConnection()` on iOS voice sessions |
| `packages/react-native/CHANGELOG.md` | Add unreleased patch entry referencing #991 |

## Testing

This issue only reproduces on a **physical iPhone** (not Simulator — Simulator has no AVAudioSession hardware stall). The recommended validation steps from the issue reporter:

1. Build a native Expo development client for iPhone using the official `examples/react-native-expo` app with this patch applied
2. Start a conversation, speak, confirm the agent responds, call `endSession()`
3. Wait for provider status `disconnected`
4. Immediately start a second conversation and speak
5. Confirm `bytesSent` and `audioLevel` are non-zero for session 2
6. Repeat for 10 consecutive sessions

**Expected** (with fix): all sessions capture and transmit microphone audio normally  
**Expected** (without fix): sessions 2+ show `audioLevel: 0`, `bytesSent` << session 1

## Related

- Issue: #991
- Upstream LiveKit report: livekit/client-sdk-react-native#422
