### PR TITLE
test: lock in that "disconnecting" outlives the audio pipeline teardown

### DIFF
--- a/packages/client/src/VoiceConversation.test.ts
+++ b/packages/client/src/VoiceConversation.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("livekit-client", () => ({
+  Room: vi.fn(),
+  RoomEvent: {},
+  Track: { Kind: { Audio: "audio" }, Source: { Microphone: "microphone" } },
+  ConnectionState: {},
+  createLocalAudioTrack: vi.fn(),
+}));
+
+import { VoiceConversation } from "./VoiceConversation.js";
+import { setSetupStrategy } from "./platform/VoiceSessionSetup.js";
+import type { VoiceSessionSetupResult } from "./platform/VoiceSessionSetup.js";
+import type { BaseConnection } from "./utils/BaseConnection.js";
+import type { Callbacks } from "./types.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+function fakeConnection() {
+  return {
+    conversationId: "conversation-1",
+    onMessage: () => {},
+    onOutgoingMessage: () => {},
+    onDisconnect: () => {},
+    onModeChange: () => {},
+    close: vi.fn(),
+    sendMessage: () => {},
+  } as unknown as BaseConnection;
+}
+
+/**
+ * Registers a setup strategy whose teardown only finishes when the returned
+ * `finishDetach` is called, standing in for a platform tearing down its audio
+ * pipeline (releasing a wake lock, stopping a native audio session, ...).
+ */
+function setupStrategyWithGatedDetach() {
+  const detached = deferred<void>();
+  const detach = vi.fn(() => detached.promise);
+  const input = { close: vi.fn(async () => {}) };
+  const output = { close: vi.fn(async () => {}) };
+
+  setSetupStrategy(
+    async () =>
+      ({
+        connection: fakeConnection(),
+        input,
+        output,
+        playbackEventTarget: null,
+        detach,
+      }) as unknown as VoiceSessionSetupResult
+  );
+
+  return { detach, input, output, finishDetach: detached.resolve };
+}
+
+function statusRecorder() {
+  const statuses: string[] = [];
+  const onStatusChange: NonNullable<Callbacks["onStatusChange"]> = ({
+    status,
+  }) => {
+    statuses.push(status);
+  };
+  return { statuses, onStatusChange };
+}
+
+async function startSession(options: Record<string, unknown> = {}) {
+  return VoiceConversation.startSession({
+    agentId: "agent-1",
+    connectionType: "webrtc",
+    ...options,
+  } as Parameters<typeof VoiceConversation.startSession>[0]);
+}
+
+describe("VoiceConversation teardown", () => {
+  it("stays in disconnecting until the platform has detached the audio pipeline", async () => {
+    // Reaching "disconnected" while the platform still owns the microphone
+    // tells consumers the session is fully gone, so they re-enable their
+    // "start" affordance and the next startSession() races this teardown.
+    const { detach, input, output, finishDetach } =
+      setupStrategyWithGatedDetach();
+    const { statuses, onStatusChange } = statusRecorder();
+    const onDisconnect = vi.fn();
+
+    const conversation = await startSession({ onStatusChange, onDisconnect });
+    expect(statuses).toEqual(["connecting", "connected"]);
+
+    const ending = conversation.endSession();
+    await flush();
+
+    expect(detach).toHaveBeenCalledTimes(1);
+    expect(statuses).toEqual(["connecting", "connected", "disconnecting"]);
+    expect(onDisconnect).not.toHaveBeenCalled();
+    // The controllers close only after the platform teardown has finished.
+    expect(input.close).not.toHaveBeenCalled();
+    expect(output.close).not.toHaveBeenCalled();
+
+    finishDetach();
+    await ending;
+
+    expect(statuses).toEqual([
+      "connecting",
+      "connected",
+      "disconnecting",
+      "disconnected",
+    ]);
+    expect(onDisconnect).toHaveBeenCalledWith({ reason: "user" });
+    expect(input.close).toHaveBeenCalledTimes(1);
+    expect(output.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -17,7 +17,8 @@
     "clean": "tsc --build tsconfig.build.json --clean && rm -rf ./dist",
     "check-types": "tsc --noEmit --skipLibCheck",
     "lint:es": "pnpm exec eslint .",
-    "lint:prettier": "prettier \"src/**/*.ts\" --check"
+    "lint:prettier": "prettier \"src/**/*.ts\" --check",
+    "test": "vitest"
   },
   "keywords": [
     "elevenlabs",
@@ -42,7 +43,8 @@
   "devDependencies": {
     "@types/react": "^19.2.18",
     "eslint": "^10.3.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^4.1.5"
   },
   "repository": {
     "type": "git",

--- a/packages/react-native/src/index.react-native.test.ts
+++ b/packages/react-native/src/index.react-native.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { VoiceConversation, WebRTCConnection } from "@elevenlabs/client";
+import type { Callbacks } from "@elevenlabs/client";
+
+// Shared with the module factories below, which are hoisted above the imports.
+const harness = vi.hoisted(() => ({
+  audioSession: {
+    configureAudio: vi.fn(async () => {}),
+    startAudioSession: vi.fn(async () => {}),
+    stopAudioSession: vi.fn(async () => {}),
+  },
+  // The connection `createConnection` hands back for the next session.
+  connection: { current: null as unknown },
+}));
+
+vi.mock("react-native", () => ({
+  NativeModules: { LivekitReactNativeModule: {} },
+  NativeEventEmitter: class {
+    addListener() {
+      return { remove() {} };
+    }
+  },
+}));
+
+vi.mock("@livekit/react-native", () => ({
+  registerGlobals: vi.fn(),
+  AndroidAudioTypePresets: { communication: {} },
+  AudioSession: harness.audioSession,
+}));
+
+vi.mock("@elevenlabs/client/internal", async importOriginal => ({
+  ...(await importOriginal<typeof import("@elevenlabs/client/internal")>()),
+  createConnection: vi.fn(async () => harness.connection.current),
+}));
+
+// Registers the React Native setup strategy as a side effect of the import,
+// which is what `VoiceConversation.startSession` reaches for below.
+import "./index.react-native.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+/**
+ * A stand-in for a live `WebRTCConnection`: enough of one to pass the
+ * `instanceof` checks in `setupWebRTCSession` and `attachNativeVolume`, with
+ * an empty room so no native volume processor is ever created.
+ */
+function fakeConnection({
+  offTrackListener = () => {},
+}: { offTrackListener?: () => void } = {}) {
+  const room = {
+    localParticipant: { audioTrackPublications: new Map() },
+    remoteParticipants: new Map(),
+    on: () => {},
+    off: offTrackListener,
+  };
+  return Object.create(WebRTCConnection.prototype, {
+    conversationId: { value: "conversation-1" },
+    room: { value: room },
+    queue: { value: [], writable: true },
+    outgoingQueue: { value: [], writable: true },
+    input: { value: { close: vi.fn(async () => {}) } },
+    output: { value: { close: vi.fn(async () => {}) } },
+    close: { value: vi.fn() },
+  });
+}
+
+function statusRecorder() {
+  const statuses: string[] = [];
+  const onStatusChange: NonNullable<Callbacks["onStatusChange"]> = ({
+    status,
+  }) => {
+    statuses.push(status);
+  };
+  return { statuses, onStatusChange };
+}
+
+async function startSession(
+  options: Partial<Parameters<typeof VoiceConversation.startSession>[0]> = {}
+) {
+  return VoiceConversation.startSession({
+    agentId: "agent-1",
+    connectionType: "webrtc",
+    ...options,
+  } as Parameters<typeof VoiceConversation.startSession>[0]);
+}
+
+describe("React Native session teardown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.audioSession.stopAudioSession.mockImplementation(async () => {});
+  });
+
+  it("holds the session in disconnecting until the audio session has stopped", async () => {
+    // A native audio session that takes its time to tear down: the status must
+    // not reach "disconnected" while the platform is still holding the mic,
+    // otherwise consumers re-enable their "start" affordance too early and the
+    // next startSession() races this teardown.
+    const stopped = deferred<void>();
+    harness.audioSession.stopAudioSession.mockImplementation(
+      () => stopped.promise
+    );
+    harness.connection.current = fakeConnection();
+    const { statuses, onStatusChange } = statusRecorder();
+    const onDisconnect = vi.fn();
+
+    const conversation = await startSession({ onStatusChange, onDisconnect });
+    expect(statuses).toEqual(["connecting", "connected"]);
+
+    const ending = conversation.endSession();
+    await flush();
+
+    expect(harness.audioSession.stopAudioSession).toHaveBeenCalledTimes(1);
+    expect(statuses).toEqual(["connecting", "connected", "disconnecting"]);
+    expect(onDisconnect).not.toHaveBeenCalled();
+
+    stopped.resolve();
+    await ending;
+
+    expect(statuses).toEqual([
+      "connecting",
+      "connected",
+      "disconnecting",
+      "disconnected",
+    ]);
+    expect(onDisconnect).toHaveBeenCalledWith({ reason: "user" });
+  });
+
+  it("stops the audio session even when detaching the connection throws", async () => {
+    harness.connection.current = fakeConnection({
+      offTrackListener: () => {
+        throw new Error("detach boom");
+      },
+    });
+    const { statuses, onStatusChange } = statusRecorder();
+
+    const conversation = await startSession({ onStatusChange });
+
+    await expect(conversation.endSession()).rejects.toThrow("detach boom");
+
+    expect(harness.audioSession.stopAudioSession).toHaveBeenCalledTimes(1);
+    expect(statuses).toEqual([
+      "connecting",
+      "connected",
+      "disconnecting",
+      "disconnected",
+    ]);
+  });
+});

--- a/packages/react-native/src/index.react-native.ts
+++ b/packages/react-native/src/index.react-native.ts
@@ -59,6 +59,10 @@ async function reactNativeSessionSetup(
       try {
         await originalDetach();
       } finally {
+        // Awaited, not fire-and-forget: the conversation only reports
+        // "disconnected" once detach settles, and the platform still owns the
+        // microphone until the audio session has stopped. Returning early
+        // would let the next startSession() race this teardown.
         await AudioSession.stopAudioSession();
       }
     },

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "files": [],
   "references": [
-    { "path": "./tsconfig.build.json" }
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/packages/react-native/tsconfig.test.json
+++ b/packages/react-native/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": [],
+  "references": [{ "path": "./tsconfig.build.json" }]
+}

--- a/packages/react-native/vitest.config.ts
+++ b/packages/react-native/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.2)(@vitest/browser-playwright@4.1.5)(jsdom@28.1.0)(msw@2.12.4(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.49.1)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/types:
     devDependencies:
@@ -18175,7 +18178,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.62.4
 
@@ -27038,8 +27041,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.16:
     dependencies:
@@ -27622,11 +27625,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.12(@types/node@25.6.2)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.49.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Makes the "the client stays in `disconnecting` until `AudioSession.stopAudioSession()` has resolved" guarantee enforced rather than incidental.

The behaviour already holds on `main`: the React Native `detach` awaits `stopAudioSession()` in a `finally`, `VoiceConversation.handleEndSession` awaits that `detach` as `cleanUp()`, and `BaseConversation.endSessionWithDetails` only calls `updateStatus("disconnected")` after `handleEndSession()` settles. Nothing in the test suite covered that chain, though, and every link in it is a plain `await` that a refactor could drop without any test noticing.

## Changes

- `packages/react-native`: added Vitest (the package had no test setup) plus `src/index.react-native.test.ts`, which drives the real React Native setup strategy through `VoiceConversation.startSession()` / `endSession()` with a mocked native audio session. One case gates `stopAudioSession()` on a deferred and asserts the status sequence stops at `disconnecting` (and `onDisconnect` has not fired) until it resolves; the other asserts the audio session is still stopped when the connection detach throws.
- `packages/client`: added `src/VoiceConversation.test.ts` covering the platform-agnostic half — a setup strategy whose `detach` never settles must keep the conversation in `disconnecting`, with the input/output controllers still open.
- `packages/react-native/src/index.react-native.ts`: a comment recording why the `stopAudioSession()` call is awaited rather than fire-and-forget.

No published behaviour changes, so no changeset.

## Testing

Both new tests were mutation-checked against the regressions they exist to catch.

Replacing `await AudioSession.stopAudioSession()` with `void AudioSession.stopAudioSession()` fails the React Native test:

```
 FAIL  src/index.react-native.test.ts > React Native session teardown > holds the session in disconnecting until the audio session has stopped
AssertionError: expected [ 'connecting', 'connected', …(2) ] to deeply equal [ 'connecting', 'connected', …(1) ]

  [
    "connecting",
    "connected",
    "disconnecting",
+   "disconnected",
  ]
```

Replacing `await this.cleanUp()` with `void this.cleanUp()` in `VoiceConversation` fails both the client test and the React Native test the same way, confirming the React Native case covers the whole chain and not just the wrapper.

Unmutated runs:

- `packages/react-native`: 2/2 pass (`pnpm exec vitest run`)
- `packages/client`: 260/260 pass across 19 files (`pnpm exec vitest run --browser.headless`)
- `pnpm exec turbo test lint check-types` for `client`, `react`, and `react-native`: all green except the client browser project, which cannot launch a headed Chromium in this VM (no XServer) and passes with `--browser.headless`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b8f2e2e-4c20-43f5-baa6-04d0c5b2873f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b8f2e2e-4c20-43f5-baa6-04d0c5b2873f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

