### PR TITLE
Export MessageAttachment from @elevenlabs/client entry point

### DIFF
--- a/.changeset/witty-doors-export.md
+++ b/.changeset/witty-doors-export.md
@@ -1,5 +1,5 @@
 ---
-"@elevenlabs/client": patch
+"@elevenlabs/client": minor
 ---
 
 Re-export the `MessageAttachment` type from the package entry point so consumers can `import type { MessageAttachment } from "@elevenlabs/client"` instead of deriving it from the `onMessage` callback signature.

--- a/.changeset/witty-doors-export.md
+++ b/.changeset/witty-doors-export.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Re-export the `MessageAttachment` type from the package entry point so consumers can `import type { MessageAttachment } from "@elevenlabs/client"` instead of deriving it from the `onMessage` callback signature.

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -49,6 +49,7 @@ export type {
   Mode,
   Status,
   Callbacks,
+  MessageAttachment,
   MCPToolApprovalRequest,
   MCPToolApprovalRequestContext,
   MCPToolApprovalHandler,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,6 +14,7 @@ export type {
   MCPToolApprovalRequest,
   MCPToolApprovalRequestContext,
   Callbacks,
+  MessageAttachment,
   Status,
   AudioWorkletConfig,
   MultimodalMessageInput,


### PR DESCRIPTION
Export the `MessageAttachment` type from the package entry point so consumers can `import type { MessageAttachment } from "@elevenlabs/client"` instead of deriving it from the `onMessage` callback signature.

`MessageAttachment` was added to the client's `types.ts` in #988 but never exported from the package root, so consumers cannot `import type { MessageAttachment } from "@elevenlabs/client"`. The xi app currently derives it via `Parameters<NonNullable<HookCallbacks["onMessage"]>>[0]["attachments"]` gymnastics (see [elevenlabs/xi#48940](https://github.com/elevenlabs/xi/pull/48940)).

This follows the existing export chain for `types.ts` symbols (`types.ts` -> `BaseConversation.ts` re-export block -> `index.ts`). Type-only change, patch changeset.

## Testing

- `pnpm --filter @elevenlabs/client build` (tsc + rolldown), `lint:es`, `lint:prettier` all pass
- unit tests: 226 passed (`vitest run --project "Unit tests"`)