### PR TITLE
[Widget] Add auto-start-text attribute for server-driven opening messages

### DIFF
--- a/.changeset/widget-auto-start-text.md
+++ b/.changeset/widget-auto-start-text.md
@@ -1,0 +1,8 @@
+---
+"@elevenlabs/convai-widget-core": minor
+---
+
+Add an opt-in `auto-start-text` attribute that starts a text conversation as
+soon as the chat panel opens, instead of waiting for the user's first message.
+This lets the agent produce the opening message server-side, e.g. from a
+workflow that resolves customer context through tools before greeting.

--- a/packages/convai-widget-core/src/contexts/conversation.tsx
+++ b/packages/convai-widget-core/src/contexts/conversation.tsx
@@ -31,6 +31,10 @@ import { useShadowHost } from "./shadow-host";
 
 const FIRST_MESSAGE_EVENT_ID = 1;
 
+interface StartSessionOptions {
+  textOnly?: boolean;
+}
+
 type AgentEventId = number | undefined;
 
 type AgentStream = {
@@ -334,7 +338,8 @@ function useConversationSetup() {
       startSession: async (
         element: HTMLElement,
         initialMessage?: string,
-        initialMessageOptions?: SendUserMessageOptions
+        initialMessageOptions?: SendUserMessageOptions,
+        options?: StartSessionOptions
       ) => {
         await terms.requestTerms();
 
@@ -352,9 +357,13 @@ function useConversationSetup() {
           processedConfig.userId = await getOrCreateUserId();
         }
 
-        // If the user started the conversation with a text message, and the
-        // agent supports it, switch to text-only mode.
-        if (initialMessage && widgetConfig.value.supports_text_only) {
+        // If the user started the conversation with a text message (or the
+        // caller asked for a text session), and the agent supports it, switch
+        // to text-only mode.
+        if (
+          (initialMessage || options?.textOnly) &&
+          widgetConfig.value.supports_text_only
+        ) {
           processedConfig.textOnly = true;
           if (!widgetConfig.value.text_only) {
             processedConfig.overrides ??= {};

--- a/packages/convai-widget-core/src/index.test.ts
+++ b/packages/convai-widget-core/src/index.test.ts
@@ -567,6 +567,36 @@ describe("elevenlabs-convai", () => {
     });
   });
 
+  describe("auto-start-text", () => {
+    it("starts a text session on open and shows the server-sent greeting", async () => {
+      setupWebComponent({
+        "agent-id": "server_greeting",
+        variant: "compact",
+        "auto-start-text": "true",
+      });
+
+      // No user interaction: the panel is expanded by default, the session
+      // starts on its own, and the greeting arrives over the wire.
+      await expect
+        .element(page.getByText("Personalized welcome"))
+        .toBeInTheDocument();
+    });
+
+    it("does not start a session without the attribute", async () => {
+      setupWebComponent({
+        "agent-id": "server_greeting",
+        variant: "compact",
+      });
+
+      await expect
+        .element(page.getByRole("textbox", { name: "Text message input" }))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByText("Personalized welcome"))
+        .not.toBeInTheDocument();
+    });
+  });
+
   it.each(Variants)(
     "$0 variant should show last message when agent calls end_call",
     async variant => {

--- a/packages/convai-widget-core/src/mocks/browser.ts
+++ b/packages/convai-widget-core/src/mocks/browser.ts
@@ -428,6 +428,18 @@ const codeBlock = true;
     default_expanded: true,
     first_message: "Welcome message",
   },
+  server_greeting: {
+    ...BASIC_CONFIG,
+    text_only: false,
+    supports_text_only: true,
+    transcript_enabled: true,
+    text_input_enabled: true,
+    terms_html: undefined,
+    default_expanded: true,
+    // No local preview; the greeting only exists server-side, like an agent
+    // whose first message comes out of a workflow.
+    first_message: "",
+  },
   text_and_voice_rich_content: {
     ...BASIC_CONFIG,
     text_only: false,
@@ -570,7 +582,12 @@ export const Worker = setupWorker(
           JSON.stringify({
             type: "agent_response",
             agent_response_event: {
-              agent_response: config.first_message,
+              // `server_greeting` has no first_message in its config; the
+              // greeting is produced server-side once the session starts.
+              agent_response:
+                agentId === "server_greeting"
+                  ? "Personalized welcome"
+                  : config.first_message,
               event_id: 1,
             },
           })

--- a/packages/convai-widget-core/src/types/attributes.ts
+++ b/packages/convai-widget-core/src/types/attributes.ts
@@ -43,6 +43,7 @@ export const CustomAttributeList = [
   "text-contents",
   "default-expanded",
   "always-expanded",
+  "auto-start-text",
   "dismissible",
   "strip-audio-tags",
   "user-id",

--- a/packages/convai-widget-core/src/widget/Wrapper.tsx
+++ b/packages/convai-widget-core/src/widget/Wrapper.tsx
@@ -1,5 +1,8 @@
 import { memo } from "preact/compat";
+import { useRef } from "preact/hooks";
 import { useComputed, useSignal, useSignalEffect } from "@preact/signals";
+import { useAttribute } from "../contexts/attributes";
+import { parseBoolAttribute } from "../types/attributes";
 import { useWidgetConfig } from "../contexts/widget-config";
 import { clsx } from "clsx";
 import { Root } from "../contexts/root-portal";
@@ -48,8 +51,10 @@ export const Wrapper = memo(function Wrapper() {
   const expanded = useSignal(config.peek().default_expanded);
   const hidden = useSignal(false);
   const sawError = useSignal(false);
-  const { error, isDisconnected } = useConversation();
+  const { error, isDisconnected, startSession } = useConversation();
   const terms = useTerms();
+  const autoStartText = useAttribute("auto-start-text");
+  const autoStartedText = useRef(false);
   const { variant } = useWidgetSize();
   const expandable = useComputed(
     () => config.value.transcript_enabled || config.value.text_input_enabled
@@ -74,6 +79,25 @@ export const Wrapper = memo(function Wrapper() {
       } else {
         sawError.value = false;
       }
+    }
+  });
+
+  // Start a text session as soon as the panel opens so the agent can produce
+  // the first message server-side (e.g. from a workflow that gathers context
+  // via tools) instead of waiting for the user to write something. Once per
+  // mount: a session the user ended must not restart on its own.
+  useSignalEffect(() => {
+    const host = shadowHost.value;
+    if (
+      host &&
+      parseBoolAttribute(autoStartText.value) &&
+      expanded.value &&
+      config.value.supports_text_only &&
+      !autoStartedText.current &&
+      isDisconnected.peek()
+    ) {
+      autoStartedText.current = true;
+      void startSession(host, undefined, undefined, { textOnly: true });
     }
   });
 


### PR DESCRIPTION
## Motivation

PostNord ([Slack thread](https://eleven-labs-workspace.slack.com/archives/C090WT9SUGJ/p1788767861722939)) wants the agent to greet widget users with a personalized, server-generated first message: the client passes only a `customer_hash_id` dynamic variable, a workflow tool resolves it to customer context, and the agent greets with that context.

The backend already supports this: a workflow whose start path leads to a tool node forces the first agent turn on connect (`RuntimeStartAgent`), and `entry_behavior: generate_immediately` does the same for agent-node entries. Mobile/JS SDK users get this today because they control when the session starts.

The embed widget is the one place it cannot work: in text mode the widget renders the configured first message locally and only opens the connection when the user sends their first message, so the agent never gets a chance to speak first.

## What this does

Adds an opt-in `auto-start-text` attribute:

```html
<elevenlabs-convai
  agent-id="..."
  auto-start-text="true"
  dynamic-variables='{"customer_hash_id": "abc123xyz"}'>
</elevenlabs-convai>
```

When set, the widget starts a text-only session as soon as the chat panel opens (immediately with `default-expanded`), and the opening message arrives over the wire from the agent. Scoped to text sessions on purpose: auto-starting voice would trigger a mic permission prompt on open.

Behavior notes:
- Starts at most once per widget mount; a session the user ended does not restart on its own.
- No-op when the agent does not support text or the attribute is absent, and terms acceptance still gates the start.
- Session start goes through the existing `startSession` path, so the `elevenlabs-convai:call` event still fires and can be used to inject fresh config.

## Testing

- New browser tests: session auto-starts on open and renders the server-sent greeting; without the attribute nothing connects.
- Full `convai-widget-core` suite passes except `DismissButton.test.ts` ("expandable widget should hide all elements when dismissed"), which fails identically on clean `main`.

Screenshot from the browser test (MSW-mocked backend): the panel just opened, no user input, and the server-sent greeting is rendered. Real-agent capture pending an agent configured with a start-to-tool workflow.

## Follow-ups

- Document the attribute in elevenlabs/docs.
- Optionally expose this as a dashboard widget setting so it can be enabled without touching the embed snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)