### PR TITLE
fix(client): pass `libsampleratePath` to MediaDeviceOutput

### DIFF
--- a/packages/client/src/platform/web/VoiceSessionSetup.ts
+++ b/packages/client/src/platform/web/VoiceSessionSetup.ts
@@ -59,6 +59,7 @@ async function setupWebSocketIO(
       ...connection.outputFormat,
       outputDeviceId: options.outputDeviceId,
       workletPaths: options.workletPaths,
+      libsampleratePath: options.libsampleratePath,
       audioContext: audioContext ?? undefined,
     }),
   ]);


### PR DESCRIPTION
Should fix https://github.com/elevenlabs/packages/issues/1002, see the issue for context.