### PR TITLE
[Widget] fix first agent message getting dropped

### DIFF
--- a/.changeset/fix-text-chat-first-agent-reply.md
+++ b/.changeset/fix-text-chat-first-agent-reply.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Fix the agent's first reply being dropped from the transcript in text chat when the agent has a first message configured.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -24,6 +24,8 @@ import { useFirstMessage, useWidgetConfig } from "./widget-config";
 import { ConversationMode } from "./conversation-mode";
 import { useShadowHost } from "./shadow-host";
 
+const FIRST_MESSAGE_EVENT_ID = 1;
+
 type ConversationSetup = ReturnType<typeof useConversationSetup>;
 
 export const ConversationContext = createContext<ConversationSetup | null>(
@@ -308,12 +310,11 @@ function useConversationSetup() {
                 firstMessage.peek() &&
                 conversationTextOnly.peek() === true &&
                 role === "agent" &&
-                !receivedFirstMessageRef.current
+                event_id === FIRST_MESSAGE_EVENT_ID
               ) {
                 receivedFirstMessageRef.current = true;
-                // Text mode is always started by the user sending a text message.
-                // We need to ignore the first agent message as it is immediately
-                // interrupted by the user input.
+                // The configured first message is already rendered locally in
+                // text mode, so ignore the server copy.
                 return;
               } else if (role === "agent") {
                 receivedFirstMessageRef.current = true;
@@ -357,9 +358,9 @@ function useConversationSetup() {
                 conversationTextOnly.peek() === true &&
                 !receivedFirstMessageRef.current
               ) {
-                // Text mode is always started by the user sending a text message.
-                // We need to ignore the first agent message as it is immediately
-                // interrupted by the user input.
+                // Ignore the opening frame of the configured first-message
+                // stream, then allow the actual reply stream through.
+                receivedFirstMessageRef.current = true;
                 return;
               }
               setAgentTyping(false);

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -166,6 +166,64 @@ describe("elevenlabs-convai", () => {
       .not.toBeInTheDocument();
   });
 
+  it("renders the first streamed reply when the configured first message is interrupted", async () => {
+    setupWebComponent({
+      "agent-id": "streamed_first_reply",
+      variant: "compact",
+    });
+
+    await expect.element(page.getByText("Agent response")).toBeInTheDocument();
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("Hello");
+    await userEvent.keyboard("{Enter}");
+
+    await expect
+      .element(page.getByText("First streamed reply"))
+      .toBeInTheDocument();
+  });
+
+  it("renders a reply that matches the streamed configured first message", async () => {
+    setupWebComponent({
+      "agent-id": "streamed_first_message",
+      variant: "compact",
+    });
+
+    const firstMessage = page.getByText("Agent response");
+    await expect.element(firstMessage).toBeInTheDocument();
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("Hello");
+    await userEvent.keyboard("{Enter}");
+
+    await expect.poll(() => firstMessage.elements().length).toBe(2);
+  });
+
+  it("handles a streamed configured first message with a final response", async () => {
+    setupWebComponent({
+      "agent-id": "streamed_first_message_with_final",
+      variant: "compact",
+    });
+
+    const firstMessage = page.getByText("Agent response");
+    await expect.element(firstMessage).toBeInTheDocument();
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("Hello");
+    await userEvent.keyboard("{Enter}");
+
+    await expect
+      .element(page.getByText("Production streamed reply"))
+      .toBeInTheDocument();
+    expect(firstMessage.elements()).toHaveLength(1);
+  });
+
   it.each(Variants)(
     "$0 expandable variant should go through a happy path (text-only)",
     async variant => {

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -194,6 +194,30 @@ const codeBlock = true;
     default_expanded: true,
     first_message: "",
   },
+  streamed_first_reply: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+  },
+  streamed_first_message: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+  },
+  streamed_first_message_with_final: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+  },
   audio_tags_strip: {
     ...BASIC_CONFIG,
     text_only: true,
@@ -329,6 +353,50 @@ function isValidAgentId(agentId: string): agentId is keyof typeof AGENTS {
   return agentId in AGENTS;
 }
 
+async function sendStreamedAgentResponse(
+  client: { send(data: string): void },
+  message: string,
+  eventId: number,
+  includeFinalResponse = true
+) {
+  client.send(
+    JSON.stringify({
+      type: "agent_chat_response_part",
+      text_response_part: { text: "", type: "start", event_id: eventId },
+    })
+  );
+  await new Promise(resolve => setTimeout(resolve, 0));
+  client.send(
+    JSON.stringify({
+      type: "agent_chat_response_part",
+      text_response_part: {
+        text: message,
+        type: "delta",
+        event_id: eventId,
+      },
+    })
+  );
+  await new Promise(resolve => setTimeout(resolve, 0));
+  if (includeFinalResponse) {
+    client.send(
+      JSON.stringify({
+        type: "agent_response",
+        agent_response_event: {
+          agent_response: message,
+          event_id: eventId,
+        },
+      })
+    );
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  client.send(
+    JSON.stringify({
+      type: "agent_chat_response_part",
+      text_response_part: { text: "", type: "stop", event_id: eventId },
+    })
+  );
+}
+
 export const Worker = setupWorker(
   http.get<{ agentId: string }>(
     `${import.meta.env.VITE_SERVER_URL_US}/v1/convai/agents/:agentId/widget`,
@@ -377,15 +445,27 @@ export const Worker = setupWorker(
         })
       );
       await new Promise(resolve => setTimeout(resolve, 0));
-      client.send(
-        JSON.stringify({
-          type: "agent_response",
-          agent_response_event: {
-            agent_response: config.first_message,
-            event_id: 1,
-          },
-        })
-      );
+      if (
+        agentId === "streamed_first_message" ||
+        agentId === "streamed_first_message_with_final"
+      ) {
+        await sendStreamedAgentResponse(
+          client,
+          config.first_message ?? "",
+          1,
+          agentId === "streamed_first_message_with_final"
+        );
+      } else if (agentId !== "streamed_first_reply") {
+        client.send(
+          JSON.stringify({
+            type: "agent_response",
+            agent_response_event: {
+              agent_response: config.first_message,
+              event_id: 1,
+            },
+          })
+        );
+      }
       // `text_and_voice` is a voice-capable agent that the widget switches to
       // text mode when the user types, so it follows the text chat script.
       const isTextChat = config.text_only || agentId === "text_and_voice";
@@ -394,6 +474,9 @@ export const Worker = setupWorker(
         agentId !== "end_call_test" &&
         agentId !== "tool_call" &&
         agentId !== "stream_consolidation" &&
+        agentId !== "streamed_first_reply" &&
+        agentId !== "streamed_first_message" &&
+        agentId !== "streamed_first_message_with_final" &&
         agentId !== "file_upload" &&
         agentId !== "no_file_upload" &&
         agentId !== "external_agent"
@@ -661,6 +744,27 @@ export const Worker = setupWorker(
               text_response_part: { text: "", type: "stop", event_id: 2 },
             })
           );
+        });
+      }
+      if (
+        agentId === "streamed_first_reply" ||
+        agentId === "streamed_first_message" ||
+        agentId === "streamed_first_message_with_final"
+      ) {
+        let hasReplied = false;
+        client.addEventListener("message", async event => {
+          const data =
+            typeof event.data === "string" ? JSON.parse(event.data) : null;
+          if (data?.type !== "user_message" || hasReplied) return;
+          hasReplied = true;
+          const message =
+            agentId === "streamed_first_reply"
+              ? "First streamed reply"
+              : agentId === "streamed_first_message"
+                ? (config.first_message ?? "")
+                : "Production streamed reply";
+
+          await sendStreamedAgentResponse(client, message, 2);
         });
       }
       if (agentId === "external_agent") {


### PR DESCRIPTION
### Summary
Fix the first agent reply being dropped in text-only widget conversations when a configured first message is interrupted.

### Root cause
[xi PR #47525](https://github.com/elevenlabs/xi/pull/47525) made backend first-message generation asynchronous. Although the widget had already displayed the greeting locally, its server-side turn could still be running when the user replied. If interrupted, its final agent_response never arrived, causing the widget to mistake and suppress the agent’s actual reply.

This exposed a latent widget bug from [packages PR #345](https://github.com/elevenlabs/packages/pull/345): the widget continued suppressing agent streams until that final greeting response arrived. When it never arrived, the real reply was suppressed too.

Before

https://github.com/user-attachments/assets/0ed330c9-2473-41bd-b0e1-c23019c91e92

After

https://github.com/user-attachments/assets/a56fab30-1bba-48bc-8fd1-97e63e334d50

### Changes
- Release the first-message guard when the greeting stream begins.
- Continue suppressing the configured greeting’s final event (event_id: 1) when it arrives.
- Regression tests