### PR TITLE
fix(client): forward async room handler rejections to onError

### DIFF
--- a/.changeset/forward-async-handler-errors.md
+++ b/.changeset/forward-async-handler-errors.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Forward rejections from async LiveKit room event handlers to `onError` instead of letting them become unhandled promise rejections. `TrackSubscribed` awaits the audio adapter and audio capture setup, so a failure there meant the agent's audio silently never attached and the caller was told nothing.

--- a/packages/client/src/utils/BaseConnection.ts
+++ b/packages/client/src/utils/BaseConnection.ts
@@ -193,14 +193,41 @@ export abstract class BaseConnection {
   protected onMessageCallback: OnMessageCallback | null = null;
   protected onModeChangeCallback: ((mode: Mode) => void) | null = null;
   protected onDebug?: (info: unknown) => void;
+  protected onError?: (message: string, context?: unknown) => void;
   protected onOutgoingMessageCallback: OnOutgoingMessageCallback | null = null;
 
-  constructor(config: { onDebug?: (info: unknown) => void } = {}) {
+  constructor(
+    config: {
+      onDebug?: (info: unknown) => void;
+      onError?: (message: string, context?: unknown) => void;
+    } = {}
+  ) {
     this.onDebug = config.onDebug;
+    this.onError = config.onError;
   }
 
   protected debug(info: unknown) {
     if (this.onDebug) this.onDebug(info);
+  }
+
+  protected reportError(message: string, context?: unknown) {
+    if (this.onError) this.onError(message, context);
+  }
+
+  /**
+   * Wraps an async event handler so that a rejection reaches `onError` instead
+   * of becoming an unhandled rejection. Emitters discard the promise a handler
+   * returns, so without this the failure is invisible to the caller.
+   */
+  protected forwardHandlerErrors<A extends unknown[]>(
+    message: string,
+    handler: (...args: A) => Promise<void>
+  ): (...args: A) => void {
+    return (...args: A) => {
+      handler(...args).catch((error: unknown) => {
+        this.reportError(message, error);
+      });
+    };
   }
 
   public abstract close(): void;

--- a/packages/client/src/utils/WebRTCConnection.test.ts
+++ b/packages/client/src/utils/WebRTCConnection.test.ts
@@ -1239,4 +1239,127 @@ describe("WebRTCConnection", () => {
       connection.close();
     });
   });
