### PR TITLE
[Widget] Render agent message attachments

### DIFF
--- a/.changeset/agent-message-attachments-widget.md
+++ b/.changeset/agent-message-attachments-widget.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/convai-widget-core": patch
+---
+
+Render `attachments` from agent messages in the widget transcript. Files with an https url show as an inline image when their mime type is an image, and as a download link otherwise. Attachment-only replies, which arrive with no text, now render instead of being dropped.

--- a/.changeset/export-message-attachment-type.md
+++ b/.changeset/export-message-attachment-type.md
@@ -1,0 +1,5 @@
+---
+"@elevenlabs/client": patch
+---
+
+Export the `MessagePayload` and `MessageAttachment` types from the package root so consumers can type `onMessage` handlers and agent message attachments.

--- a/packages/client/src/BaseConversation.ts
+++ b/packages/client/src/BaseConversation.ts
@@ -49,6 +49,8 @@ export type {
   Mode,
   Status,
   Callbacks,
+  MessagePayload,
+  MessageAttachment,
   MCPToolApprovalRequest,
   MCPToolApprovalRequestContext,
   MCPToolApprovalHandler,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,6 +14,8 @@ export type {
   MCPToolApprovalRequest,
   MCPToolApprovalRequestContext,
   Callbacks,
+  MessagePayload,
+  MessageAttachment,
   Status,
   AudioWorkletConfig,
   MultimodalMessageInput,

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -1,5 +1,6 @@
 import {
   Conversation,
+  MessageAttachment,
   Mode,
   Role,
   SendUserMessageOptions,
@@ -103,6 +104,8 @@ export type TranscriptEntry =
       conversationIndex: number;
       eventId?: number;
       fileInput?: TranscriptFileInput | null;
+      /** Files sent with an agent message, e.g. relayed from a human agent. */
+      attachments?: MessageAttachment[];
     }
   | {
       type: "agent_tool_request";
@@ -368,7 +371,7 @@ function useConversationSetup() {
             onCanSendFeedbackChange: props => {
               canSendFeedback.value = props.canSendFeedback;
             },
-            onMessage: ({ role, message, event_id }) => {
+            onMessage: ({ role, message, event_id, attachments }) => {
               if (
                 firstMessage.peek() &&
                 conversationTextOnly.peek() === true &&
@@ -420,6 +423,7 @@ function useConversationSetup() {
                     isText: conversationTextOnly.peek() === true,
                     conversationIndex: conversationIndex.peek(),
                     eventId: event_id,
+                    attachments,
                   };
                   transcript.value = updatedTranscript;
                   streamState.pending.delete(agentMessageKey);
@@ -440,6 +444,7 @@ function useConversationSetup() {
                   isText: conversationTextOnly.peek() === true,
                   conversationIndex: conversationIndex.peek(),
                   eventId: event_id,
+                  attachments,
                 },
               ];
               if (agentMessageKey) {

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -370,6 +370,15 @@ const codeBlock = true;
     default_expanded: true,
     first_message: "",
   },
+  agent_attachments: {
+    ...BASIC_CONFIG,
+    text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+    first_message: "",
+  },
   text_and_voice: {
     ...BASIC_CONFIG,
     text_only: false,
@@ -459,7 +468,27 @@ async function sendStreamedAgentResponse(
   );
 }
 
+const ATTACHMENT_HOST = "https://files.convai.test";
+
+function attachmentImage(label: string) {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200">
+  <rect width="320" height="200" fill="#1f2937"/>
+  <text x="160" y="108" fill="#f9fafb" font-family="sans-serif" font-size="28" text-anchor="middle">${label}</text>
+</svg>`;
+}
+
 export const Worker = setupWorker(
+  http.get(`${ATTACHMENT_HOST}/:fileName`, ({ params }) => {
+    const fileName = String(params.fileName);
+    if (!fileName.endsWith(".svg")) {
+      return new HttpResponse("mock file", {
+        headers: { "Content-Type": "application/octet-stream" },
+      });
+    }
+    return new HttpResponse(attachmentImage(fileName.replace(".svg", "")), {
+      headers: { "Content-Type": "image/svg+xml" },
+    });
+  }),
   http.get<{ agentId: string }>(
     `${import.meta.env.VITE_SERVER_URL_US}/v1/convai/agents/:agentId/widget`,
     ({ params }) => {
@@ -544,7 +573,8 @@ export const Worker = setupWorker(
         agentId !== "streamed_first_message_with_final" &&
         agentId !== "file_upload" &&
         agentId !== "no_file_upload" &&
-        agentId !== "external_agent"
+        agentId !== "external_agent" &&
+        agentId !== "agent_attachments"
       ) {
         const agentResponse =
           agentId === "markdown_agent_response"
@@ -1050,6 +1080,57 @@ export const Worker = setupWorker(
                 : "Production streamed reply";
 
           await sendStreamedAgentResponse(client, message, 2);
+        });
+      }
+      if (agentId === "agent_attachments") {
+        // Human-agent replies relay files: the first turn pairs text with an
+        // image and a PDF, the second is attachment-only with no text at all.
+        let replies = 0;
+        client.addEventListener("message", async event => {
+          const data =
+            typeof event.data === "string" ? JSON.parse(event.data) : null;
+          if (data?.type !== "user_message") return;
+
+          replies++;
+          client.send(
+            JSON.stringify({
+              type: "agent_response",
+              agent_response_event:
+                replies === 1
+                  ? {
+                      agent_response: "Here is the receipt you asked for.",
+                      event_id: replies + 1,
+                      attachments: [
+                        {
+                          url: `${ATTACHMENT_HOST}/receipt.svg`,
+                          name: "receipt.svg",
+                          mime_type: "image/svg+xml",
+                        },
+                        {
+                          url: `${ATTACHMENT_HOST}/invoice.pdf`,
+                          name: "invoice.pdf",
+                          mime_type: "application/pdf",
+                        },
+                      ],
+                    }
+                  : {
+                      agent_response: "",
+                      event_id: replies + 1,
+                      attachments: [
+                        {
+                          url: `${ATTACHMENT_HOST}/diagram.svg`,
+                          name: "diagram.svg",
+                          mime_type: "image/svg+xml",
+                        },
+                        {
+                          url: "http://insecure.example.com/leak.png",
+                          name: "leak.png",
+                          mime_type: "image/png",
+                        },
+                      ],
+                    },
+            })
+          );
         });
       }
       if (agentId === "external_agent") {

--- a/packages/convai-widget-core/src/utils/display-transcript.ts
+++ b/packages/convai-widget-core/src/utils/display-transcript.ts
@@ -1,4 +1,4 @@
-import type { Role } from "@elevenlabs/client";
+import type { MessageAttachment, Role } from "@elevenlabs/client";
 import type {
   TranscriptEntry,
   TranscriptFileInput,
@@ -24,6 +24,7 @@ export type DisplayTranscriptEntry =
       eventId?: number;
       toolStatus?: ToolCallStatusType;
       fileInput?: TranscriptFileInput | null;
+      attachments?: MessageAttachment[];
     }
   | {
       type: "disconnection";
@@ -137,11 +138,13 @@ export function buildDisplayTranscript(
       continue;
     }
 
-    // Skip empty agent messages unless they have a tool status to display
+    // Skip empty agent messages unless they carry attachments or a tool status
+    // to display. Human-agent replies that are only files arrive with no text.
     if (
       entry.type === "message" &&
       entry.role === "agent" &&
       !entry.message &&
+      !entry.attachments?.length &&
       !(
         config.showAgentStatus &&
         entry.eventId != null &&
@@ -166,7 +169,12 @@ export function buildDisplayTranscript(
       prev.role === entry.role &&
       !prev.message.trim()
     ) {
-      result[result.length - 1] = entry;
+      // An attachment-only placeholder has no text but still carries files,
+      // so keep them when the text message folds over it.
+      result[result.length - 1] =
+        prev.attachments?.length && !entry.attachments?.length
+          ? { ...entry, attachments: prev.attachments }
+          : entry;
       continue;
     }
 

--- a/packages/convai-widget-core/src/widget/AgentMessageAttachments.test.ts
+++ b/packages/convai-widget-core/src/widget/AgentMessageAttachments.test.ts
@@ -1,0 +1,64 @@
+import { page, userEvent } from "vitest/browser";
+import { describe, it, beforeAll, expect, afterAll } from "vitest";
+import { Worker } from "../mocks/browser";
+import { setupWebComponent } from "../mocks/web-component";
+
+describe("Agent message attachments", () => {
+  beforeAll(() => Worker.start({ quiet: true }));
+  afterAll(() => Worker.stop());
+
+  it("renders images inline and other files as download links", async () => {
+    setupWebComponent({
+      "agent-id": "agent_attachments",
+      variant: "compact",
+    });
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+
+    await textInput.fill("send me the receipt");
+    await userEvent.keyboard("{Enter}");
+
+    await expect
+      .element(page.getByText("Here is the receipt you asked for."))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("img", { name: "receipt.svg" }))
+      .toBeInTheDocument();
+
+    const pdfLink = page.getByRole("link", { name: "invoice.pdf" });
+    await expect.element(pdfLink).toBeInTheDocument();
+    await expect
+      .element(pdfLink)
+      .toHaveAttribute("href", "https://files.convai.test/invoice.pdf");
+  });
+
+  it("renders an attachment-only message and drops non-https urls", async () => {
+    setupWebComponent({
+      "agent-id": "agent_attachments",
+      variant: "compact",
+    });
+
+    const textInput = page.getByRole("textbox", {
+      name: "Text message input",
+    });
+
+    await textInput.fill("send me the receipt");
+    await userEvent.keyboard("{Enter}");
+    await expect
+      .element(page.getByRole("img", { name: "receipt.svg" }))
+      .toBeInTheDocument();
+
+    // The second reply carries no text at all, so the bubble exists only
+    // because of its attachments.
+    await textInput.fill("anything else?");
+    await userEvent.keyboard("{Enter}");
+    await expect
+      .element(page.getByRole("img", { name: "diagram.svg" }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("img", { name: "leak.png" }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
+++ b/packages/convai-widget-core/src/widget/TranscriptMessage.tsx
@@ -41,6 +41,9 @@ function AgentMessageBubble({
   const displayMessage = shouldStripAudioTags
     ? stripAudioTags(entry.message)
     : entry.message;
+  const attachments = entry.attachments?.filter(attachment =>
+    isHttpsUrl(attachment.url)
+  );
 
   return (
     <div className="pr-8">
@@ -52,6 +55,24 @@ function AgentMessageBubble({
           {displayMessage}
         </WidgetStreamdown>
       )}
+      {!!attachments?.length && (
+        <div
+          className={clsx(
+            "flex flex-col items-start gap-1.5",
+            displayMessage && "mt-2"
+          )}
+        >
+          {attachments.map((attachment, index) => (
+            <FileAttachment
+              key={`${index}-${attachment.url}`}
+              fileName={attachment.name}
+              mimeType={attachment.mime_type ?? ""}
+              previewUrl={attachment.url}
+              href={attachment.url}
+            />
+          ))}
+        </div>
+      )}
       {entry.toolStatus && (
         <div className={displayMessage ? "mt-2" : undefined}>
           <ToolCallMessage status={entry.toolStatus} />
@@ -59,6 +80,14 @@ function AgentMessageBubble({
       )}
     </div>
   );
+}
+
+function isHttpsUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function UserMessageBubble({
@@ -111,33 +140,68 @@ function UserMessageBubble({
   );
 }
 
+/**
+ * Renders one file bubble. `href` marks the file as remotely hosted (an agent
+ * attachment rather than the user's own pending upload), so it opens in a new
+ * tab and gets interactive styling instead of the user bubble's accent fill.
+ */
 function FileAttachment({
   fileName,
   mimeType,
   previewUrl,
+  href,
 }: {
   fileName: string;
   mimeType: string;
   previewUrl: string | null;
+  href?: string;
 }) {
   const isImage = isImageMimeType(mimeType);
 
   if (isImage && previewUrl) {
-    return (
+    const image = (
+      <img
+        src={previewUrl}
+        alt={fileName}
+        className="max-w-[180px] rounded-input object-cover"
+      />
+    );
+
+    return href ? (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="rounded-bubble border border-base-border shadow-sm p-1 focus-ring"
+      >
+        {image}
+      </a>
+    ) : (
       <div className="rounded-bubble border border-base-border shadow-sm p-1">
-        <img
-          src={previewUrl}
-          alt={fileName}
-          className="max-w-[180px] rounded-input object-cover"
-        />
+        {image}
       </div>
     );
   }
 
-  return (
-    <div className="flex items-center gap-2 px-3 py-2.5 rounded-bubble bg-accent text-accent-primary">
+  const content = (
+    <>
       <FileDocIcon />
       <span className="truncate text-sm">{fileName}</span>
+    </>
+  );
+
+  return href ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 px-3 py-2.5 rounded-bubble border border-base-border bg-base text-base-primary hover:bg-base-hover active:bg-base-active transition-colors duration-200 focus-ring"
+    >
+      {content}
+    </a>
+  ) : (
+    <div className="flex items-center gap-2 px-3 py-2.5 rounded-bubble bg-accent text-accent-primary">
+      {content}
     </div>
   );
 }


### PR DESCRIPTION
Renders `attachments` from `agent_response` events in the embeddable widget chat, matching the xi app behaviour from [#48940](https://github.com/elevenlabs/xi/pull/48940). Files relayed on an agent message - e.g. from a human agent takeover - now show up in the transcript instead of being silently dropped.

## Behaviour

- Only `https` urls render. Anything else is filtered out.
- `mime_type` starting with `image/` renders inline, everything else becomes a download link with the file name.
- Renders even when the message text is empty.

Note: these urls are not gated on `markdown_link_allowed_hosts`, which is the same choice the app render makes. That allowlist exists for agent-*authored* markdown links; `attachments` is a server-populated field on the relay path, not something the model emits. Flagging it since it's the one security-adjacent judgement call here.

## Visual proof

captured from the real widget driven by the mock backend: 

<!-- TODO: attach agent-attachments-with-text.png and agent-attachments-only.png -->
<img width="415" height="897" alt="agent-attachments-only" src="https://github.com/user-attachments/assets/571eb121-17bd-4444-86d4-df37246f3f11" />

<img width="415" height="897" alt="agent-attachments-with-text" src="https://github.com/user-attachments/assets/a8549120-3991-40af-a69b-372aae184bf2" />
