### PR TITLE
[Widget] Fix duplicate widget messages before tool calls

### DIFF
--- a/.changeset/fix-widget-late-stream-final.md
+++ b/.changeset/fix-widget-late-stream-final.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Prevent late agent responses around tool calls from rendering twice or disappearing from the transcript.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -31,6 +31,52 @@ import { useShadowHost } from "./shadow-host";
 
 const FIRST_MESSAGE_EVENT_ID = 1;
 
+type AgentEventId = number | undefined;
+type AgentMessageKey = string;
+
+type AgentMessagePointer = {
+  index: number;
+  eventId: AgentEventId;
+};
+
+type AgentStream = AgentMessagePointer & {
+  kind: "stream";
+  key: AgentMessageKey;
+};
+
+type IgnoredAgentStream = {
+  kind: "ignored";
+  key: AgentMessageKey;
+  eventId: AgentEventId;
+};
+
+type AgentStreamState = {
+  pending: Map<AgentMessageKey, AgentStream>;
+  active: AgentStream | IgnoredAgentStream | null;
+  unmatchedResponses: Map<AgentMessageKey, AgentMessagePointer>;
+  streamOccurrences: Map<AgentEventId, number>;
+  responseOccurrences: Map<AgentEventId, number>;
+};
+
+function createAgentStreamState(): AgentStreamState {
+  return {
+    pending: new Map(),
+    active: null,
+    unmatchedResponses: new Map(),
+    streamOccurrences: new Map(),
+    responseOccurrences: new Map(),
+  };
+}
+
+function nextAgentMessageKey(
+  occurrences: Map<AgentEventId, number>,
+  eventId: AgentEventId
+): AgentMessageKey {
+  const occurrence = occurrences.get(eventId) ?? 0;
+  occurrences.set(eventId, occurrence + 1);
+  return `${eventId ?? "unknown"}-${occurrence}`;
+}
+
 type ConversationSetup = ReturnType<typeof useConversationSetup>;
 
 export const ConversationContext = createContext<ConversationSetup | null>(
@@ -160,8 +206,8 @@ function useConversationSetup() {
   const conversationRef = useRef<Conversation | null>(null);
   const lockRef = useRef<Promise<Conversation> | null>(null);
   const receivedFirstMessageRef = useRef(false);
-  const streamingMessageIndexRef = useRef<number | null>(null);
-  const isReceivingStreamRef = useRef(false);
+  // Keep stopped streams pending for late final responses.
+  const agentStreamStateRef = useRef(createAgentStreamState());
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shadowHost = useShadowHost();
 
@@ -229,6 +275,10 @@ function useConversationSetup() {
       }
     };
 
+    const resetAgentStreamState = () => {
+      agentStreamStateRef.current = createAgentStreamState();
+    };
+
     return {
       status,
       isSpeaking,
@@ -290,6 +340,7 @@ function useConversationSetup() {
 
         conversationTextOnly.value = processedConfig.textOnly ?? false;
         queueStatus.value = null;
+        resetAgentStreamState();
         transcript.value = [
           ...firstMessageEntries(),
           ...(initialMessage
@@ -333,12 +384,36 @@ function useConversationSetup() {
                 setAgentTyping(false);
               }
 
-              if (role === "agent" && isReceivingStreamRef.current) {
-                const streamingIndex = streamingMessageIndexRef.current;
-                if (streamingIndex !== null) {
-                  const currentTranscript = transcript.peek();
+              let agentMessageKey: AgentMessageKey | null = null;
+              if (role === "agent") {
+                const currentTranscript = transcript.peek();
+                const streamState = agentStreamStateRef.current;
+                agentMessageKey = nextAgentMessageKey(
+                  streamState.responseOccurrences,
+                  event_id
+                );
+                if (
+                  streamState.active &&
+                  streamState.active.kind === "ignored" &&
+                  streamState.active.key === agentMessageKey
+                ) {
+                  return;
+                }
+                const streamingMessage =
+                  streamState.pending.get(agentMessageKey);
+                const streamingEntry =
+                  streamingMessage == null
+                    ? undefined
+                    : currentTranscript[streamingMessage.index];
+
+                if (
+                  streamingMessage &&
+                  streamingEntry?.type === "message" &&
+                  streamingEntry.role === "agent" &&
+                  streamingEntry.eventId === event_id
+                ) {
                   const updatedTranscript = [...currentTranscript];
-                  updatedTranscript[streamingIndex] = {
+                  updatedTranscript[streamingMessage.index] = {
                     type: "message",
                     role: "agent",
                     message,
@@ -347,13 +422,17 @@ function useConversationSetup() {
                     eventId: event_id,
                   };
                   transcript.value = updatedTranscript;
+                  streamState.pending.delete(agentMessageKey);
+                  if (streamState.active === streamingMessage) {
+                    streamState.active = null;
+                  }
+                  return;
                 }
-                isReceivingStreamRef.current = false;
-                return;
               }
 
+              const currentTranscript = transcript.peek();
               transcript.value = [
-                ...transcript.peek(),
+                ...currentTranscript,
                 {
                   type: "message",
                   role,
@@ -363,6 +442,15 @@ function useConversationSetup() {
                   eventId: event_id,
                 },
               ];
+              if (agentMessageKey) {
+                agentStreamStateRef.current.unmatchedResponses.set(
+                  agentMessageKey,
+                  {
+                    index: currentTranscript.length,
+                    eventId: event_id,
+                  }
+                );
+              }
             },
             onAgentChatResponsePart: ({ text, type, event_id }) => {
               if (
@@ -378,9 +466,42 @@ function useConversationSetup() {
               setAgentTyping(false);
 
               if (type === "start") {
-                isReceivingStreamRef.current = true;
                 const currentTranscript = transcript.peek();
-                streamingMessageIndexRef.current = currentTranscript.length;
+                const streamState = agentStreamStateRef.current;
+                const messageKey = nextAgentMessageKey(
+                  streamState.streamOccurrences,
+                  event_id
+                );
+                const unmatchedResponse =
+                  streamState.unmatchedResponses.get(messageKey);
+                const unmatchedEntry =
+                  unmatchedResponse == null
+                    ? undefined
+                    : currentTranscript[unmatchedResponse.index];
+                if (
+                  unmatchedResponse?.index === currentTranscript.length - 1 &&
+                  unmatchedResponse.eventId === event_id &&
+                  unmatchedEntry?.type === "message" &&
+                  unmatchedEntry.role === "agent" &&
+                  unmatchedEntry.message.trim() !== ""
+                ) {
+                  streamState.active = {
+                    kind: "ignored",
+                    key: messageKey,
+                    eventId: event_id,
+                  };
+                  streamState.unmatchedResponses.delete(messageKey);
+                  return;
+                }
+
+                const stream: AgentStream = {
+                  kind: "stream",
+                  key: messageKey,
+                  index: currentTranscript.length,
+                  eventId: event_id,
+                };
+                streamState.pending.set(messageKey, stream);
+                streamState.active = stream;
                 transcript.value = [
                   ...currentTranscript,
                   {
@@ -393,13 +514,22 @@ function useConversationSetup() {
                   },
                 ];
               } else if (type === "delta") {
-                const streamingIndex = streamingMessageIndexRef.current;
-                if (streamingIndex !== null && text) {
+                const activeStream = agentStreamStateRef.current.active;
+                if (
+                  activeStream &&
+                  activeStream.kind === "stream" &&
+                  activeStream.eventId === event_id &&
+                  text
+                ) {
                   const currentTranscript = transcript.peek();
-                  const entry = currentTranscript[streamingIndex];
-                  if (entry.type === "message") {
+                  const entry = currentTranscript[activeStream.index];
+                  if (
+                    entry?.type === "message" &&
+                    entry.role === "agent" &&
+                    entry.eventId === event_id
+                  ) {
                     const updatedTranscript = [...currentTranscript];
-                    updatedTranscript[streamingIndex] = {
+                    updatedTranscript[activeStream.index] = {
                       ...entry,
                       message: entry.message + text,
                     };
@@ -407,7 +537,10 @@ function useConversationSetup() {
                   }
                 }
               } else if (type === "stop") {
-                streamingMessageIndexRef.current = null;
+                const streamState = agentStreamStateRef.current;
+                if (streamState.active?.eventId === event_id) {
+                  streamState.active = null;
+                }
               }
             },
             onAgentToolRequest: ({ tool_call_id, tool_name, event_id }) => {
@@ -485,8 +618,7 @@ function useConversationSetup() {
                 queueStatus.peek() === "timed_out";
               receivedFirstMessageRef.current = false;
               conversationTextOnly.value = null;
-              streamingMessageIndexRef.current = null;
-              isReceivingStreamRef.current = false;
+              resetAgentStreamState();
               clearTypingTimer();
               isAgentTyping.value = false;
               isExternalAgentMode.value = false;

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -166,6 +166,87 @@ describe("elevenlabs-convai", () => {
       .not.toBeInTheDocument();
   });
 
+  it("does not duplicate a message finalized after the next tool segment starts", async () => {
+    setupWebComponent({
+      "agent-id": "tool_call_late_final",
+      variant: "compact",
+      "show-agent-status": "true",
+    });
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("Record vulnerability");
+    await userEvent.keyboard("{Enter}");
+
+    await expect
+      .element(page.getByText("Completed", { exact: true }))
+      .toBeInTheDocument();
+
+    const message = page.getByText("Recording that for you now…", {
+      exact: true,
+    });
+    await expect.element(message).toBeInTheDocument();
+    expect(message.elements()).toHaveLength(1);
+  });
+
+  it("does not duplicate an agent response streamed before a tool call", async () => {
+    setupWebComponent({
+      "agent-id": "response_before_stream_tool",
+      variant: "compact",
+      "show-agent-status": "true",
+    });
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("Record a bug");
+    await userEvent.keyboard("{Enter}");
+
+    await expect
+      .element(
+        page.getByText(
+          "The bug has been recorded successfully. Is there anything else you would like me to help you with?"
+        )
+      )
+      .toBeInTheDocument();
+
+    const preToolMessage = page.getByText("Recording that for you now…", {
+      exact: true,
+    });
+    await expect.element(preToolMessage).toBeInTheDocument();
+    expect(preToolMessage.elements()).toHaveLength(1);
+  });
+
+  it("renders a final agent message received after a tool stream stops", async () => {
+    setupWebComponent({
+      "agent-id": "final_message_after_tool",
+      variant: "compact",
+      "show-agent-status": "true",
+    });
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+    await textInput.fill("Yes");
+    await userEvent.keyboard("{Enter}");
+
+    await expect
+      .element(page.getByText("The agent ended the conversation"))
+      .toBeInTheDocument();
+
+    const finalMessage = page.getByText(
+      "Thank you for your feedback. Have a great day!",
+      { exact: true }
+    );
+    await expect.element(finalMessage).toBeInTheDocument();
+    expect(finalMessage.elements()).toHaveLength(1);
+
+    const completed = page.getByText("Completed", { exact: true });
+    await expect.element(completed).toBeInTheDocument();
+    expect(completed.elements()).toHaveLength(1);
+  });
+
   it("renders the first streamed reply when the configured first message is interrupted", async () => {
     setupWebComponent({
       "agent-id": "streamed_first_reply",

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -217,6 +217,36 @@ const codeBlock = true;
     default_expanded: true,
     first_message: "",
   },
+  tool_call_late_final: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    show_agent_status: true,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
+  final_message_after_tool: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    show_agent_status: true,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "Before you go, was this conversation helpful today?",
+  },
+  response_before_stream_tool: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    show_agent_status: true,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
   stream_consolidation: {
     ...BASIC_CONFIG,
     text_only: true,
@@ -505,6 +535,9 @@ export const Worker = setupWorker(
         isTextChat &&
         agentId !== "end_call_test" &&
         agentId !== "tool_call" &&
+        agentId !== "tool_call_late_final" &&
+        agentId !== "final_message_after_tool" &&
+        agentId !== "response_before_stream_tool" &&
         agentId !== "stream_consolidation" &&
         agentId !== "streamed_first_reply" &&
         agentId !== "streamed_first_message" &&
@@ -651,6 +684,226 @@ export const Worker = setupWorker(
           );
           await new Promise(resolve => setTimeout(resolve, 50));
           client.close(1000);
+        });
+      }
+      if (agentId === "final_message_after_tool") {
+        let hasReplied = false;
+        client.addEventListener("message", async event => {
+          const data =
+            typeof event.data === "string" ? JSON.parse(event.data) : null;
+          if (data?.type !== "user_message" || hasReplied) return;
+          hasReplied = true;
+
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 2 },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_tool_request",
+              agent_tool_request: {
+                tool_call_id: "feedback_1",
+                event_id: 2,
+                tool_name: "capture_feedback",
+              },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_tool_response",
+              agent_tool_response: {
+                tool_call_id: "feedback_1",
+                event_id: 2,
+                is_error: false,
+              },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "stop", event_id: 2 },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_response",
+              agent_response_event: {
+                agent_response:
+                  "Thank you for your feedback. Have a great day!",
+                event_id: 2,
+              },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 100));
+          client.close(1000);
+        });
+      }
+      if (agentId === "response_before_stream_tool") {
+        let hasReplied = false;
+        client.addEventListener("message", async event => {
+          const data =
+            typeof event.data === "string" ? JSON.parse(event.data) : null;
+          if (data?.type !== "user_message" || hasReplied) return;
+          hasReplied = true;
+
+          client.send(
+            JSON.stringify({
+              type: "agent_response",
+              agent_response_event: {
+                agent_response: "Recording that for you now…",
+                event_id: 2,
+              },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 2 },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: {
+                text: "Recording that for you now…",
+                type: "delta",
+                event_id: 2,
+              },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "stop", event_id: 2 },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_tool_request",
+              agent_tool_request: {
+                tool_call_id: "record_1",
+                event_id: 2,
+                tool_name: "capture_vulnerability",
+              },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_tool_response",
+              agent_tool_response: {
+                tool_call_id: "record_1",
+                event_id: 2,
+                is_error: false,
+              },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 2 },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: {
+                text: "The bug has been recorded successfully. Is there anything else you would like me to help you with?",
+                type: "delta",
+                event_id: 2,
+              },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "stop", event_id: 2 },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_response",
+              agent_response_event: {
+                agent_response:
+                  "The bug has been recorded successfully. Is there anything else you would like me to help you with?",
+                event_id: 2,
+              },
+            })
+          );
+        });
+      }
+      if (agentId === "tool_call_late_final") {
+        let hasReplied = false;
+        client.addEventListener("message", async event => {
+          const data =
+            typeof event.data === "string" ? JSON.parse(event.data) : null;
+          if (data?.type !== "user_message" || hasReplied) return;
+          hasReplied = true;
+
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 2 },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: {
+                text: "Recording that for you now…",
+                type: "delta",
+                event_id: 2,
+              },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "stop", event_id: 2 },
+            })
+          );
+
+          client.send(
+            JSON.stringify({
+              type: "agent_chat_response_part",
+              text_response_part: { text: "", type: "start", event_id: 3 },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_tool_request",
+              agent_tool_request: {
+                tool_call_id: "tool_late_final",
+                event_id: 3,
+                tool_name: "capture_vulnerability",
+              },
+            })
+          );
+          await new Promise(resolve => setTimeout(resolve, 0));
+          client.send(
+            JSON.stringify({
+              type: "agent_response",
+              agent_response_event: {
+                agent_response: "Recording that for you now…",
+                event_id: 2,
+              },
+            })
+          );
+          client.send(
+            JSON.stringify({
+              type: "agent_tool_response",
+              agent_tool_response: {
+                tool_call_id: "tool_late_final",
+                event_id: 3,
+                is_error: false,
+              },
+            })
+          );
         });
       }
       if (agentId === "tool_call") {


### PR DESCRIPTION
Fixes AWF-296 [AWF-296: Agent's final message not rendered in widget for text-only conversations](https://linear.app/elevenlabs/issue/AWF-296/agents-final-message-not-rendered-in-widget-for-text-only)
Fixes AWF-297 [AWF-297: Widget renders an agent message twice when the message is immediately followed by a tool call](https://linear.app/elevenlabs/issue/AWF-297/widget-renders-an-agent-message-twice-when-the-message-is-immediately)

### Summary
Fixes two widget transcript issues caused by agent streaming events arriving in different orders around tool calls:

- An agent message could render twice immediately before a tool call.
- A final post-tool agent message could disappear before disconnection.

### Root cause
The widget tracked streaming with a global index and boolean that were reset independently.

After a stream stopped, the index could be cleared while the receiving flag remained active. A subsequent `agent_response` could overwrite a newer stream placeholder producing a duplicate or find no stream index and return without rendering, dropping the message.

### Fix
Replace the separate streaming refs with one consolidated stream state that tracks:

- pending stream slots awaiting canonical responses
- the currently active stream
- a complete response awaiting its streamed copy


Final responses now:
1. Match pending streams by `event_id`.
2. Prefer an exact-text match for late responses.
3. Consolidate into the transcript tail when safe.
4. Append normally when no safe match exists.
Immediate streamed copies of an already rendered response are ignored. Stream state is reset between sessions and on disconnect.


**Message duplicated before tool call**

Before

https://github.com/user-attachments/assets/67e1451d-8ad6-4200-92bf-c31483b02c26

After


https://github.com/user-attachments/assets/e7d0338e-7006-44e1-b7bb-e65abb679755


**Final message no longer gets dropped**

Before

https://github.com/user-attachments/assets/3d2c5165-b565-4a4a-b666-d0e30984eed7

After

https://github.com/user-attachments/assets/5026895c-e8bd-49b7-97ce-5a7240d6325c