+
+  describe("async event handler errors", () => {
+    // Emitters discard the promise a handler returns, so a rejection inside an
+    // async room handler used to surface only as an unhandled rejection: the
+    // agent's audio silently never attached and the caller was told nothing.
+    async function createWithHandlers(
+      attachRemoteTrack: () => Promise<void>,
+      onError: (message: string, context?: unknown) => void
+    ) {
+      const eventHandlers = new Map<string, (...args: unknown[]) => void>();
+      const mockRoom = new Room() as any;
+
+      (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          eventHandlers.set(event, callback);
+          if (event === "connected") queueMicrotask(() => callback());
+        }
+      );
+      (mockRoom.once as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, callback: () => void) => {
+          if (event === "signalConnected") queueMicrotask(callback);
+        }
+      );
+
+      setWebRTCAudioAdapterFactory(
+        () =>
+          ({
+            attachRemoteTrack,
+            setOutputDevice: vi.fn(),
+            cleanup: vi.fn(),
+          }) as any
+      );
+
+      const connection = await WebRTCConnection.create({
+        conversationToken: "test-token",
+        connectionType: "webrtc",
+        onError,
+      });
+
+      return { connection, eventHandlers };
+    }
+
+    const agentAudioTrack = [
+      { kind: "audio" },
+      {},
+      { identity: "agent-1" },
+    ] as const;
+
+    it("forwards a rejection from an async TrackSubscribed handler to onError", async () => {
+      const onError = vi.fn();
+      const failure = new Error("attach failed");
+      const { connection, eventHandlers } = await createWithHandlers(
+        () => Promise.reject(failure),
+        onError
+      );
+
+      eventHandlers.get("trackSubscribed")?.(...agentAudioTrack);
+      await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+
+      expect(onError).toHaveBeenCalledWith(
+        "Failed to attach subscribed audio track",
+        failure
+      );
+
+      connection.close();
+    });
+
+    it("does not leave the rejection unhandled", async () => {
+      const unhandled: unknown[] = [];
+      const capture = (event: PromiseRejectionEvent | unknown) =>
+        unhandled.push(event);
+      process.on("unhandledRejection", capture);
+
+      try {
+        const { connection, eventHandlers } = await createWithHandlers(
+          () => Promise.reject(new Error("attach failed")),
+          vi.fn()
+        );
+
+        eventHandlers.get("trackSubscribed")?.(...agentAudioTrack);
+        // Give the rejection a chance to go unhandled before asserting.
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        expect(unhandled).toEqual([]);
+        connection.close();
+      } finally {
+        process.off("unhandledRejection", capture);
+      }
+    });
+
+    it("stays silent when the handler resolves", async () => {
+      const onError = vi.fn();
+      const { connection, eventHandlers } = await createWithHandlers(
+        () => Promise.resolve(),
+        onError
+      );
+
+      eventHandlers.get("trackSubscribed")?.(...agentAudioTrack);
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(onError).not.toHaveBeenCalled();
+
+      connection.close();
+    });
+
+    it("forwards a rejection from ActiveSpeakersChanged to onError", async () => {
+      const onError = vi.fn();
+      const { connection, eventHandlers } = await createWithHandlers(
+        () => Promise.resolve(),
+        onError
+      );
+
+      // updateMode throws for a participant whose identity is not a string.
+      eventHandlers.get("activeSpeakersChanged")?.([{ identity: undefined }]);
+      await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+
+      expect(onError.mock.calls[0][0]).toBe(
+        "Failed to handle active speaker change"
+      );
+
+      connection.close();
+    });
+  });
 });

--- a/packages/client/src/utils/WebRTCConnection.ts
+++ b/packages/client/src/utils/WebRTCConnection.ts
@@ -52,6 +52,11 @@ export type WebRTCConnectionConfig = SessionConfig &
   Pick<AudioWorkletConfig, "workletPaths"> &
   InputDeviceConfig & {
     onDebug?: (info: unknown) => void;
+    /**
+     * Receives errors that surface outside a caller-visible promise, such as a
+     * rejection inside an async room event handler.
+     */
+    onError?: (message: string, context?: unknown) => void;
   };
 
 /** @deprecated Use {@link WebRTCConnectionConfig} instead. */
@@ -223,6 +228,7 @@ export class WebRTCConnection extends BaseConnection {
     outputFormat: FormatConfig,
     config: {
       onDebug?: (info: unknown) => void;
+      onError?: (message: string, context?: unknown) => void;
       workletPaths?: AudioWorkletConfig["workletPaths"];
     } = {}
   ) {
@@ -451,44 +457,52 @@ export class WebRTCConnection extends BaseConnection {
 
     this.room.on(
       RoomEvent.TrackSubscribed,
-      async (
-        track: Track,
-        _publication: TrackPublication,
-        participant: Participant
-      ) => {
-        if (
-          track.kind === Track.Kind.Audio &&
-          participant.identity.includes("agent")
-        ) {
-          const remoteAudioTrack = track as RemoteAudioTrack;
+      this.forwardHandlerErrors(
+        "Failed to attach subscribed audio track",
+        async (
+          track: Track,
+          _publication: TrackPublication,
+          participant: Participant
+        ) => {
+          if (
+            track.kind === Track.Kind.Audio &&
+            participant.identity.includes("agent")
+          ) {
+            const remoteAudioTrack = track as RemoteAudioTrack;
 
-          if (this.audioAdapter) {
-            // Delegate playback to the platform-specific adapter
-            await this.audioAdapter.attachRemoteTrack(
-              remoteAudioTrack,
-              this.outputDeviceId
-            );
+            if (this.audioAdapter) {
+              // Delegate playback to the platform-specific adapter
+              await this.audioAdapter.attachRemoteTrack(
+                remoteAudioTrack,
+                this.outputDeviceId
+              );
 
-            // Set up output volume analysis and audio capture
-            await this.setupAudioCapture(remoteAudioTrack);
+              // Set up output volume analysis and audio capture
+              await this.setupAudioCapture(remoteAudioTrack);
 
-            this.onDebug?.({ type: "audio_element_ready" });
+              this.onDebug?.({ type: "audio_element_ready" });
+            }
           }
         }
-      }
+      )
     );
 
     this.room.on(
       RoomEvent.ActiveSpeakersChanged,
-      async (speakers: Participant[]) => {
-        if (speakers.length > 0) {
-          this.updateMode(
-            speakers[0].identity.startsWith("agent") ? "speaking" : "listening"
-          );
-        } else {
-          this.updateMode("listening");
+      this.forwardHandlerErrors(
+        "Failed to handle active speaker change",
+        async (speakers: Participant[]) => {
+          if (speakers.length > 0) {
+            this.updateMode(
+              speakers[0].identity.startsWith("agent")
+                ? "speaking"
+                : "listening"
+            );
+          } else {
+            this.updateMode("listening");
+          }
         }
-      }
+      )
     );
 
     this.room.on(


### PR DESCRIPTION
Closes #803, for the `WebRTCConnection` half.

## The bug

Two LiveKit room handlers in `WebRTCConnection` are `async`, and an emitter discards the promise a handler returns. A rejection therefore became an unhandled rejection rather than reaching the caller.

`TrackSubscribed` is the one that matters. It awaits `audioAdapter.attachRemoteTrack` and `setupAudioCapture`:

```ts
this.room.on(RoomEvent.TrackSubscribed, async (track, _publication, participant) => {
  ...
  await this.audioAdapter.attachRemoteTrack(remoteAudioTrack, this.outputDeviceId);
  await this.setupAudioCapture(remoteAudioTrack);
```

If either fails, the agent's audio never attaches and the consumer is told nothing at all. No error, no disconnect, just silence, which is about the worst shape a failure can take in a voice SDK.

## The fix

`onError` alongside the existing `onDebug` on `BaseConnection`, plus a `forwardHandlerErrors` helper that catches a handler's rejection and reports it. Applied to `TrackSubscribed` and `ActiveSpeakersChanged`.

`onError` is declared on `WebRTCConnectionConfig` next to `onDebug`, so the contract is explicit rather than relying on the structural pass-through that currently gets `onDebug` to the connection.

The helper lives on `BaseConnection` rather than in `WebRTCConnection` because #803 says "and potentially others", so the next one is a one-line wrap.

## Scope

Only `WebRTCConnection`. The issue also names `scribe.ts` `streamFromMicrophone`, but that already catches internally, calls `connection._emitError(error)` and closes the connection, so it needs no change. Worth confirming if you had something else in mind there.

## Verification

Four tests added. To check they actually detect the bug rather than just passing, I reverted the helper to the previous fire-and-forget behaviour and reran:

| test | pre-fix | post-fix |
|---|---|---|
| forwards a `TrackSubscribed` rejection to `onError` | fail | pass |
| does not leave the rejection unhandled | fail | pass |
| forwards an `ActiveSpeakersChanged` rejection to `onError` | fail | pass |
| stays silent when the handler resolves | pass | pass |

The last is the negative control and passes either way, by design.

The unhandled-rejection test subscribes to `process.on("unhandledRejection")` and asserts nothing is emitted, which is the specific symptom the issue describes.

Full client package: prettier, eslint and `tsc --noEmit` clean, 230 unit tests passing.

Patch changeset included.
